### PR TITLE
Add support for web extension messages.json & plain key-value JSON files

### DIFF
--- a/moz/l10n/plain/__init__.py
+++ b/moz/l10n/plain/__init__.py
@@ -1,0 +1,4 @@
+from .parse import plain_parse
+from .serialize import plain_serialize
+
+__all__ = ["plain_parse", "plain_serialize"]

--- a/moz/l10n/plain/parse.py
+++ b/moz/l10n/plain/parse.py
@@ -1,0 +1,42 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from json import loads
+from typing import Any
+
+from ..resource import Entry, Resource, Section
+
+
+def plain_parse(source: str | bytes) -> Resource[str, None]:
+    """
+    Parse a JSON file into a message resource.
+
+    The input is expected to be a nested object with string values at leaf nodes.
+    """
+    json: dict[str, dict[str, Any]] = loads(source)
+    if not isinstance(json, dict):
+        raise ValueError(f"Unexpected root value: {json}")
+    return Resource([Section([], [e for e in plain_object([], json)])])
+
+
+def plain_object(path: list[str], obj: dict[str, Any]) -> Iterator[Entry[str, None]]:
+    for k, value in obj.items():
+        key = path + [k]
+        if isinstance(value, str):
+            yield Entry(key, value)
+        elif isinstance(value, dict):
+            yield from plain_object(key, value)
+        else:
+            raise ValueError(f"Unexpected value at {key}: {value}")

--- a/moz/l10n/plain/serialize.py
+++ b/moz/l10n/plain/serialize.py
@@ -1,0 +1,67 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections import defaultdict
+from collections.abc import Iterator
+from json import dumps
+from typing import Any
+
+from ..resource import Entry, Metadata, Resource
+
+
+def plain_serialize(
+    resource: Resource[str, None],
+    trim_comments: bool = False,
+) -> Iterator[str]:
+    """
+    Serialize a resource as a nested JSON object.
+
+    Comments and metadata are not supported.
+
+    Yields the entire JSON result as a single string.
+    """
+
+    def check(comment: str | None, meta: list[Metadata[None]] | None) -> None:
+        if comment and not trim_comments:
+            raise ValueError("Resource and section comments are not supported")
+        if meta:
+            raise ValueError("Metadata is not supported")
+
+    def ddict() -> dict[str, Any]:
+        return defaultdict(ddict)
+
+    check(resource.comment, resource.meta)
+    root = ddict()
+    for section in resource.sections:
+        check(section.comment, section.meta)
+        section_parent = root
+        for part in section.id:
+            section_parent = section_parent[part]
+        for entry in section.entries:
+            if isinstance(entry, Entry):
+                check(entry.comment, entry.meta)
+                if not entry.id:
+                    raise ValueError(f"Unsupported empty identifier in {section.id}")
+                if not isinstance(entry.value, str):
+                    raise ValueError(
+                        f"Source value for {section.id + entry.id} is not a string"
+                    )
+                parent = section_parent
+                for part in entry.id[:-1]:
+                    parent = parent[part]
+                parent[entry.id[-1]] = entry.value
+            else:
+                check(entry.comment, None)
+    yield dumps(root, indent=2)
+    yield "\n"

--- a/moz/l10n/webext/__init__.py
+++ b/moz/l10n/webext/__init__.py
@@ -1,0 +1,4 @@
+from .parse import webext_parse
+from .serialize import webext_serialize
+
+__all__ = ["webext_parse", "webext_serialize"]

