### PR TITLE
Check for ImportError before LxmlError, as the latter depends on the import

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,6 +22,8 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - run: pip install importlib_resources pytest
+      - run: pip install .
+      - run: pytest -vv
       - run: pip install '.[xml]'
       - run: pytest -vv
 

--- a/moz/l10n/resource/format.py
+++ b/moz/l10n/resource/format.py
@@ -121,7 +121,10 @@ def detect_format(name: str | None, source: bytes | str) -> Format | None:
         if ns:
             return Format.xliff if ns in xliff_ns else None
         return Format.android if xml_root.tag == "resources" else None
-    except (ImportError, LxmlError):
+    except ImportError:
+        pass
+    except LxmlError:
+        # Must be separate and after ImportError
         pass
 
     return None

--- a/tests/resource/test_android.py
+++ b/tests/resource/test_android.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from importlib_resources import files
 from textwrap import dedent
-from unittest import TestCase
+from unittest import SkipTest, TestCase
 
 from moz.l10n.message import (
     CatchallKey,
@@ -27,9 +27,13 @@ from moz.l10n.message import (
     SelectMessage,
     VariableRef,
 )
-from moz.l10n.resource.android import android_parse, android_serialize
 from moz.l10n.resource.data import Comment, Entry, Metadata, Resource, Section
 from moz.l10n.resource.format import Format
+
+try:
+    from moz.l10n.resource.android import android_parse, android_serialize
+except ImportError:
+    raise SkipTest("Requires [xml] extra")
 
 source = files("tests.resource.data").joinpath("strings.xml").read_bytes()
 

--- a/tests/resource/test_detect_format.py
+++ b/tests/resource/test_detect_format.py
@@ -14,32 +14,44 @@
 
 from __future__ import annotations
 
+from importlib.util import find_spec
 from importlib_resources import files
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
 from moz.l10n.resource import Format, detect_format
 
+no_xml = find_spec("lxml") is None
+
 
 class TestDetectFormat(TestCase):
-    def test_data_files(self):
+    def test_common_data_files(self):
         data = {
             "accounts.dtd": Format.dtd,
-            "angular.xliff": Format.xliff,
             "bug121341.properties": Format.properties,
             "defines.inc": Format.inc,
             "demo.ftl": Format.fluent,
             "foo.po": Format.po,
+            "messages.json": Format.webext,
+            "test.properties": Format.properties,
+        }
+        for file, exp_format in data.items():
+            source = files("tests.resource.data").joinpath(file).read_bytes()
+            assert detect_format(file, source) == exp_format
+
+    @skipIf(no_xml, "Requires [xml] extra")
+    def test_xml_data_files(self):
+        data = {
+            "angular.xliff": Format.xliff,
             "hello.xliff": Format.xliff,
             "icu-docs.xliff": Format.xliff,
-            "messages.json": Format.webext,
             "strings.xml": Format.android,
-            "test.properties": Format.properties,
             "xcode.xliff": Format.xliff,
         }
         for file, exp_format in data.items():
             source = files("tests.resource.data").joinpath(file).read_bytes()
             assert detect_format(file, source) == exp_format
 
+    @skipIf(no_xml, "Requires [xml] extra")
     def test_xliff_source(self):
         for file in ("angular.xliff", "hello.xliff", "icu-docs.xliff", "xcode.xliff"):
             source = files("tests.resource.data").joinpath(file).read_bytes()

--- a/tests/resource/test_parse_serialize_resource.py
+++ b/tests/resource/test_parse_serialize_resource.py
@@ -14,8 +14,9 @@
 
 from __future__ import annotations
 
+from importlib.util import find_spec
 from importlib_resources import files
-from unittest import TestCase
+from unittest import TestCase, skipIf
 
 from moz.l10n.resource import (
     Format,
@@ -25,25 +26,39 @@ from moz.l10n.resource import (
 )
 from moz.l10n.resource.data import Resource
 
+no_xml = find_spec("lxml") is None
+
 
 def get_source(filename: str) -> bytes:
     return files("tests.resource.data").joinpath(filename).read_bytes()
 
 
 class TesteParseResource(TestCase):
-    def test_named_files(self):
+    def test_named_common_files(self):
         data = (
             "accounts.dtd",
-            "angular.xliff",
             "bug121341.properties",
             "defines.inc",
             "demo.ftl",
             "foo.po",
+            "messages.json",
+            "test.properties",
+        )
+        for file in data:
+            res = parse_resource(file, get_source(file))
+            assert isinstance(res, Resource)
+            assert all(isinstance(s, str) for s in serialize_resource(res))
+            assert all(
+                isinstance(s, str) for s in serialize_resource(res, trim_comments=True)
+            )
+
+    @skipIf(no_xml, "Requires [xml] extra")
+    def test_named_xml_files(self):
+        data = (
+            "angular.xliff",
             "hello.xliff",
             "icu-docs.xliff",
-            "messages.json",
             "strings.xml",
-            "test.properties",
             "xcode.xliff",
         )
         for file in data:
@@ -54,6 +69,7 @@ class TesteParseResource(TestCase):
                 isinstance(s, str) for s in serialize_resource(res, trim_comments=True)
             )
 
+    @skipIf(no_xml, "Requires [xml] extra")
     def test_parse_anon_files(self):
         data = {
             Format.android: ("strings.xml",),
@@ -77,8 +93,8 @@ class TesteParseResource(TestCase):
             parse_resource(None, source)
 
     def test_serialize_unsupported_format(self):
-        source = get_source("xcode.xliff")
-        res = parse_resource(Format.xliff, source)
+        source = get_source("foo.po")
+        res = parse_resource(Format.po, source)
         with self.assertRaises(ValueError):
             assert all(
                 isinstance(s, str) for s in serialize_resource(res, Format.fluent)

--- a/tests/resource/test_xliff1.py
+++ b/tests/resource/test_xliff1.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from importlib_resources import files
 from textwrap import dedent
-from unittest import TestCase
+from unittest import SkipTest, TestCase
 
 from moz.l10n.message import (
     CatchallKey,
@@ -29,7 +29,12 @@ from moz.l10n.message import (
 )
 from moz.l10n.resource.data import Comment, Entry, Metadata, Resource, Section
 from moz.l10n.resource.format import Format
-from moz.l10n.resource.xliff import xliff_parse, xliff_serialize
+
+try:
+    from moz.l10n.resource.xliff import xliff_parse, xliff_serialize
+except ImportError:
+    raise SkipTest("Requires [xml] extra")
+
 
 hello = files("tests.resource.data").joinpath("hello.xliff").read_bytes()
 angular = files("tests.resource.data").joinpath("angular.xliff").read_bytes()


### PR DESCRIPTION
Also account for the optionality of `lxml` in CI tests, to catch any later regressions.