### PR TITLE
l10n-compare: Conflate anonymous sections together

### DIFF
--- a/moz/l10n/resource/l10n_equal.py
+++ b/moz/l10n/resource/l10n_equal.py
@@ -48,6 +48,16 @@ def l10n_sections(resource: Resource[Any, Any]) -> _L10nData[_L10nData[Any]]:
         if any(isinstance(entry, Entry) for entry in section.entries)
     ]
     ls.sort()
+    nonempty_idx = next(
+        (idx for idx, (id, comment, meta, _) in enumerate(ls) if id or comment or meta),
+        len(ls),
+    )
+    if nonempty_idx > 1:
+        # Anonymous sections are considered equivalent
+        first = ls[0]
+        for sd in ls[1:nonempty_idx]:
+            first[3].extend(sd[3])
+        del ls[1:nonempty_idx]
     return ls
 
 

--- a/tests/test_l10n_equal.py
+++ b/tests/test_l10n_equal.py
@@ -93,3 +93,10 @@ class TestL10nEqual(TestCase):
         a = Resource(None, [Section((), [Entry(("foo",), "Foo", meta=am)])])
         b = Resource(None, [Section((), [Entry(("foo",), "Foo", meta=bm)])])
         assert l10n_equal(a, b)
+
+    def test_empty_sections(self):
+        a = Resource(None, [Section((), [Entry(("foo",), "Foo"), Entry(("bar",), "Bar")])])
+        b = Resource(
+            None, [Section((), [Entry(("bar",), "Bar")]), Section((), [Entry(("foo",), "Foo")])]
+        )
+        assert l10n_equal(a, b)

--- a/tests/test_l10n_equal.py
+++ b/tests/test_l10n_equal.py
@@ -95,8 +95,14 @@ class TestL10nEqual(TestCase):
         assert l10n_equal(a, b)
 
     def test_empty_sections(self):
-        a = Resource(None, [Section((), [Entry(("foo",), "Foo"), Entry(("bar",), "Bar")])])
+        a = Resource(
+            None, [Section((), [Entry(("foo",), "Foo"), Entry(("bar",), "Bar")])]
+        )
         b = Resource(
-            None, [Section((), [Entry(("bar",), "Bar")]), Section((), [Entry(("foo",), "Foo")])]
+            None,
+            [
+                Section((), [Entry(("bar",), "Bar")]),
+                Section((), [Entry(("foo",), "Foo")]),
+            ],
         )
         assert l10n_equal(a, b)


### PR DESCRIPTION
This should resolve some of the comparison issues seen in `firefox-l10n-source`.