--- a/moz/l10n/webext/parse.py
+++ b/moz/l10n/webext/parse.py
@@ -1,0 +1,92 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from json import loads
+from re import finditer, fullmatch
+from typing import Any
+
+from ..message import (
+    Declaration,
+    Expression,
+    Pattern,
+    PatternMessage,
+    UnsupportedStatement,
+    VariableRef,
+)
+from ..resource import Comment, Entry, Resource, Section
+
+
+def webext_parse(source: str | bytes) -> Resource[PatternMessage, None]:
+    """
+    Parse a messages.json file into a message resource.
+
+    Named placeholders are represented as declarations,
+    with an attribute used for an example, if it's available.
+    """
+    json: dict[str, dict[str, Any]] = loads(source)
+    entries: list[Entry[PatternMessage, None] | Comment] = []
+    for key, msg in json.items():
+        src: str = msg["message"]
+        comment: str = msg.get("description", "")
+        ph_data: dict[str, dict[str, str]] = (
+            {k.lower(): v for k, v in msg["placeholders"].items()}
+            if "placeholders" in msg
+            else {}
+        )
+        declarations: list[Declaration | UnsupportedStatement] = []
+        pattern: Pattern = []
+        pos = 0
+        for m in finditer(r"\$([a-zA-Z0-9_@]+)\$|(\$[1-9])|\$(\$+)", src):
+            text = src[pos : m.start()]
+            if text:
+                if pattern and isinstance(pattern[-1], str):
+                    pattern[-1] += text
+                else:
+                    pattern.append(text)
+            if m[1]:
+                # Named placeholder, with content & optional example in placeholders object
+                ph = ph_data[m[1].lower()]
+                if "_prev" in ph:
+                    ph_key = ph["_prev"]
+                else:
+                    ph_key = m[1]
+                    ph_src = ph["content"]
+                    ph_value = Expression(
+                        VariableRef(ph_src) if fullmatch(r"\$[1-9]", ph_src) else ph_src
+                    )
+                    if "example" in ph:
+                        ph_value.attributes["example"] = ph["example"]
+                    declarations.append(Declaration(ph_key, ph_value))
+                    ph["_prev"] = ph_key
+                pattern.append(Expression(VariableRef(ph_key)))
+            elif m[2]:
+                # Indexed placeholder
+                pattern.append(Expression(VariableRef(m[2])))
+            else:
+                # Escaped literal dollar sign
+                if pattern and isinstance(pattern[-1], str):
+                    pattern[-1] += m[3]
+                else:
+                    pattern.append(m[3])
+            pos = m.end()
+        if pos < len(src):
+            rest = src[pos:]
+            if pattern and isinstance(pattern[-1], str):
+                pattern[-1] += rest
+            else:
+                pattern.append(rest)
+        entries.append(
+            Entry([key], PatternMessage(pattern, declarations), comment=comment)
+        )
+    return Resource([Section([], entries)])

--- a/moz/l10n/webext/serialize.py
+++ b/moz/l10n/webext/serialize.py
@@ -1,0 +1,120 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Iterator
+from json import dumps
+from re import sub
+from typing import Any
+
+from ..message import Declaration, Expression, PatternMessage, VariableRef
+from ..resource import Entry, Metadata, Resource
+
+
+def webext_serialize(
+    resource: Resource[PatternMessage, None],
+    trim_comments: bool = False,
+) -> Iterator[str]:
+    """
+    Serialize a resource as the contents of a messages.json file.
+
+    Section identifiers and multi-part message identifiers are not supported.
+    Resource and section comments are not supported.
+    Metadata is not supported.
+
+    Yields the entire JSON result as a single string.
+    """
+
+    def check(comment: str | None, meta: list[Metadata[None]] | None) -> None:
+        if comment:
+            raise ValueError("Resource and section comments are not supported")
+        if meta:
+            raise ValueError("Metadata is not supported")
+
+    check(resource.comment, resource.meta)
+    res: dict[str, Any] = {}
+    for section in resource.sections:
+        if section.id:
+            raise ValueError(f"Section identifiers not supported: {section.id}")
+        check(section.comment, section.meta)
+        for entry in section.entries:
+            if isinstance(entry, Entry):
+                check(None, entry.meta)
+                if len(entry.id) != 1:
+                    raise ValueError(f"Unsupported entry identifier: {entry.id}")
+                name = entry.id[0]
+                if not isinstance(entry.value, PatternMessage):
+                    raise ValueError(f"Unsupported entry for {name}: {entry.value}")
+                res[name] = webext_message(name, entry, trim_comments)
+            else:
+                check(entry.comment, None)
+    yield dumps(res, indent=2)
+    yield "\n"
+
+
+def webext_message(
+    name: str, entry: Entry[PatternMessage, None], trim_comments: bool
+) -> dict[str, Any]:
+    msg = ""
+    placeholders = {}
+    for part in entry.value.pattern:
+        if isinstance(part, str):
+            msg += sub(r"\$+", r"$\g<0>", part)
+        elif (
+            isinstance(part, Expression)
+            and isinstance(part.arg, VariableRef)
+            and part.annotation is None
+        ):
+            ph_name = part.arg.name
+            local = next(
+                (
+                    d.value
+                    for d in entry.value.declarations
+                    if isinstance(d, Declaration) and d.name == ph_name
+                ),
+                None,
+            )
+            if local:
+                if isinstance(local.arg, VariableRef):
+                    content = local.arg.name
+                elif isinstance(local.arg, str):
+                    content = local.arg
+                else:
+                    raise ValueError(
+                        f"Unsupported placeholder for {ph_name} in {name}: {local}"
+                    )
+                if local.annotation:
+                    raise ValueError(
+                        f"Unsupported annotation for {ph_name} in {name}: {local}"
+                    )
+                placeholders[ph_name] = {"content": content}
+                example = (
+                    None if trim_comments else local.attributes.get("example", None)
+                )
+                if isinstance(example, str):
+                    placeholders[ph_name]["example"] = example
+                elif example:
+                    raise ValueError(
+                        f"Unsupported placeholder example for {ph_name} in {name}: {example}"
+                    )
+                msg += f"${ph_name}$"
+            else:
+                msg += ph_name
+        else:
+            raise ValueError(f"Unsupported message part for {name}: {part}")
+    res: dict[str, Any] = {"message": msg}
+    if not trim_comments and entry.comment:
+        res["description"] = entry.comment
+    if placeholders:
+        res["placeholders"] = placeholders
+    return res

