### PR TITLE
Fix more small bugs

### DIFF
--- a/moz/l10n/resource/fluent/parse.py
+++ b/moz/l10n/resource/fluent/parse.py
@@ -67,7 +67,11 @@ def fluent_parse(
     entries: list[res.Entry[Any, Any] | res.Comment] = []
     section = res.Section((), entries)
     resource = res.Resource(Format.fluent, [section])
-    for entry in fluent_res.body:
+    fluent_body = fluent_res.body
+    if fluent_body and isinstance(fluent_body[0], ftl.Comment):
+        resource.meta.append(res.Metadata("info", fluent_body[0].content))
+        fluent_body = fluent_body[1:]
+    for entry in fluent_body:
         if isinstance(entry, ftl.Message) or isinstance(entry, ftl.Term):
             entries.extend(patterns(entry, as_ftl_patterns))
         elif isinstance(entry, ftl.ResourceComment):

--- a/moz/l10n/resource/fluent/parse.py
+++ b/moz/l10n/resource/fluent/parse.py
@@ -252,6 +252,8 @@ def inline_expression(exp: ftl.InlineExpression) -> msg.Expression:
         return msg.Expression(name, msg.FunctionAnnotation("message"))
     elif isinstance(exp, ftl.TermReference):
         name = "-" + exp.id.name
+        if exp.attribute is not None:
+            name += "." + exp.attribute.name
         ftl_named = exp.arguments.named if exp.arguments else []
         return msg.Expression(
             name,

--- a/moz/l10n/resource/fluent/serialize.py
+++ b/moz/l10n/resource/fluent/serialize.py
@@ -76,7 +76,8 @@ def fluent_astify(
     Function names are upper-cased, and annotations with the `message` function
     are mapped to message and term references.
 
-    If the resource includes any metadata, a `serialize_metadata` callable must be provided
+    If the resource includes any metadata other than a string resource `info` value,
+    a `serialize_metadata` callable must be provided
     to map each field into a comment value, or to discard it by returning an empty value.
     """
 
@@ -95,6 +96,12 @@ def fluent_astify(
             if not serialize_metadata:
                 raise ValueError("Metadata requires serialize_metadata parameter")
             for field in node.meta:
+                if (
+                    isinstance(node, res.Resource)
+                    and field.key == "info"
+                    and field == node.meta[0]
+                ):
+                    continue
                 meta_str = serialize_metadata(field)
                 if meta_str:
                     ms = meta_str.strip("\n")
@@ -102,7 +109,18 @@ def fluent_astify(
         return cs
 
     body: list[ftl.EntryType] = []
-    res_comment = comment(resource)
+    res_info = resource.meta[0] if resource.meta else None
+    if (
+        not trim_comments
+        and res_info
+        and res_info.key == "info"
+        and isinstance(res_info.value, str)
+        and res_info.value
+    ):
+        body.append(ftl.Comment(res_info.value))
+        res_comment = resource.comment.rstrip()
+    else:
+        res_comment = comment(resource)
     if res_comment:
         body.append(ftl.ResourceComment(res_comment))
     for idx, section in enumerate(resource.sections):

--- a/moz/l10n/resource/fluent/serialize.py
+++ b/moz/l10n/resource/fluent/serialize.py
@@ -313,6 +313,10 @@ def function_ref(
     return ftl.FunctionReference(ftl.Identifier(annotation.name.upper()), args)
 
 
+# Non-printable ASCII C0 & C1 / Unicode Cc characters
+esc_cc = {n: f"\\u{n:04X}" for r in (range(0, 32), range(127, 160)) for n in r}
+
+
 def value(
     decl: list[msg.Declaration], val: str | msg.VariableRef
 ) -> ftl.InlineExpression:
@@ -321,7 +325,7 @@ def value(
             float(val)
             return ftl.NumberLiteral(val)
         except Exception:
-            return ftl.StringLiteral(val)
+            return ftl.StringLiteral(val.translate(esc_cc))
     else:
         local = next((d for d in decl if d.name == val.name), None)
         return (

--- a/moz/l10n/resource/ini/parse.py
+++ b/moz/l10n/resource/ini/parse.py
@@ -46,8 +46,8 @@ def ini_parse(source: TextIO | str | bytes) -> Resource[Message, Any]:
 
     def add_comment(cl: str | None) -> None:
         nonlocal comment
-        cv = cl[1:] if cl and cl.startswith(" ") else cl
-        if cv:
+        if cl is not None:
+            cv = cl[1:] if cl and cl.startswith(" ") else cl
             comment = f"{comment}\n{cv}" if comment else cv
 
     for line in ini_lines(cfg._data):

--- a/moz/l10n/resource/properties/parse.py
+++ b/moz/l10n/resource/properties/parse.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from re import sub
-from typing import Any, Tuple, cast
+from typing import Any
 
 from translate.storage.properties import propfile
 
@@ -32,17 +32,12 @@ def parse_comment(lines: list[str]) -> str:
 
 class propfile_shim(propfile):  # type: ignore[misc]
     def detect_encoding(
-        self, text: bytes | str, default_encodings: list[str] | None = None
+        self, text: str, default_encodings: list[str] | None = None
     ) -> tuple[str, str]:
         """
         Allow propfile().parse() to parse str inputs.
         """
-        if isinstance(text, str):
-            return (text, default_encodings[0] if default_encodings else "utf-8")
-        else:
-            return cast(
-                Tuple[str, str], super().detect_encoding(text, default_encodings)
-            )
+        return (text, default_encodings[0] if default_encodings else "utf-8")
 
 
 def properties_parse(
@@ -61,7 +56,7 @@ def properties_parse(
     pf = propfile_shim(personality="java-utf8")
     if encoding != "utf-8":
         pf.default_encoding = encoding
-    pf.parse(source)
+    pf.parse(source if isinstance(source, str) else source.decode(encoding))
     entries: list[Entry[Message, Any] | Comment] = []
     resource = Resource(Format.properties, [Section((), entries)])
     for unit in pf.getunits():

--- a/tests/resource/data/demo.ftl
+++ b/tests/resource/data/demo.ftl
@@ -1,3 +1,8 @@
+# Any copyright is dedicated to the Public Domain.
+# http://creativecommons.org/publicdomain/zero/1.0/
+
+### Resource Comment
+
 # Simple string
 title = About Localization
 

--- a/tests/resource/test_fluent.py
+++ b/tests/resource/test_fluent.py
@@ -129,6 +129,13 @@ class TestFluent(TestCase):
                            *[other] x,x
                         }
                   }
+                -term = Term
+                  .attr = foo
+                term-sel =
+                  { -term.attr ->
+                     [foo] Foo
+                    *[other] Other
+                  }
                 """
             ),
         )
@@ -207,140 +214,157 @@ class TestFluent(TestCase):
                     },
                 ),
             ),
