### PR TITLE
Add l10n-build-file command, fill missing messages from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,13 @@ Iterates source files as defined by `--config`, reads localization sources from 
 Trims out all comments and messages not in the source files for each of the `--locales`.
 Adds empty files for any missing from the target locale.
 
+### `l10n-build-one`
+
+Build one localization file for release.
+
+Uses the `--source` file as a baseline, applying `--l10n` localizations to build `--target`.
+Trims out all comments and messages not in the source file.
+
 ### `l10n-compare`
 
 Compare localizations to their `source`, which may be

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Iterates source files as defined by `--config`, reads localization sources from 
 Trims out all comments and messages not in the source files for each of the `--locales`.
 Adds empty files for any missing from the target locale.
 
-### `l10n-build-one`
+### `l10n-build-file`
 
 Build one localization file for release.
 

--- a/moz/l10n/bin/build.py
+++ b/moz/l10n/bin/build.py
@@ -66,9 +66,7 @@ def cli() -> None:
     log_level = (
         logging.WARNING
         if args.verbose == 0
-        else logging.INFO
-        if args.verbose == 1
-        else logging.DEBUG
+        else logging.INFO if args.verbose == 1 else logging.DEBUG
     )
     logging.basicConfig(format="%(message)s", level=log_level)
 

--- a/moz/l10n/bin/build.py
+++ b/moz/l10n/bin/build.py
@@ -75,7 +75,7 @@ def cli() -> None:
     l10n_target: str = args.target
     locales: set[str] = set(args.locales)
 
-    # locale -> [ftl_filtered, l10n_fallback]
+    # locale -> [ftl_missing, src_fallback]
     msg_data: dict[str, list[int]] = defaultdict(lambda: [0, 0])
 
     paths = L10nConfigPaths(cfg_path)
@@ -110,12 +110,12 @@ def cli() -> None:
                 log.info(f"skip {rel_path}")
 
     log.info("----")