--- a/tests/data/messages.json
+++ b/tests/data/messages.json
@@ -1,0 +1,36 @@
+{
+  "SourceString": {
+    "message": "Translated String",
+    "description": "Sample comment"
+  },
+
+  "MultipleComments": {
+    "message": "Translated Multiple Comments",
+    "description": "First comment",
+    "description": "Second comment"
+  },
+
+  "NoCommentsorSources": {
+    "message": "Translated No Comments or Sources"
+  },
+
+  "placeholders": {
+    "message": "Hello$$$ $1YOUR_NAME$ at $2",
+    "description": "Peer greeting",
+    "placeholders": {
+      "1your_name": {
+        "content": "$1",
+        "example": "Cira"
+      }
+    }
+  },
+
+  "repeated_ref": {
+    "message": "$foo$ and $Foo$",
+    "placeholders": {
+      "foo": {
+        "content": "$1"
+      }
+    }
+  }
+}

--- a/tests/test_plain.py
+++ b/tests/test_plain.py
@@ -1,0 +1,123 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib.resources import files
+from textwrap import dedent
+from unittest import TestCase
+
+from moz.l10n.plain import plain_parse, plain_serialize
+from moz.l10n.resource import Entry, Resource, Section
+
+# Show full diff in self.assertEqual. https://stackoverflow.com/a/61345284
+# __import__("sys").modules["unittest.util"]._MAX_LENGTH = 999999999
+
+source = files("tests.data").joinpath("messages.json").read_bytes()
+
+
+class TestPlain(TestCase):
+    def test_parse(self):
+        res = plain_parse(source)
+        self.assertEqual(
+            res,
+            Resource(
+                [
+                    Section(
+                        [],
+                        [
+                            Entry(["SourceString", "message"], "Translated String"),
+                            Entry(["SourceString", "description"], "Sample comment"),
+                            Entry(
+                                ["MultipleComments", "message"],
+                                "Translated Multiple Comments",
+                            ),
+                            Entry(
+                                ["MultipleComments", "description"], "Second comment"
+                            ),
+                            Entry(
+                                ["NoCommentsorSources", "message"],
+                                "Translated No Comments or Sources",
+                            ),
+                            Entry(
+                                ["placeholders", "message"],
+                                "Hello$$$ $1YOUR_NAME$ at $2",
+                            ),
+                            Entry(["placeholders", "description"], "Peer greeting"),
+                            Entry(
+                                [
+                                    "placeholders",
+                                    "placeholders",
+                                    "1your_name",
+                                    "content",
+                                ],
+                                "$1",
+                            ),
+                            Entry(
+                                [
+                                    "placeholders",
+                                    "placeholders",
+                                    "1your_name",
+                                    "example",
+                                ],
+                                "Cira",
+                            ),
+                            Entry(["repeated_ref", "message"], "$foo$ and $Foo$"),
+                            Entry(
+                                ["repeated_ref", "placeholders", "foo", "content"], "$1"
+                            ),
+                        ],
+                    )
+                ],
+            ),
+        )
+
+    def test_serialize(self):
+        res = plain_parse(source)
+        self.assertEqual(
+            "".join(plain_serialize(res)),
+            dedent(
+                """\
+                {
+                  "SourceString": {
+                    "message": "Translated String",
+                    "description": "Sample comment"
+                  },
+                  "MultipleComments": {
+                    "message": "Translated Multiple Comments",
+                    "description": "Second comment"
+                  },
+                  "NoCommentsorSources": {
+                    "message": "Translated No Comments or Sources"
+                  },
+                  "placeholders": {
+                    "message": "Hello$$$ $1YOUR_NAME$ at $2",
+                    "description": "Peer greeting",
+                    "placeholders": {
+                      "1your_name": {
+                        "content": "$1",
+                        "example": "Cira"
+                      }
+                    }
+                  },
+                  "repeated_ref": {
+                    "message": "$foo$ and $Foo$",
+                    "placeholders": {
+                      "foo": {
+                        "content": "$1"
+                      }
+                    }
+                  }
+                }
+                """
+            ),
+        )