+            Entry(("-term",), PatternMessage(["Term"])),
+            Entry(("-term", "attr"), PatternMessage(["foo"])),
+            Entry(
+                ("term-sel",),
+                SelectMessage(
+                    [Expression("-term.attr", FunctionAnnotation("message"))],
+                    {
+                        ("foo",): ["Foo"],
+                        (other,): ["Other"],
+                    },
+                ),
+            ),
         ]
-        self.assertEqual(
-            res,
-            Resource(
-                Format.fluent,
-                [
-                    Section(
-                        id=(),
-                        entries=[
-                            Entry(("simple",), PatternMessage(["A"])),
-                            Comment("Standalone Comment"),
-                        ],
-                        comment="Group Comment",
-                    ),
-                    Section((), entries),
-                ],
-                comment="Resource Comment",
-            ),
+        assert res == Resource(
+            Format.fluent,
+            [
+                Section(
+                    id=(),
+                    entries=[
+                        Entry(("simple",), PatternMessage(["A"])),
+                        Comment("Standalone Comment"),
+                    ],
+                    comment="Group Comment",
+                ),
+                Section((), entries),
+            ],
+            comment="Resource Comment",
         )
-        self.assertEqual(
-            "".join(fluent_serialize(res)),
-            dedent(
-                """\
-                ### Resource Comment
+        assert "".join(fluent_serialize(res)) == dedent(
+            """\
+            ### Resource Comment
 
 
-                ## Group Comment
+            ## Group Comment
 
-                simple = A
+            simple = A
 
-                # Standalone Comment
+            # Standalone Comment
 
 
-                ##
+            ##
 
-                # Message Comment
-                # on two lines.
-                expressions = A { $arg } B { msg.foo } C { -term(x: 42) }
-                functions = { NUMBER($arg) }{ FOO("bar", opt: "val") }
-                has-attr = ABC
-                    .attr = Attr
-                # Attr Comment
-                has-only-attr =
-                    .attr = Attr
-                single-sel =
-                    { NUMBER($num) ->
-                        [one] One
-                       *[other] Other
-                    }
-                two-sels =
-                    { NUMBER($a) ->
-                        [1]
-                            { $b ->
-                                [cc] pre One mid CC post
-                               *[bb] pre One mid BB post
-                            }
-                       *[2]
-                            { $b ->
-                                [cc] pre Two mid CC post
-                               *[bb] pre Two mid BB post
-                            }
-                    }
-                deep-sels =
-                    { NUMBER($a) ->
-                        [0]
-                            { NUMBER($b) ->
-                                [one] { "" }
-                               *[other] 0,x
-                            }
-                        [one]
-                            { NUMBER($b) ->
-                                [one] { "1,1" }
-                               *[other] 1,x
-                            }
-                       *[other]
-                            { NUMBER($b) ->
-                                [0] x,0
-                                [one] x,1
-                               *[other] x,x
-                            }
-                    }
-                """
-            ),
+            # Message Comment
+            # on two lines.
+            expressions = A { $arg } B { msg.foo } C { -term(x: 42) }
+            functions = { NUMBER($arg) }{ FOO("bar", opt: "val") }
+            has-attr = ABC
+                .attr = Attr
+            # Attr Comment
+            has-only-attr =
+                .attr = Attr
+            single-sel =
+                { NUMBER($num) ->
+                    [one] One
+                   *[other] Other
+                }
+            two-sels =
+                { NUMBER($a) ->
+                    [1]
+                        { $b ->
+                            [cc] pre One mid CC post
+                           *[bb] pre One mid BB post
+                        }
+                   *[2]
+                        { $b ->
+                            [cc] pre Two mid CC post
+                           *[bb] pre Two mid BB post
+                        }
+                }
+            deep-sels =
+                { NUMBER($a) ->
+                    [0]
+                        { NUMBER($b) ->
+                            [one] { "" }
+                           *[other] 0,x
+                        }
+                    [one]
+                        { NUMBER($b) ->
+                            [one] { "1,1" }
+                           *[other] 1,x
+                        }
+                   *[other]
+                        { NUMBER($b) ->
+                            [0] x,0
+                            [one] x,1
+                           *[other] x,x
+                        }
+                }
+            -term = Term
+                .attr = foo
+            term-sel =
+                { -term.attr ->
+                    [foo] Foo
+                   *[other] Other
+                }
+            """
         )
-        self.assertEqual(
-            "".join(fluent_serialize(res, trim_comments=True)),
-            dedent(
-                """\
-                simple = A
-                expressions = A { $arg } B { msg.foo } C { -term(x: 42) }
-                functions = { NUMBER($arg) }{ FOO("bar", opt: "val") }
-                has-attr = ABC
-                    .attr = Attr
-                has-only-attr =
-                    .attr = Attr
-                single-sel =
-                    { NUMBER($num) ->
-                        [one] One
-                       *[other] Other
-                    }
-                two-sels =
-                    { NUMBER($a) ->
-                        [1]
-                            { $b ->
-                                [cc] pre One mid CC post
-                               *[bb] pre One mid BB post
-                            }
-                       *[2]
-                            { $b ->
-                                [cc] pre Two mid CC post
-                               *[bb] pre Two mid BB post
-                            }
-                    }
-                deep-sels =
-                    { NUMBER($a) ->
-                        [0]
-                            { NUMBER($b) ->
-                                [one] { "" }
-                               *[other] 0,x
-                            }
-                        [one]
-                            { NUMBER($b) ->
-                                [one] { "1,1" }
-                               *[other] 1,x
-                            }
-                       *[other]
-                            { NUMBER($b) ->
-                                [0] x,0
-                                [one] x,1
-                               *[other] x,x
-                            }
-                    }
+        assert "".join(fluent_serialize(res, trim_comments=True)) == dedent(
+            """\
+            simple = A
+            expressions = A { $arg } B { msg.foo } C { -term(x: 42) }
+            functions = { NUMBER($arg) }{ FOO("bar", opt: "val") }
+            has-attr = ABC
+                .attr = Attr
+            has-only-attr =
+                .attr = Attr
+            single-sel =
+                { NUMBER($num) ->
+                    [one] One
+                   *[other] Other
+                }
+            two-sels =
+                { NUMBER($a) ->
+                    [1]
+                        { $b ->
+                            [cc] pre One mid CC post
+                           *[bb] pre One mid BB post
+                        }
+                   *[2]
+                        { $b ->
+                            [cc] pre Two mid CC post
+                           *[bb] pre Two mid BB post
+                        }
+                }
+            deep-sels =
+                { NUMBER($a) ->
+                    [0]
+                        { NUMBER($b) ->
+                            [one] { "" }
+                           *[other] 0,x
+                        }
+                    [one]
+                        { NUMBER($b) ->
+                            [one] { "1,1" }
+                           *[other] 1,x
+                        }
+                   *[other]
+                        { NUMBER($b) ->
+                            [0] x,0
+                            [one] x,1
+                           *[other] x,x
+                        }
+                }
+            -term = Term
+                .attr = foo
+            term-sel =
+                { -term.attr ->
+                    [foo] Foo
+                   *[other] Other
+                }
                 """
-            ),
         )
 
     def test_escapes(self):

--- a/tests/resource/test_fluent.py
+++ b/tests/resource/test_fluent.py
@@ -455,6 +455,7 @@ class TestFluent(TestCase):
     def test_file(self):
         bytes = files("tests.resource.data").joinpath("demo.ftl").read_bytes()
         res = fluent_parse(bytes)
+        copyright = "Any copyright is dedicated to the Public Domain.\nhttp://creativecommons.org/publicdomain/zero/1.0/"
         entries = [
             Entry(
                 id=("title",),
@@ -701,121 +702,130 @@ class TestFluent(TestCase):
             ),
         ]
         self.assertEqual(
-            res, Resource(Format.fluent, sections=[Section(id=(), entries=entries)])
+            res,
+            Resource(
+                Format.fluent,
+                meta=[Metadata("info", copyright)],
+                comment="Resource Comment",
+                sections=[Section(id=(), entries=entries)],
+            ),
         )
-        self.assertEqual(
-            "".join(fluent_serialize(res)),
-            dedent(
-                """\
-                # Simple string
-                title = About Localization
-                # Multiline string: press Shift + Enter to insert new line
-                feedbackUninstallCopy =
-                    Your participation in Firefox Test Pilot means
-                    a lot! Please check out our other experiments,
-                    and stay tuned for more to come.
-                # Attributes: in original string
-                emailOptInInput =
-                    .placeholder = email goes here :)
-                # Attributes: access keys
-                file-menu =
-                    .label = File
-                    .accesskey = F
-                other-file-menu =
-                    .aria-label = { file-menu.label }
-                    .accesskey = { file-menu.accesskey }
-                # Value and an attribute
-                shotIndexNoExpirationSymbol = ∞
-                    .title = This shot does not expire
-                # Plurals
-                delete-all-message =
-                    { NUMBER($num) ->
-                        [one] Delete this download?
-                       *[other] Delete { $num } downloads?
-                    }
-                # Plurals with custom values
-                delete-all-message-special-cases =
-                    { NUMBER($num) ->
-                        [1] Delete this download?
-                        [2] Delete this pair of downloads?
-                        [12] Delete this dozen of downloads?
-                       *[other] Delete { $num } downloads?
-                    }
-                # DATETIME Built-in function
-                today-is = Today is { DATETIME($date, month: "long", year: "numeric", day: "numeric") }
-                # Soft Launch
-                default-content-process-count =
-                    .label = { $num } (default)
-                # PLATFORM() selector
-                platform =
+        assert "".join(fluent_serialize(res)) == dedent(
+            """\
+            # Any copyright is dedicated to the Public Domain.
+            # http://creativecommons.org/publicdomain/zero/1.0/
+
+
+            ### Resource Comment
+
+            # Simple string
+            title = About Localization
+            # Multiline string: press Shift + Enter to insert new line
+            feedbackUninstallCopy =
+                Your participation in Firefox Test Pilot means
+                a lot! Please check out our other experiments,
+                and stay tuned for more to come.
+            # Attributes: in original string
+            emailOptInInput =
+                .placeholder = email goes here :)
+            # Attributes: access keys
+            file-menu =
+                .label = File
+                .accesskey = F
+            other-file-menu =
+                .aria-label = { file-menu.label }
+                .accesskey = { file-menu.accesskey }
+            # Value and an attribute
+            shotIndexNoExpirationSymbol = ∞
+                .title = This shot does not expire
+            # Plurals
+            delete-all-message =
+                { NUMBER($num) ->
+                    [one] Delete this download?
+                   *[other] Delete { $num } downloads?
+                }
+            # Plurals with custom values
+            delete-all-message-special-cases =
+                { NUMBER($num) ->
+                    [1] Delete this download?
+                    [2] Delete this pair of downloads?
+                    [12] Delete this dozen of downloads?
+                   *[other] Delete { $num } downloads?
+                }
+            # DATETIME Built-in function
+            today-is = Today is { DATETIME($date, month: "long", year: "numeric", day: "numeric") }
+            # Soft Launch
+            default-content-process-count =
+                .label = { $num } (default)
+            # PLATFORM() selector
+            platform =
+                { PLATFORM() ->
+                    [win] Options
+                   *[other] Preferences
+                }
+            # NUMBER() selector
+            number =
+                { NUMBER($var, type: "ordinal") ->
+                    [1] first
+                    [one] { $var }st
+                   *[other] { $var }nd
+                }
+            # PLATFORM() selector in attribute
+            platform-attribute =
+                .title =
                     { PLATFORM() ->
                         [win] Options
                        *[other] Preferences
                     }
-                # NUMBER() selector
-                number =
-                    { NUMBER($var, type: "ordinal") ->
-                        [1] first
-                        [one] { $var }st
-                       *[other] { $var }nd
+            # Double selector in attributes
+            download-choose-folder =
+                .label =
+                    { PLATFORM() ->
+                        [macos] Choose…
+                       *[other] Browse…
                     }
-                # PLATFORM() selector in attribute
-                platform-attribute =
-                    .title =
-                        { PLATFORM() ->
-                            [win] Options
-                           *[other] Preferences
-                        }
-                # Double selector in attributes
-                download-choose-folder =
-                    .label =
-                        { PLATFORM() ->
-                            [macos] Choose…
-                           *[other] Browse…
-                        }
-                    .accesskey =
-                        { PLATFORM() ->
-                            [macos] e
-                           *[other] o
-                        }
-                # Multiple selectors
-                selector-multi =
-                    { NUMBER($num) ->
-                        [one]
-                            { $gender ->
-                                [feminine] There is one email for her
-                               *[masculine] There is one email for him
-                            }
-                       *[other]
-                            { $gender ->
-                                [feminine] There are many emails for her
-                               *[masculine] There are many emails for him
-                            }
+                .accesskey =
+                    { PLATFORM() ->
+                        [macos] e
+                       *[other] o
                     }
-                # Term
-                -term = Term
-                # TermReference
-                term-reference = Term { -term } Reference
-                # StringExpression
-                string-expression = { "" }
-                # NumberExpression
-                number-expression = { 5 }
-                # MessageReference with attribute (was: AttributeExpression)
-                attribute-expression = { my_id.title }
-                # Nested selectors
-                selector-nested =
-                    { $gender ->
-                        [masculine]
-                            { NUMBER($num) ->
-                                [one] There is one email for him
-                               *[other] There are many emails for him
-                            }
-                       *[feminine]
-                            { NUMBER($num) ->
-                                [one] There is one email for her
-                               *[other] There are many emails for her
-                            }
-                    }
-                """
-            ),
+            # Multiple selectors
+            selector-multi =
+                { NUMBER($num) ->
+                    [one]
+                        { $gender ->
+                            [feminine] There is one email for her
+                           *[masculine] There is one email for him
+                        }
+                   *[other]
+                        { $gender ->
+                            [feminine] There are many emails for her
+                           *[masculine] There are many emails for him
+                        }
+                }
+            # Term
+            -term = Term
+            # TermReference
+            term-reference = Term { -term } Reference
+            # StringExpression
+            string-expression = { "" }
+            # NumberExpression
+            number-expression = { 5 }
+            # MessageReference with attribute (was: AttributeExpression)
+            attribute-expression = { my_id.title }
+            # Nested selectors
+            selector-nested =
+                { $gender ->
+                    [masculine]
+                        { NUMBER($num) ->
+                            [one] There is one email for him
+                           *[other] There are many emails for him
+                        }
+                   *[feminine]
+                        { NUMBER($num) ->
+                            [one] There is one email for her
+                           *[other] There are many emails for her
+                        }
+                }
+            """
         )

--- a/tests/resource/test_fluent.py
+++ b/tests/resource/test_fluent.py
@@ -343,6 +343,20 @@ class TestFluent(TestCase):
             ),
         )
 
+    def test_escapes(self):
+        source = 'key = { "" } { "\t" } { "\\u000a" }'
+        res = fluent_parse(source)
+        exp_msg = PatternMessage(
+            [Expression(""), " ", Expression("\t"), " ", Expression("\n")]
+        )
+        assert res == Resource(
+            Format.fluent, [Section(id=(), entries=[Entry(("key",), exp_msg)])]
+        )
+        assert (
+            "".join(fluent_serialize(res))
+            == 'key = { "" } { "\\u0009" } { "\\u000A" }\n'
+        )
+
     def test_attr_comment(self):
         res = fluent_parse("msg = body\n  .attr = value")
 

--- a/tests/resource/test_ini.py
+++ b/tests/resource/test_ini.py
@@ -34,35 +34,29 @@ class TestIni(TestCase):
                 ; This file is in the UTF-8 encoding
                 [Strings]
                 TitleText=Some Title
-                """,
+                """
             )
         )
-        self.assertEqual(
-            res,
-            Resource(
-                Format.ini,
-                [
-                    Section(
-                        id=("Strings",),
-                        entries=[Entry(("TitleText",), PatternMessage(["Some Title"]))],
-                        comment="This file is in the UTF-8 encoding",
-                    )
-                ],
-            ),
+        assert res == Resource(
+            Format.ini,
+            [
+                Section(
+                    id=("Strings",),
+                    entries=[Entry(("TitleText",), PatternMessage(["Some Title"]))],
+                    comment="This file is in the UTF-8 encoding",
+                )
+            ],
         )
-        self.assertEqual(
-            "".join(ini_serialize(res)),
-            dedent(
-                """\
-                # This file is in the UTF-8 encoding
-                [Strings]
-                TitleText = Some Title
-                """
-            ),
+        assert "".join(ini_serialize(res)) == dedent(
+            """\
+            # This file is in the UTF-8 encoding
+            [Strings]
+            TitleText = Some Title
+            """
         )
-        self.assertEqual(
-            "".join(ini_serialize(res, trim_comments=True)),
-            "[Strings]\nTitleText = Some Title\n",
+        assert (
+            "".join(ini_serialize(res, trim_comments=True))
+            == "[Strings]\nTitleText = Some Title\n"
         )
 
     def test_resource_comment(self):
@@ -72,43 +66,42 @@ class TestIni(TestCase):
                 ; This Source Code Form is subject to the terms of the Mozilla Public
                 ; License, v. 2.0. If a copy of the MPL was not distributed with this file,
                 ; You can obtain one at http://mozilla.org/MPL/2.0/.
+                ;
+                ; This file is in the UTF-8 encoding
 
                 [Strings]
                 TitleText=Some Title
                 """
             )
         )
-        self.assertEqual(
-            res,
-            Resource(
-                Format.ini,
-                [
-                    Section(
-                        id=("Strings",),
-                        entries=[Entry(("TitleText",), PatternMessage(["Some Title"]))],
-                    )
-                ],
-                comment="This Source Code Form is subject to the terms of the Mozilla Public\n"
-                "License, v. 2.0. If a copy of the MPL was not distributed with this file,\n"
-                "You can obtain one at http://mozilla.org/MPL/2.0/.",
-            ),
+        assert res == Resource(
+            Format.ini,
+            [
+                Section(
+                    id=("Strings",),
+                    entries=[Entry(("TitleText",), PatternMessage(["Some Title"]))],
+                )
+            ],
+            comment="This Source Code Form is subject to the terms of the Mozilla Public\n"
+            "License, v. 2.0. If a copy of the MPL was not distributed with this file,\n"
+            "You can obtain one at http://mozilla.org/MPL/2.0/.\n\n"
+            "This file is in the UTF-8 encoding",
         )
-        self.assertEqual(
-            "".join(ini_serialize(res)),
-            dedent(
-                """\
-                # This Source Code Form is subject to the terms of the Mozilla Public
-                # License, v. 2.0. If a copy of the MPL was not distributed with this file,
-                # You can obtain one at http://mozilla.org/MPL/2.0/.
+        assert "".join(ini_serialize(res)) == dedent(
+            """\
+            # This Source Code Form is subject to the terms of the Mozilla Public
+            # License, v. 2.0. If a copy of the MPL was not distributed with this file,
+            # You can obtain one at http://mozilla.org/MPL/2.0/.
+            #
+            # This file is in the UTF-8 encoding
 
-                [Strings]
-                TitleText = Some Title
-                """
-            ),
+            [Strings]
+            TitleText = Some Title
+            """
         )
-        self.assertEqual(
-            "".join(ini_serialize(res, trim_comments=True)),
-            "[Strings]\nTitleText = Some Title\n",
+        assert (
+            "".join(ini_serialize(res, trim_comments=True))
+            == "[Strings]\nTitleText = Some Title\n"
         )
 
     def test_junk(self):


### PR DESCRIPTION
This is a grab-bag of small stuff, discovered by testing the tools against [firefox-l10n](https://github.com/mozilla-l10n/firefox-l10n) contents.

The test changes replacing `self.assertEqual()` with `assert ...` are because they result in clearer error logs with `pytest`, whereas the former was better with `python -m unittest`.