### PR TITLE
fluent: Strip bare NUMBER() from selectors when serialising

### DIFF
--- a/moz/l10n/resource/fluent/serialize.py
+++ b/moz/l10n/resource/fluent/serialize.py
@@ -211,6 +211,14 @@ def fluent_astify_message(message: str | msg.Message) -> ftl.Pattern:
     keys0 = variants[0][0]
     while keys0:
         selector = expression(decl, message.selectors[len(keys0) - 1])
+        if (
+            isinstance(selector, ftl.FunctionReference)
+            and selector.id.name == "NUMBER"
+            and selector.arguments.positional
+            and isinstance(selector.arguments.positional[0], ftl.VariableReference)
+            and not selector.arguments.named
+        ):
+            selector = selector.arguments.positional[0]
         base_keys = []
         sel_exp = None
         i = 0

--- a/tests/resource/test_fluent.py
+++ b/tests/resource/test_fluent.py
@@ -281,12 +281,12 @@ class TestFluent(TestCase):
             has-only-attr =
                 .attr = Attr
             single-sel =
-                { NUMBER($num) ->
+                { $num ->
                     [one] One
                    *[other] Other
                 }
             two-sels =
-                { NUMBER($a) ->
+                { $a ->
                     [1]
                         { $b ->
                             [cc] pre One mid CC post
@@ -299,19 +299,19 @@ class TestFluent(TestCase):
                         }
                 }
             deep-sels =
-                { NUMBER($a) ->
+                { $a ->
                     [0]
-                        { NUMBER($b) ->
+                        { $b ->
                             [one] { "" }
                            *[other] 0,x
                         }
                     [one]
-                        { NUMBER($b) ->
+                        { $b ->
                             [one] { "1,1" }
                            *[other] 1,x
                         }
                    *[other]
-                        { NUMBER($b) ->
+                        { $b ->
                             [0] x,0
                             [one] x,1
                            *[other] x,x
@@ -336,12 +336,12 @@ class TestFluent(TestCase):
             has-only-attr =
                 .attr = Attr
             single-sel =
-                { NUMBER($num) ->
+                { $num ->
                     [one] One
                    *[other] Other
                 }
             two-sels =
-                { NUMBER($a) ->
+                { $a ->
                     [1]
                         { $b ->
                             [cc] pre One mid CC post
@@ -354,19 +354,19 @@ class TestFluent(TestCase):
                         }
                 }
             deep-sels =
-                { NUMBER($a) ->
+                { $a ->
                     [0]
-                        { NUMBER($b) ->
+                        { $b ->
                             [one] { "" }
                            *[other] 0,x
                         }
                     [one]
-                        { NUMBER($b) ->
+                        { $b ->
                             [one] { "1,1" }
                            *[other] 1,x
                         }
                    *[other]
-                        { NUMBER($b) ->
+                        { $b ->
                             [0] x,0
                             [one] x,1
                            *[other] x,x
@@ -749,13 +749,13 @@ class TestFluent(TestCase):
                 .title = This shot does not expire
             # Plurals
             delete-all-message =
-                { NUMBER($num) ->
+                { $num ->
                     [one] Delete this download?
                    *[other] Delete { $num } downloads?
                 }
             # Plurals with custom values
             delete-all-message-special-cases =
-                { NUMBER($num) ->
+                { $num ->
                     [1] Delete this download?
                     [2] Delete this pair of downloads?
                     [12] Delete this dozen of downloads?
@@ -800,7 +800,7 @@ class TestFluent(TestCase):
                     }
             # Multiple selectors
             selector-multi =
-                { NUMBER($num) ->
+                { $num ->
                     [one]
                         { $gender ->
                             [feminine] There is one email for her
@@ -826,12 +826,12 @@ class TestFluent(TestCase):
             selector-nested =
                 { $gender ->
                     [masculine]
-                        { NUMBER($num) ->
+                        { $num ->
                             [one] There is one email for him
                            *[other] There are many emails for him
                         }
                    *[feminine]
-                        { NUMBER($num) ->
+                        { $num ->
                             [one] There is one email for her
                            *[other] There are many emails for her
                         }


### PR DESCRIPTION
This circumvents the issues discovered in [bug 1918729](https://bugzilla.mozilla.org/show_bug.cgi?id=1918729) by removing the `NUMBER()` wrapper from selectors when serialising Fluent.