--- a/tests/test_webext.py
+++ b/tests/test_webext.py
@@ -1,0 +1,171 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from importlib.resources import files
+from textwrap import dedent
+from unittest import TestCase
+
+from moz.l10n.message import Declaration, Expression, PatternMessage, VariableRef
+from moz.l10n.resource import Entry, Resource, Section
+from moz.l10n.webext import webext_parse, webext_serialize
+
+# Show full diff in self.assertEqual. https://stackoverflow.com/a/61345284
+# __import__("sys").modules["unittest.util"]._MAX_LENGTH = 999999999
+
+source = files("tests.data").joinpath("messages.json").read_bytes()
+
+
+class TestWebext(TestCase):
+    def test_parse(self):
+        res = webext_parse(source)
+        self.assertEqual(
+            res,
+            Resource(
+                [
+                    Section(
+                        [],
+                        [
+                            Entry(
+                                ["SourceString"],
+                                PatternMessage(["Translated String"]),
+                                comment="Sample comment",
+                            ),
+                            Entry(
+                                ["MultipleComments"],
+                                PatternMessage(["Translated Multiple Comments"]),
+                                comment="Second comment",
+                            ),
+                            Entry(
+                                ["NoCommentsorSources"],
+                                PatternMessage(["Translated No Comments or Sources"]),
+                            ),
+                            Entry(
+                                ["placeholders"],
+                                PatternMessage(
+                                    [
+                                        "Hello$$ ",
+                                        Expression(VariableRef("1YOUR_NAME")),
+                                        " at ",
+                                        Expression(VariableRef("$2")),
+                                    ],
+                                    declarations=[
+                                        Declaration(
+                                            "1YOUR_NAME",
+                                            Expression(
+                                                VariableRef("$1"),
+                                                attributes={"example": "Cira"},
+                                            ),
+                                        )
+                                    ],
+                                ),
+                                comment="Peer greeting",
+                            ),
+                            Entry(
+                                ["repeated_ref"],
+                                PatternMessage(
+                                    [
+                                        Expression(VariableRef("foo")),
+                                        " and ",
+                                        Expression(VariableRef("foo")),
+                                    ],
+                                    declarations=[
+                                        Declaration(
+                                            "foo", Expression(VariableRef("$1"))
+                                        )
+                                    ],
+                                ),
+                            ),
+                        ],
+                    )
+                ],
+            ),
+        )
+
+    def test_serialize(self):
+        res = webext_parse(source)
+        self.assertEqual(
+            "".join(webext_serialize(res)),
+            dedent(
+                """\
+                {
+                  "SourceString": {
+                    "message": "Translated String",
+                    "description": "Sample comment"
+                  },
+                  "MultipleComments": {
+                    "message": "Translated Multiple Comments",
+                    "description": "Second comment"
+                  },
+                  "NoCommentsorSources": {
+                    "message": "Translated No Comments or Sources"
+                  },
+                  "placeholders": {
+                    "message": "Hello$$$ $1YOUR_NAME$ at $2",
+                    "description": "Peer greeting",
+                    "placeholders": {
+                      "1YOUR_NAME": {
+                        "content": "$1",
+                        "example": "Cira"
+                      }
+                    }
+                  },
+                  "repeated_ref": {
+                    "message": "$foo$ and $foo$",
+                    "placeholders": {
+                      "foo": {
+                        "content": "$1"
+                      }
+                    }
+                  }
+                }
+                """
+            ),
+        )
+
+    def test_trim_comments(self):
+        res = webext_parse(source)
+        self.assertEqual(
+            "".join(webext_serialize(res, trim_comments=True)),
+            dedent(
+                """\
+                {
+                  "SourceString": {
+                    "message": "Translated String"
+                  },
+                  "MultipleComments": {
+                    "message": "Translated Multiple Comments"
+                  },
+                  "NoCommentsorSources": {
+                    "message": "Translated No Comments or Sources"
+                  },
+                  "placeholders": {
+                    "message": "Hello$$$ $1YOUR_NAME$ at $2",
+                    "placeholders": {
+                      "1YOUR_NAME": {
+                        "content": "$1"
+                      }
+                    }
+                  },
+                  "repeated_ref": {
+                    "message": "$foo$ and $foo$",
+                    "placeholders": {
+                      "foo": {
+                        "content": "$1"
+                      }
+                    }
+                  }
+                }
+                """
+            ),
+        )


### PR DESCRIPTION
The parser and serialiser are pretty strict for this, as the `messages.json` format is pretty explicit. It also effectively requires using the MF2 data model representation, does not allow for metadata, and is also pretty strict on the keys it supports.