### PR TITLE
paths.config: Fix L10nConfigPaths.target() for relative paths

### DIFF
--- a/moz/l10n/paths/config.py
+++ b/moz/l10n/paths/config.py
@@ -189,9 +189,10 @@ class L10nConfigPaths:
 
     @base.setter
     def base(self, base: str) -> None:
-        self._base = base
         for incl in self._includes:
-            incl.base = base
+            rel_base = relpath(incl._base, self._base)
+            incl.base = join(base, rel_base)
+        self._base = base
 
     @property
     def locales(self) -> list[str] | None:
@@ -280,7 +281,7 @@ class L10nConfigPaths:
         pd = self._path_data.get(norm_ref_path, None)
         if pd is None:
             for incl in self._includes:
-                target = incl.target(ref_path, format_map=format_map)
+                target = incl.target(norm_ref_path, format_map=format_map)
                 if target[0] is not None:
                     return target
             return None, ()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -386,20 +386,22 @@ class TestL10nConfigPaths(TestCase):
         res_path = normpath(
             "mozilla-mobile/android-components/components/foo/src/main/res"
         )
-        exp_ref = join(root, res_path, normpath("values/strings.xml"))
+        rel_ref_path = join(res_path, normpath("values/strings.xml"))
+        abs_ref_path = join(root, rel_ref_path)
         exp_tgt = join(root, res_path, normpath("values-{android_locale}/strings.xml"))
-        assert paths.all() == {(exp_ref, exp_tgt): None}
-        assert paths.target(exp_ref) == (exp_tgt, ())
+        assert paths.all() == {(abs_ref_path, exp_tgt): None}
+        assert paths.target(abs_ref_path) == (exp_tgt, ())
+        assert paths.target(rel_ref_path) == (exp_tgt, ())
         assert paths.find_reference("values-xx/strings.xml") is None
         assert paths.find_reference(join(res_path, "values-xx/strings.xml")) == (
-            exp_ref,
+            abs_ref_path,
             {"android_locale": "xx"},
         )
         assert paths.find_reference(join(res_path, "values-de-FG/strings.xml")) == (
-            exp_ref,
+            abs_ref_path,
             {"android_locale": "de-FG"},
         )
         assert paths.find_reference(exp_tgt.format(android_locale="b+de+FG")) == (
-            exp_ref,
+            abs_ref_path,
             {"android_locale": "b+de+FG"},
         )


### PR DESCRIPTION
In a config with included sub-configs that use a different `base` than the parent, fix `target()` for relative input paths.