-    for locale, (ftl_missing, l10n_fallback) in sorted(
+    for locale, (ftl_missing, src_fallback) in sorted(
         msg_data.items(), key=lambda d: d[0]
     ):
         log.info(f"{locale}:")
-        log.info(f"  missing_ftl {ftl_missing:>6}")
-        log.info(f"  fallback    {l10n_fallback:>6}")
+        log.info(f"  ftl_missing  {ftl_missing:>6}")
+        log.info(f"  src_fallback {src_fallback:>6}")
 
 
 def write_target_file(
@@ -124,90 +124,53 @@ def write_target_file(
     l10n_path: str,
     tgt_path: str,
 ) -> int:
-    l10n_res = parse_resource(l10n_path) if exists(l10n_path) else None
-
-    if source_res.format == Format.fluent:
-        # Fluent uses per-message fallback at runtime, allowing resources to be incomplete.
-        # Therefore, build result by filtering out any content not in the source.
-        if l10n_res is None:
-            msg_delta = -sum(
-                sum(1 for entry in section.entries if isinstance(entry, Entry))
-                for section in source_res.sections
-            )
-            log.info(f"create empty {name} ({msg_delta})")
-            open(tgt_path, "a").close()
-            return msg_delta
-
-        source_map = _message_map(name, source_res)
-        msg_delta = 0
-        for section in l10n_res.sections:
-            msg_delta -= len(section.entries)
-            section.entries = [
-                entry
-                for entry in section.entries
-                if isinstance(entry, Entry) and section.id + entry.id in source_map
-            ]
-            msg_delta += len(section.entries)
-        msg = f"filter {name}"
-        log.info(f"{msg} ({msg_delta})" if msg_delta != 0 else msg)
-        with open(tgt_path, "w") as file:
-            for line in serialize_resource(l10n_res, trim_comments=True):
-                file.write(line)
-        return msg_delta
-
-    # For other formats, build result from source,
-    # using any localized messages that are available.
-    if l10n_res is None:
-        l10n_map = {}
-        l10n_res = Resource(source_res.format, [])
-    else:
-        l10n_map = _message_map(l10n_path, l10n_res)
+    if exists(l10n_path):
+        l10n_res = parse_resource(l10n_path)
+        l10n_map = {
+            section.id + entry.id: entry
+            for section in l10n_res.sections
+            for entry in section.entries
+            if isinstance(entry, Entry)
+        }
         l10n_res.sections = []
+    else:
+        l10n_res = Resource(source_res.format, [])
+        l10n_map = {}
+    # Fluent uses per-message fallback at runtime, allowing resources to be incomplete.
+    fill_from_source = source_res.format != Format.fluent
     msg_delta = 0
 
     def get_entry(
-        section_id: tuple[str, ...], source_entry: Entry[Message, str]
-    ) -> Entry[Message, str] | Comment:
+        section_id: tuple[str, ...], source_entry: Entry[Message, str] | Comment
+    ) -> Entry[Message, str] | Comment | None:
+        nonlocal msg_delta
+        if isinstance(source_entry, Comment):
+            return None
         id = section_id + source_entry.id
         if id in l10n_map:
             return l10n_map[id]
-        else:
-            nonlocal msg_delta
+        elif fill_from_source:
             msg_delta += 1
             return source_entry
+        else:
+            msg_delta -= 1
+            return None
 
     for section in source_res.sections:
         tgt_entries = [
-            get_entry(section.id, entry)
-            for entry in section.entries
-            if isinstance(entry, Entry)
+            entry
+            for entry_ in section.entries
+            if (entry := get_entry(section.id, entry_)) is not None
         ]
         l10n_res.sections.append(Section(section.id, tgt_entries))
-    msg = f"fill {name}"
-    log.info(f"{msg} (+{msg_delta})" if msg_delta != 0 else msg)
+
+    msg = f"merge {name}"
+    log.info(f"{msg} ({msg_delta:+d})" if msg_delta != 0 else msg)
     with open(tgt_path, "w") as file:
         for line in serialize_resource(l10n_res, trim_comments=True):
             file.write(line)
     return msg_delta
 
-
-def _message_map(
-    path: str,
-    resource: Resource[Message, str],
-) -> dict[tuple[str, ...], Entry[Message, str]]:
-    if path in _message_id_map_cache:
-        return _message_id_map_cache[path]
-    else:
-        id_map = _message_id_map_cache[path] = {
-            section.id + entry.id: entry
-            for section in resource.sections
-            for entry in section.entries
-            if isinstance(entry, Entry)
-        }
-        return id_map
-
-
-_message_id_map_cache: dict[str, dict[tuple[str, ...], Entry[Message, str]]] = {}
 
 if __name__ == "__main__":
     cli()

--- a/moz/l10n/bin/build_file.py
+++ b/moz/l10n/bin/build_file.py
@@ -60,6 +60,8 @@ def cli() -> None:
         source_res = parse_resource(args.source)
         makedirs(dirname(args.target), exist_ok=True)
         write_target_file(args.source, source_res, args.l10n, args.target)
+    except OSError as error:
+        raise SystemExit(error)
     except UnsupportedResource:
         log.warning(f"Not a localization file: {args.source}")
         exit(-1)

--- a/moz/l10n/bin/build_one.py
+++ b/moz/l10n/bin/build_one.py
@@ -1,0 +1,70 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from os import makedirs
+from os.path import dirname
+from textwrap import dedent
+
+from moz.l10n.bin.build import get_source_message_ids, write_target_file
+
+log = logging.getLogger(__name__)
+
+
+def cli() -> None:
+    parser = ArgumentParser(
+        description=dedent(
+            """
+            Build one localization file for release.
+
+            Uses the --source file as a baseline, applying --l10n localizations to build --target.
+
+            Trims out all comments and messages not in the source file.
+            """
+        ),
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="increase logging verbosity"
+    )
+    parser.add_argument("--source", metavar="PATH", required=True, help="source file")
+    parser.add_argument(
+        "--l10n", metavar="PATH", required=True, help="localization file"
+    )
+    parser.add_argument("--target", metavar="PATH", required=True, help="output target")
+    args = parser.parse_args()
+
+    log_level = (
+        logging.WARNING
+        if args.verbose == 0
+        else logging.INFO
+        if args.verbose == 1
+        else logging.DEBUG
+    )
+    logging.basicConfig(format="%(message)s", level=log_level)
+
+    source_ids = get_source_message_ids(args.source)
+    if source_ids is not None:
+        makedirs(dirname(args.target), exist_ok=True)
+        write_target_file(args.source, source_ids, args.l10n, args.target)
+    else:
+        log.warning(f"Not a localization file: {args.source}")
+        exit(-1)
+
+
+if __name__ == "__main__":
+    cli()

--- a/moz/l10n/bin/build_one.py
+++ b/moz/l10n/bin/build_one.py
@@ -52,9 +52,7 @@ def cli() -> None:
     log_level = (
         logging.WARNING
         if args.verbose == 0
-        else logging.INFO
-        if args.verbose == 1
-        else logging.DEBUG
+        else logging.INFO if args.verbose == 1 else logging.DEBUG
     )
     logging.basicConfig(format="%(message)s", level=log_level)
 

--- a/moz/l10n/bin/build_one.py
+++ b/moz/l10n/bin/build_one.py
@@ -20,7 +20,8 @@ from os import makedirs
 from os.path import dirname
 from textwrap import dedent
 
-from moz.l10n.bin.build import get_source_message_ids, write_target_file
+from moz.l10n.bin.build import write_target_file
+from moz.l10n.resource import UnsupportedResource, parse_resource
 
 log = logging.getLogger(__name__)
 
@@ -57,11 +58,11 @@ def cli() -> None:
     )
     logging.basicConfig(format="%(message)s", level=log_level)
 
-    source_ids = get_source_message_ids(args.source)
-    if source_ids is not None:
+    try:
+        source_res = parse_resource(args.source)
         makedirs(dirname(args.target), exist_ok=True)
-        write_target_file(args.source, source_ids, args.l10n, args.target)
-    else:
+        write_target_file(args.source, source_res, args.l10n, args.target)
+    except UnsupportedResource:
         log.warning(f"Not a localization file: {args.source}")
         exit(-1)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ xml = ["lxml ~= 5.0"]
 
 [project.scripts]
 l10n-build = "moz.l10n.bin.build:cli"
+l10n-build-one = "moz.l10n.bin.build_one:cli"
 l10n-compare = "moz.l10n.bin.compare:cli"
 l10n-fix = "moz.l10n.bin.fix:cli"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ xml = ["lxml ~= 5.0"]
 
 [project.scripts]
 l10n-build = "moz.l10n.bin.build:cli"
-l10n-build-one = "moz.l10n.bin.build_one:cli"
+l10n-build-file = "moz.l10n.bin.build_file:cli"
 l10n-compare = "moz.l10n.bin.compare:cli"
 l10n-fix = "moz.l10n.bin.fix:cli"
 


### PR DESCRIPTION
Three related improvements:
1. Adds a CLI command `l10n-build-one`, to replace [l10n_merge.py](https://searchfox.org/mozilla-central/source/python/mozbuild/mozbuild/action/l10n_merge.py) that's used by the m-c FasterMake backend.
2. In `l10n-build` and `l10n-build-one`, ensure that non-Fluent target files are complete by using the source as fallback.
3. Adds a per-locale summary to the `l10n-build` output.