### PR TITLE
Extend compatibility back to Python 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
       - uses: actions/checkout@v4
@@ -21,8 +21,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+      - run: pip install importlib_resources pytest
       - run: pip install .
-      - run: pip install pytest
       - run: pytest -vv
 
   lint:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 __pycache__/
 dist/
 *.egg-info/
+/build/

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,6 @@
 black ~= 24.0
 flake8 ~= 7.0
+importlib_resources ~= 6.0
 isort ~= 5.0
 mypy ~= 1.0
 pytest ~= 8.1.1

--- a/moz/l10n/message.py
+++ b/moz/l10n/message.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Dict, List, Literal, Tuple, Union
 
 __all__ = [
     "CatchallKey",
@@ -70,7 +72,7 @@ class Markup:
     attributes: dict[str, str | VariableRef | None] = field(default_factory=dict)
 
 
-Pattern = list[str | Expression | Markup]
+Pattern = List[Union[str, Expression, Markup]]
 """
 A linear sequence of text and placeholders corresponding to potential output of a message.
 
@@ -126,7 +128,7 @@ class PatternMessage:
     declarations: list[Declaration | UnsupportedStatement] = field(default_factory=list)
 
 
-Variants = dict[tuple[str | CatchallKey, ...], Pattern]
+Variants = Dict[Tuple[Union[str, CatchallKey], ...], Pattern]
 
 
 @dataclass
@@ -140,4 +142,4 @@ class SelectMessage:
     declarations: list[Declaration | UnsupportedStatement] = field(default_factory=list)
 
 
-Message = PatternMessage | SelectMessage
+Message = Union[PatternMessage, SelectMessage]

--- a/moz/l10n/resource/android/parse.py
+++ b/moz/l10n/resource/android/parse.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Callable, Iterable, Iterator
 from re import compile
 
@@ -402,18 +404,18 @@ def parse_inline(
                     else:
                         # Placeholder
                         func: str | None
-                        match conversion:
-                            case "b" | "B":
-                                func = "boolean"
-                            case "c" | "C" | "s" | "S":
-                                func = "string"
-                            case "d" | "h" | "H" | "o" | "x" | "X":
-                                func = "integer"
-                            case "a" | "A" | "e" | "E" | "f" | "g" | "G":
-                                func = "number"
-                            case _:
-                                c0 = conversion[0]
-                                func = "datetime" if c0 == "t" or c0 == "T" else None
+                        # TODO post-py38: should be a match
+                        if conversion in {"b", "B"}:
+                            func = "boolean"
+                        elif conversion in {"c", "C", "s", "S"}:
+                            func = "string"
+                        elif conversion in {"d", "h", "H", "o", "x", "X"}:
+                            func = "integer"
+                        elif conversion in {"a", "A", "e", "E", "f", "g", "G"}:
+                            func = "number"
+                        else:
+                            c0 = conversion[0]
+                            func = "datetime" if c0 == "t" or c0 == "T" else None
                         name = get_var_name(m[4])
                         yield Expression(
                             VariableRef(name),

--- a/moz/l10n/resource/android/serialize.py
+++ b/moz/l10n/resource/android/serialize.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from re import compile
-from typing import cast
+from typing import Dict, cast
 
 from lxml import etree
 
@@ -290,7 +292,7 @@ def set_pattern(el: etree._Element, pattern: Pattern) -> None:
             if part.attributes.get("translate", None) == "no":
                 # <xliff:g>
                 attrib = (
-                    cast(dict[str, str], part.annotation.options)
+                    cast(Dict[str, str], part.annotation.options)
                     if isinstance(part.annotation, FunctionAnnotation)
                     else None
                 )
@@ -342,7 +344,7 @@ def set_pattern(el: etree._Element, pattern: Pattern) -> None:
                 name = f"{{{xmlns}}}{local}"
             else:
                 name = part.name
-            attrib = cast(dict[str, str], part.options)
+            attrib = cast(Dict[str, str], part.options)
             if part.kind == "standalone":
                 node = etree.SubElement(parent, name, attrib=attrib)
             elif part.kind == "open":

--- a/moz/l10n/resource/data.py
+++ b/moz/l10n/resource/data.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
 from typing import Generic, TypeVar
 

--- a/moz/l10n/resource/dtd/parse.py
+++ b/moz/l10n/resource/dtd/parse.py
@@ -15,6 +15,8 @@
 # The core logic of the parser used here is taken from silme:
 # https://github.com/mozilla/silme/blob/2f7af3dd87fff27a3c3650d442a065b5a290268e/lib/silme/format/dtd/parser.py
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from re import DOTALL, MULTILINE, UNICODE, compile
 from sys import maxsize

--- a/moz/l10n/resource/dtd/serialize.py
+++ b/moz/l10n/resource/dtd/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from re import UNICODE, compile
 from typing import Any

--- a/moz/l10n/resource/fluent/parse.py
+++ b/moz/l10n/resource/fluent/parse.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Generator
 from itertools import product
-from typing import Any, Literal, cast, overload
+from typing import Any, Literal, Tuple, cast, overload
 
 from fluent.syntax import FluentParser
 from fluent.syntax import ast as ftl
@@ -171,7 +173,7 @@ def fluent_parse_message(ftl_pattern: ftl.Pattern) -> msg.Message:
         return msg.PatternMessage(next(iter(msg_variants.values())))
 
 
-Key = tuple[str, bool, bool]
+Key = Tuple[str, bool, bool]
 "(name, is_numeric, is_default)"
 
 

--- a/moz/l10n/resource/fluent/serialize.py
+++ b/moz/l10n/resource/fluent/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from re import fullmatch
 from typing import Any, Iterator

--- a/moz/l10n/resource/format.py
+++ b/moz/l10n/resource/format.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from enum import Enum
 from io import BytesIO
 from json import JSONDecodeError, loads

--- a/moz/l10n/resource/inc/parse.py
+++ b/moz/l10n/resource/inc/parse.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from re import compile
 from typing import Any
 

--- a/moz/l10n/resource/inc/serialize.py
+++ b/moz/l10n/resource/inc/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from typing import Any
 

--- a/moz/l10n/resource/ini/parse.py
+++ b/moz/l10n/resource/ini/parse.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from io import StringIO
 from typing import Any, Generator, TextIO
 

--- a/moz/l10n/resource/ini/serialize.py
+++ b/moz/l10n/resource/ini/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from re import search
 from typing import Any

--- a/moz/l10n/resource/iter_resources.py
+++ b/moz/l10n/resource/iter_resources.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 import os
 from collections.abc import Iterator
 from os.path import isdir, join, relpath

--- a/moz/l10n/resource/parse_resource.py
+++ b/moz/l10n/resource/parse_resource.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from ..message import Message
 from .android.parse import android_parse
 from .data import Resource
@@ -47,26 +49,27 @@ def parse_resource(
             raise TypeError("Source is required if type is not a string path")
         with open(input, mode="rb") as file:
             source = file.read()
-    match input if isinstance(input, Format) else detect_format(input, source):
-        case Format.android:
-            return android_parse(source)
-        case Format.dtd:
-            return dtd_parse(source)
-        case Format.fluent:
-            return fluent_parse(source)
-        case Format.inc:
-            return inc_parse(source)
-        case Format.ini:
-            return ini_parse(source)
-        case Format.plain_json:
-            return plain_json_parse(source)
-        case Format.po:
-            return po_parse(source)
-        case Format.properties:
-            return properties_parse(source)
-        case Format.webext:
-            return webext_parse(source)
-        case Format.xliff:
-            return xliff_parse(source)
-        case _:
-            raise ValueError(f"Unsupported resource format: {input}")
+    # TODO post-py38: should be a match
+    format = input if isinstance(input, Format) else detect_format(input, source)
+    if format == Format.android:
+        return android_parse(source)
+    elif format == Format.dtd:
+        return dtd_parse(source)
+    elif format == Format.fluent:
+        return fluent_parse(source)
+    elif format == Format.inc:
+        return inc_parse(source)
+    elif format == Format.ini:
+        return ini_parse(source)
+    elif format == Format.plain_json:
+        return plain_json_parse(source)
+    elif format == Format.po:
+        return po_parse(source)
+    elif format == Format.properties:
+        return properties_parse(source)
+    elif format == Format.webext:
+        return webext_parse(source)
+    elif format == Format.xliff:
+        return xliff_parse(source)
+    else:
+        raise ValueError(f"Unsupported resource format: {input}")

--- a/moz/l10n/resource/plain_json/parse.py
+++ b/moz/l10n/resource/plain_json/parse.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from json import loads
 from typing import Any

--- a/moz/l10n/resource/plain_json/serialize.py
+++ b/moz/l10n/resource/plain_json/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Iterator
 from json import dumps

--- a/moz/l10n/resource/po/parse.py
+++ b/moz/l10n/resource/po/parse.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import OrderedDict
 
 from polib import pofile

--- a/moz/l10n/resource/po/serialize.py
+++ b/moz/l10n/resource/po/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 
 from polib import POEntry, POFile

--- a/moz/l10n/resource/properties/parse.py
+++ b/moz/l10n/resource/properties/parse.py
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from re import sub
-from typing import Any, cast
+from typing import Any, Tuple, cast
 
 from translate.storage.properties import propfile
 
@@ -39,7 +41,7 @@ class propfile_shim(propfile):  # type: ignore[misc]
             return (text, default_encodings[0] if default_encodings else "utf-8")
         else:
             return cast(
-                tuple[str, str], super().detect_encoding(text, default_encodings)
+                Tuple[str, str], super().detect_encoding(text, default_encodings)
             )
 
 

--- a/moz/l10n/resource/properties/serialize.py
+++ b/moz/l10n/resource/properties/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Callable, Iterator
 from typing import Any, Literal
 

--- a/moz/l10n/resource/serialize_resource.py
+++ b/moz/l10n/resource/serialize_resource.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 
 from moz.l10n.message import Message
@@ -43,28 +45,28 @@ def serialize_resource(
     With `trim_comments`,
     all standalone and attached comments are left out of the serialization.
     """
-    match format or resource.format:
-        case Format.android:
-            return android_serialize(resource, trim_comments=trim_comments)
-        case Format.dtd:
-            return dtd_serialize(resource, trim_comments=trim_comments)
-        case Format.fluent:
-            return fluent_serialize(resource, trim_comments=trim_comments)
-        case Format.inc:
-            return inc_serialize(resource, trim_comments=trim_comments)
-        case Format.ini:
-            return ini_serialize(resource, trim_comments=trim_comments)
-        case Format.plain_json:
-            return plain_json_serialize(resource, trim_comments=trim_comments)
-        case Format.po:
-            return po_serialize(resource, trim_comments=trim_comments)
-        case Format.properties:
-            return properties_serialize(resource, trim_comments=trim_comments)
-        case Format.webext:
-            return webext_serialize(resource, trim_comments=trim_comments)
-        case Format.xliff:
-            return xliff_serialize(resource, trim_comments=trim_comments)
-        case _:
-            raise ValueError(
-                f"Unsupported resource format: {format or resource.format}"
-            )
+    # TODO post-py38: should be a match
+    if not format:
+        format = resource.format
+    if format == Format.android:
+        return android_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.dtd:
+        return dtd_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.fluent:
+        return fluent_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.inc:
+        return inc_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.ini:
+        return ini_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.plain_json:
+        return plain_json_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.po:
+        return po_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.properties:
+        return properties_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.webext:
+        return webext_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.xliff:
+        return xliff_serialize(resource, trim_comments=trim_comments)
+    else:
+        raise ValueError(f"Unsupported resource format: {format or resource.format}")

--- a/moz/l10n/resource/webext/parse.py
+++ b/moz/l10n/resource/webext/parse.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from json import loads
 from re import compile
 from typing import Any

--- a/moz/l10n/resource/webext/serialize.py
+++ b/moz/l10n/resource/webext/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from json import dumps
 from re import sub

--- a/moz/l10n/resource/xliff/common.py
+++ b/moz/l10n/resource/xliff/common.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Iterator
 

--- a/moz/l10n/resource/xliff/parse.py
+++ b/moz/l10n/resource/xliff/parse.py
@@ -12,10 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Iterator
 from re import compile
-from typing import cast
+from typing import List, Union, cast
 
 from lxml import etree
 
@@ -111,7 +113,9 @@ def xliff_parse(source: str | bytes) -> Resource[Message, str]:
             if file_name.endswith(".stringsdict"):
                 plural_entries = parse_xliff_stringsdict(ns, body)
                 if plural_entries is not None:
-                    entries += cast(list[Entry[Message, str] | Comment], plural_entries)
+                    entries += cast(
+                        List[Union[Entry[Message, str], Comment]], plural_entries
+                    )
                     continue
 
             for unit in body:

--- a/moz/l10n/resource/xliff/parse_trans_unit.py
+++ b/moz/l10n/resource/xliff/parse_trans_unit.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections import defaultdict
 from collections.abc import Iterator
 

--- a/moz/l10n/resource/xliff/parse_xcode.py
+++ b/moz/l10n/resource/xliff/parse_xcode.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from dataclasses import dataclass
 from re import compile
@@ -186,19 +188,19 @@ def parse_pattern(src: str | None) -> Iterator[str | Expression]:
         else:
             name: str
             func: str | None
-            match format:
-                case "c" | "C" | "s" | "S":
-                    name = "str"
-                    func = "string"
-                case "d" | "D" | "o" | "O" | "p" | "u" | "U" | "x" | "X":
-                    name = "int"
-                    func = "integer"
-                case "a" | "A" | "e" | "E" | "f" | "g" | "G":
-                    name = "num"
-                    func = "number"
-                case _:
-                    name = "arg"
-                    func = None
+            # TODO post-py38: should be a match
+            if format in {"c", "C", "s", "S"}:
+                name = "str"
+                func = "string"
+            elif format in {"d", "D", "o", "O", "p", "u", "U", "x", "X"}:
+                name = "int"
+                func = "integer"
+            elif format in {"a", "A", "e", "E", "f", "g", "G"}:
+                name = "num"
+                func = "number"
+            else:
+                name = "arg"
+                func = None
             if m[1]:
                 name += m[1][0]
             yield Expression(

--- a/moz/l10n/resource/xliff/serialize.py
+++ b/moz/l10n/resource/xliff/serialize.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from collections.abc import Iterator
 from typing import cast
 

--- a/moz/l10n/transform/add_entries.py
+++ b/moz/l10n/transform/add_entries.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from dataclasses import replace
 from typing import Any
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,8 @@ classifiers = [
   "Operating System :: OS Independent",
   "Programming Language :: Python",
   "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.8",
+  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
@@ -26,7 +28,7 @@ classifiers = [
   "Topic :: Software Development :: Localization",
   "Topic :: Software Development :: Testing",
 ]
-requires-python = "~= 3.10"
+requires-python = "~= 3.8"
 dependencies = [
   "fluent.syntax ~= 0.19.0",
   "gitignorant ~= 0.3.1",
@@ -40,10 +42,11 @@ dependencies = [
 repository = "https://github.com/mozilla/moz-l10n"
 
 [tool.isort]
+extra_standard_library = ["importlib_resources"]
 profile = "black"
 
 [tool.mypy]
-exclude = "^tests/"
+exclude = "^(build|tests)/"
 explicit_package_bases = true
 strict = true
 
@@ -53,4 +56,6 @@ ignore_missing_imports = true
 
 [tool.setuptools]
 platforms = ["any"]
-packages = ["moz.l10n"]
+
+[tool.setuptools.packages.find]
+include = ["moz.l10n*"]

--- a/tests/resource/test_android.py
+++ b/tests/resource/test_android.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_detect_format.py
+++ b/tests/resource/test_detect_format.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from unittest import TestCase
 
 from moz.l10n.resource import Format, detect_format

--- a/tests/resource/test_dtd.py
+++ b/tests/resource/test_dtd.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_fluent.py
+++ b/tests/resource/test_fluent.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_inc.py
+++ b/tests/resource/test_inc.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_ini.py
+++ b/tests/resource/test_ini.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_iter_resources.py
+++ b/tests/resource/test_iter_resources.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from os import getcwd, sep
 from os.path import join, splitext
 from tempfile import TemporaryDirectory

--- a/tests/resource/test_parse_serialize_resource.py
+++ b/tests/resource/test_parse_serialize_resource.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from unittest import TestCase
 
 from moz.l10n.resource import Format, parse_resource, serialize_resource

--- a/tests/resource/test_plain_json.py
+++ b/tests/resource/test_plain_json.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_po.py
+++ b/tests/resource/test_po.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from unittest import TestCase
 
 from moz.l10n.message import (

--- a/tests/resource/test_properties.py
+++ b/tests/resource/test_properties.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_webext.py
+++ b/tests/resource/test_webext.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/resource/test_xliff1.py
+++ b/tests/resource/test_xliff1.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from importlib.resources import files
+from __future__ import annotations
+
+from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 

--- a/tests/test_add_entries.py
+++ b/tests/test_add_entries.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import annotations
+
 from unittest import TestCase
 
 from moz.l10n.resource.data import Entry, Resource, Section


### PR DESCRIPTION
This is needed to be able to use the command for linting Firefox, as `mach` [still supports 3.8](https://searchfox.org/mozilla-central/rev/9a763b338a42ed373342d25091b02305fd8040a4/mach#13).

Changes consist of:
- Using `if..elif..elif..else` instead of `match` ([PEP 634](https://peps.python.org/pep-0634/))
- `from __future__ import annotations` everywhere ([PEP 585](https://peps.python.org/pep-0585/))
- Using old type syntax for type aliases and `cast` targets ([PEP 585](https://peps.python.org/pep-0585/))
- Using `importlib_resources` rather than using the built-in `importlib.resources` in tests ([bpo-39791](https://bugs.python.org/issue?@action=redirect&bpo=39791))
- The `pyproject.toml` fixes from 2d6439d