### PR TITLE
Reduce minimum external dependencies and add line positions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install importlib_resources pytest
-      - run: pip install .
+      - run: pip install '.[xml]'
       - run: pytest -vv
 
   lint:
@@ -33,7 +33,7 @@ jobs:
         with:
           python-version: "3.12"
       - run: pip install -r dev-requirements.txt
-      - run: pip install -e .
+      - run: pip install -e '.[xml]'
       - run: python -m flake8 .
       - run: python -m mypy .
       - run: python -m black --check .

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ The Message and Resource representations are drawn from work done for the
 Unicode [MessageFormat 2 specification](https://github.com/unicode-org/message-format-wg/tree/main/spec)
 and the [Message resource specification](https://github.com/eemeli/message-resource-wg/).
 
+Support for XML formats (`android`, `xliff`) is an optional extra;
+to support them, install as `moz.l10n[xml]`.
+
 ## Command-line Tools
 
 For usage details, use each command's `--help` argument.

--- a/moz/l10n/resource/data.py
+++ b/moz/l10n/resource/data.py
@@ -39,6 +39,34 @@ The Message value type.
 
 
 @dataclass
+class LinePos:
+    """
+    The source line position of an entry or section header.
+    """
+
+    start: int
+    """
+    The starting line of the entry or section.
+    May be less than `value` if preceded by a comment.
+    """
+
+    key: int
+    """
+    The start line of the entry or section header key or name.
+    """
+
+    value: int
+    """
+    The start line of the entry pattern or section header.
+    """
+
+    end: int
+    """
+    The line one past the end of the entry or section header.
+    """
+
+
+@dataclass
 class Metadata(Generic[M]):
     """
     Metadata is attached to a resource, section, or a single entry.
@@ -122,6 +150,12 @@ class Entry(Generic[V, M]):
     Metadata attached to this entry.
     """
 
+    linepos: LinePos | None = None
+    """
+    The parsed position of the entry,
+    available for some formats.
+    """
+
 
 @dataclass
 class Section(Generic[V, M]):
@@ -170,6 +204,12 @@ class Section(Generic[V, M]):
     meta: list[Metadata[M]] = field(default_factory=list)
     """
     Metadata attached to this section.
+    """
+
+    linepos: LinePos | None = None
+    """
+    The parsed position of the section,
+    available for some formats.
     """
 
 

--- a/moz/l10n/resource/format.py
+++ b/moz/l10n/resource/format.py
@@ -20,8 +20,6 @@ from json import JSONDecodeError, loads
 from os.path import splitext
 from typing import Any
 
-from lxml.etree import LxmlError, iterparse
-
 # from moz.l10n.resource.xliff.common import xliff_ns
 xliff_ns = {
     "urn:oasis:names:tc:xliff:document:1.0",
@@ -115,13 +113,15 @@ def detect_format(name: str | None, source: bytes | str) -> Format | None:
 
     # Let's presume the input is XML and look at its root node.
     try:
+        from lxml.etree import LxmlError, iterparse
+
         bs = source.encode() if isinstance(source, str) else source
         _, xml_root = next(iterparse(BytesIO(bs), events=("start",)))
         ns = xml_root.nsmap.get(None, None)
         if ns:
             return Format.xliff if ns in xliff_ns else None
         return Format.android if xml_root.tag == "resources" else None
-    except LxmlError:
+    except (ImportError, LxmlError):
         pass
 
     return None

--- a/moz/l10n/resource/properties/parse.py
+++ b/moz/l10n/resource/properties/parse.py
@@ -14,30 +14,41 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from re import sub
-from typing import Any
-
-from translate.storage.properties import propfile
+from enum import Enum
+from re import Match, compile
+from typing import Any, Callable
 
 from moz.l10n.message import Message, PatternMessage
 
-from ..data import Comment, Entry, Resource, Section
+from ..data import Comment, Entry, LinePos, Resource, Section
 from ..format import Format
 
 
-def parse_comment(lines: list[str]) -> str:
-    return "\n".join(sub("^# ?", "", line) for line in lines if line.startswith("#"))
+class LineKind(Enum):
+    EMPTY = 0
+    COMMENT = 1
+    KEY = 2
+    VALUE = 3
 
 
-class propfile_shim(propfile):  # type: ignore[misc]
-    def detect_encoding(
-        self, text: str, default_encodings: list[str] | None = None
-    ) -> tuple[str, str]:
-        """
-        Allow propfile().parse() to parse str inputs.
-        """
-        return (text, default_encodings[0] if default_encodings else "utf-8")
+esc_re = compile("\\\\(u[0-9A-Fa-f]{1,4}|.)")
+
+
+def esc_parse(match: Match[str]) -> str:
+    esc = match.group(1)
+    if len(esc) > 1 and esc[0] == "u":
+        n = int(esc[1:], 16)
+        return chr(n)
+    elif esc == "t":
+        return "\t"
+    elif esc == "n":
+        return "\n"
+    elif esc == "f":
+        return "\f"
+    elif esc == "r":
+        return "\r"
+    else:
+        return esc
 
 
 def properties_parse(
@@ -53,30 +64,175 @@ def properties_parse(
 
     The parsed resource will not include any metadata.
     """
-    pf = propfile_shim(personality="java-utf8")
-    if encoding != "utf-8":
-        pf.default_encoding = encoding
-    pf.parse(source if isinstance(source, str) else source.decode(encoding))
+    if not isinstance(source, str):
+        source = source.decode(encoding)
+    parser = PropertiesParser(source)
     entries: list[Entry[Message, Any] | Comment] = []
     resource = Resource(Format.properties, [Section((), entries)])
-    for unit in pf.getunits():
-        if unit.name or unit.value:
-            entries.append(
-                Entry(
-                    id=(unit.name,),
-                    value=(
-                        parse_message(unit.source)
-                        if parse_message
-                        else PatternMessage([unit.source])
-                    ),
-                    comment=parse_comment(unit.comments),
-                )
-            )
+
+    start_line = 0
+    comment = ""
+    prev_linepos: LinePos | None = None
+    entry: Entry[Message, Any] | None = None
+    for kind, line, value in parser:
+        if kind == LineKind.VALUE:
+            assert entry
+            if parse_message:
+                entry.value = parse_message(value)
+            else:
+                assert isinstance(entry.value, PatternMessage)
+                entry.value.pattern.append(value)
+            if entry.linepos and line > entry.linepos.key:
+                entry.linepos.value = line
+                entry.linepos.end = line + 1
+            entry = None
         else:
-            comment = parse_comment(unit.comments)
-            if comment:
+            if prev_linepos:
+                prev_linepos.end = line
+                prev_linepos = None
+            entry = None
+            if kind == LineKind.KEY:
+                entry = Entry(
+                    id=(value,),
+                    value=PatternMessage([]),
+                    comment=comment,
+                    linepos=LinePos(start_line or line, line, line, line + 1),
+                )
+                prev_linepos = entry.linepos
+                entries.append(entry)
+                comment = ""
+                start_line = 0
+            elif kind == LineKind.COMMENT:
+                if comment:
+                    comment += "\n" + value
+                else:
+                    comment = value
+                    start_line = line
+            elif comment:
+                # empty line or EOF after a comment
                 if entries or resource.comment:
                     entries.append(Comment(comment))
                 else:
                     resource.comment = comment
+                comment = ""
+                start_line = 0
     return resource
+
+
+class PropertiesParser:
+    def __init__(self, source: str) -> None:
+        self.source = source
+        self.pos = 0
+        self.line_pos = 1
+        self.at_value = False
+        self.done = False
+
+    def __iter__(self) -> PropertiesParser:
+        return self
+
+    def __next__(self) -> tuple[LineKind, int, str]:
+        if self.done:
+            raise StopIteration
+
+        lp = self.line_pos
+        self.ws()
+        if self.pos == len(self.source):
+            self.done = True
+            return LineKind.EMPTY, lp, ""
+
+        if self.nl():
+            self.at_value = False
+            return LineKind.EMPTY, lp, ""
+
+        if self.at_value:
+            # value
+            self.at_value = False
+            line_start = start = self.pos
+            at_escape = False
+            at_cr = False
+            idx = -1
+            lines: list[str] = []
+            for idx, ch in enumerate(self.source[start:]):
+                if ch == "\n" or ch == "\r":
+                    if at_escape:
+                        at_escape = False
+                        self.line_pos += 1
+                        end = start + idx - 1
+                        lines.append(self.source[line_start:end])
+                        at_cr = ch == "\r"
+                        line_start = start + idx + 1
+                    elif ch == "\n" and at_cr:
+                        at_cr = False
+                        line_start = start + idx + 1
+                    else:
+                        idx -= 1
+                        break
+                else:
+                    if at_cr:
+                        at_cr = False
+                    if at_escape:
+                        at_escape = False
+                    elif ch == "\\":
+                        at_escape = True
+            self.pos = end = start + idx + 1
+            lines.append(self.source[line_start:end])
+            self.nl()
+            value = "".join(
+                esc_re.sub(esc_parse, line.lstrip("\f\t ")) for line in lines
+            )
+            return LineKind.VALUE, lp, value
+
+        if self.source.startswith(("#", "!"), self.pos):
+            # comment
+            self.pos += 1
+            if self.source.startswith(" ", self.pos):
+                # Ignore one space after #, if present.
+                self.pos += 1
+            start = self.pos
+            idx = -1
+            for idx, ch in enumerate(self.source[start:]):
+                if ch == "\n" or ch == "\r":
+                    idx -= 1
+                    break
+            end = self.pos = start + idx + 1
+            self.nl()
+            return LineKind.COMMENT, lp, self.source[start:end]
+
+        # key
+        start = self.pos
+        at_escape = False
+        idx = -1
+        for idx, ch in enumerate(self.source[start:]):
+            if at_escape:
+                at_escape = False
+            elif ch == "\\":
+                at_escape = True
+            elif ch in {"\n", "\r", "\t", "\f", " ", "=", ":"}:
+                idx -= 1
+                break
+        end = self.pos = start + idx + 1
+        self.ws()
+        if self.source.startswith(("=", ":"), self.pos):
+            self.pos += 1
+        self.at_value = True
+        return LineKind.KEY, lp, esc_re.sub(esc_parse, self.source[start:end])
+
+    def nl(self) -> bool:
+        if self.source.startswith("\n", self.pos):
+            self.pos += 1
+            self.line_pos += 1
+            return True
+        elif self.source.startswith("\r", self.pos):
+            self.pos += 1
+            self.line_pos += 1
+            if self.source.startswith("\n", self.pos):
+                self.pos += 1
+            return True
+        return False
+
+    def ws(self) -> None:
+        for ch in self.source[self.pos :]:
+            if ch in {" ", "\t", "\f"}:
+                self.pos += 1
+            else:
+                break

--- a/moz/l10n/resource/properties/parse.py
+++ b/moz/l10n/resource/properties/parse.py
@@ -88,7 +88,7 @@ def properties_parse(
             entry = None
         else:
             if prev_linepos:
-                prev_linepos.end = line
+                prev_linepos.end = max(prev_linepos.end, line)
                 prev_linepos = None
             entry = None
             if kind == LineKind.KEY:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,11 +33,13 @@ dependencies = [
   "fluent.syntax ~= 0.19.0",
   "gitignorant ~= 0.3.1",
   "iniparse ~= 0.5",
-  "lxml ~= 5.0",
   "polib ~= 1.2",
   "tomli >= 1.1.0; python_version < '3.11'",
   "translate-toolkit ~= 3.13",
 ]
+
+[project.optional-dependencies]
+xml = ["lxml ~= 5.0"]
 
 [project.scripts]
 l10n-build = "moz.l10n.bin.build:cli"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
   "iniparse ~= 0.5",
   "polib ~= 1.2",
   "tomli >= 1.1.0; python_version < '3.11'",
-  "translate-toolkit ~= 3.13",
 ]
 
 [project.optional-dependencies]

--- a/tests/resource/__init__.py
+++ b/tests/resource/__init__.py
@@ -1,0 +1,32 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from moz.l10n.resource.data import LinePos
+
+
+def get_linepos(
+    start: int,
+    key: int | None = None,
+    value: int | None = None,
+    end: int | None = None,
+) -> None:
+    if key is None:
+        key = start
+    if value is None:
+        value = key
+    if end is None:
+        end = value + 1
+    return LinePos(start, key, value, end)

--- a/tests/resource/test_properties.py
+++ b/tests/resource/test_properties.py
@@ -27,6 +27,74 @@ from . import get_linepos
 
 
 class TestProperties(TestCase):
+    def test_java_docs(self):
+        # Examples from https://docs.oracle.com/javase/8/docs/api/java/util/Properties.html#load-java.io.Reader-
+        src = r"""
+Truth = Beauty
+ Truth:Beauty
+Truth                    :Beauty
+fruits                           apple, banana, pear, \
+                                 cantaloupe, watermelon, \
+                                 kiwi, mango
+ cheeses
+\:\=
+"""
+        res = properties_parse(src)
+        assert res == Resource(
+            Format.properties,
+            [
+                Section(
+                    (),
+                    [
+                        Entry(
+                            ("Truth",),
+                            PatternMessage(["Beauty"]),
+                            linepos=get_linepos(2),
+                        ),
+                        Entry(
+                            ("Truth",),
+                            PatternMessage(["Beauty"]),
+                            linepos=get_linepos(3),
+                        ),
+                        Entry(
+                            ("Truth",),
+                            PatternMessage(["Beauty"]),
+                            linepos=get_linepos(4),
+                        ),
+                        Entry(
+                            ("fruits",),
+                            PatternMessage(
+                                [
+                                    "apple, banana, pear, cantaloupe, watermelon, kiwi, mango"
+                                ]
+                            ),
+                            linepos=get_linepos(5, end=8),
+                        ),
+                        Entry(
+                            ("cheeses",),
+                            PatternMessage([]),
+                            linepos=get_linepos(8),
+                        ),
+                        Entry(
+                            (":=",),
+                            PatternMessage([]),
+                            linepos=get_linepos(9),
+                        ),
+                    ],
+                )
+            ],
+        )
+        assert "".join(properties_serialize(res)) == dedent(
+            """\
+            Truth = Beauty
+            Truth = Beauty
+            Truth = Beauty
+            fruits = apple, banana, pear, cantaloupe, watermelon, kiwi, mango
+            cheeses =
+            \\:\\= =
+            """
+        )
+
     def test_backslashes(self):
         src = r"""one_line = This is one line
 two_line = This is the first \


### PR DESCRIPTION
The `translate-toolkit` and `lxml` dependencies form the vast majority of the filesize footprint of the library. To reduce that:
1. Write our own .properties parser and serialiser.
2. Treat the support of XML formats (Android, XLIFF) as an optional extra, installable as `moz.l10n[xml]`.