### PR TITLE
Add MF2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ as format-independent representations of localizable and localized messages and 
 so that operations like linting and transforms can be applied to them.
 
 The Message and Resource representations are drawn from work done for the
-Unicode [MessageFormat 2 specification](https://github.com/unicode-org/message-format-wg/tree/main/spec)
+Unicode [MessageFormat 2 specification](https://unicode.org/reports/tr35/tr35-messageFormat.html)
 and the [Message resource specification](https://github.com/eemeli/message-resource-wg/).
 
 The library currently supports the following resource formats:
@@ -73,6 +73,23 @@ and `FORMAT_serialize(resource)` will always provide a `str` iterator.
 All the serializers accept a `trim_comments` argument
 which leaves out comments from the serialized result,
 but additional input types and options vary by format.
+
+### moz.l10n.formats.mf2
+
+```python
+from moz.l10n.formats.mf2 import (
+    MF2ParseError,          # May be raised by mf2_parse_message()
+    MF2ValidationError,     # May be raised by mf2_from_json() and mf2_validate_message()
+    mf2_parse_message,      # Parse MF2 message syntax into a Message
+    mf2_serialize_message,  # Serialize a Message using MF2 syntax
+    mf2_from_json,          # Marshal a MF2 data model JSON Schema object into a Message
+    mf2_to_json,            # Represent a Message using the MF2 data model JSON Schema
+    mf2_validate_message    # Validate that a Message meets all of the MF2 validity constraints
+)
+```
+
+Tools for working with [MessageFormat 2.0](https://unicode.org/reports/tr35/tr35-messageFormat.html) messages,
+which may be embedded in resource formats.
 
 ### moz.l10n.formats.detect_format
 

--- a/moz/l10n/formats/mf2/__init__.py
+++ b/moz/l10n/formats/mf2/__init__.py
@@ -1,0 +1,10 @@
+from .message_parser import MF2ParseError, mf2_parse_message
+from .serialize import MF2SerializeError, mf2_serialize_message, mf2_serialize_pattern
+
+__all__ = [
+    "MF2ParseError",
+    "MF2SerializeError",
+    "mf2_parse_message",
+    "mf2_serialize_message",
+    "mf2_serialize_pattern",
+]

--- a/moz/l10n/formats/mf2/__init__.py
+++ b/moz/l10n/formats/mf2/__init__.py
@@ -1,10 +1,12 @@
 from .message_parser import MF2ParseError, mf2_parse_message
-from .serialize import MF2SerializeError, mf2_serialize_message, mf2_serialize_pattern
+from .serialize import mf2_serialize_message, mf2_serialize_pattern
+from .validate import MF2ValidationError, mf2_validate_message
 
 __all__ = [
     "MF2ParseError",
-    "MF2SerializeError",
+    "MF2ValidationError",
     "mf2_parse_message",
     "mf2_serialize_message",
     "mf2_serialize_pattern",
+    "mf2_validate_message",
 ]

--- a/moz/l10n/formats/mf2/__init__.py
+++ b/moz/l10n/formats/mf2/__init__.py
@@ -1,12 +1,16 @@
+from .from_json import mf2_from_json
 from .message_parser import MF2ParseError, mf2_parse_message
 from .serialize import mf2_serialize_message, mf2_serialize_pattern
+from .to_json import mf2_to_json
 from .validate import MF2ValidationError, mf2_validate_message
 
 __all__ = [
     "MF2ParseError",
     "MF2ValidationError",
+    "mf2_from_json",
     "mf2_parse_message",
     "mf2_serialize_message",
     "mf2_serialize_pattern",
+    "mf2_to_json",
     "mf2_validate_message",
 ]

--- a/moz/l10n/formats/mf2/from_json.py
+++ b/moz/l10n/formats/mf2/from_json.py
@@ -24,6 +24,8 @@ def mf2_from_json(json: dict[str, Any]) -> msg.Message:
     """
     Marshal a MessageFormat 2 data model [JSON Schema](https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json)
     object into a parsed `moz.l10n.message.data.Message`.
+
+    May raise `MF2ValidationError`.
     """
     try:
         msg_type = json["type"]

--- a/moz/l10n/formats/mf2/from_json.py
+++ b/moz/l10n/formats/mf2/from_json.py
@@ -1,0 +1,151 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any, Literal, cast
+
+from ...message import data as msg
+from .validate import MF2ValidationError
+
+
+def mf2_from_json(json: dict[str, Any]) -> msg.Message:
+    """
+    Marshal a MessageFormat 2 data model [JSON Schema](https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json)
+    object into a parsed `moz.l10n.message.data.Message`.
+    """
+    try:
+        msg_type = json["type"]
+        if msg_type not in {"message", "select"}:
+            raise MF2ValidationError(f"Invalid JSON message: {json}")
+
+        declarations: dict[str, msg.Expression] = {}
+        for decl in json["declarations"]:
+            decl_type = decl["type"]
+            if decl_type not in {"input", "local"}:
+                raise MF2ValidationError(f"Invalid JSON declaration type: {decl}")
+            decl_name = _string(decl, "name")
+            decl_expr = _expression(decl["value"])
+            if decl_type == "input":
+                if (
+                    not isinstance(decl_expr.arg, msg.VariableRef)
+                    or decl_expr.arg.name != decl_name
+                ):
+                    raise MF2ValidationError(f"Invalid JSON .input declaration: {decl}")
+            if decl_name in declarations:
+                raise MF2ValidationError(f"Duplicate JSON declaration for ${decl_name}")
+            declarations[decl_name] = decl_expr
+
+        if msg_type == "message":
+            pattern = _pattern(json["pattern"])
+            return msg.PatternMessage(pattern, declarations)
+
+        assert msg_type == "select"
+        selectors = tuple(_variable(sel) for sel in json["selectors"])
+        variants = {
+            tuple(_key(key) for key in vari["keys"]): _pattern(vari["value"])
+            for vari in json["variants"]
+        }
+        return msg.SelectMessage(declarations, selectors, variants)
+    except (IndexError, KeyError, TypeError) as err:
+        raise MF2ValidationError(f"Invalid JSON: {err!r}")
+
+
+def _pattern(json: list[Any]) -> msg.Pattern:
+    return [
+        part
+        if isinstance(part, str)
+        else _markup(part)
+        if part["type"] == "markup"
+        else _expression(part)
+        for part in json
+    ]
+
+
+def _expression(json: dict[str, Any]) -> msg.Expression:
+    if json["type"] != "expression":
+        raise MF2ValidationError(f"Invalid JSON expression type: {json}")
+    arg = _value(json["arg"]) if "arg" in json else None
+    json_func = json.get("function", None)
+    if json_func:
+        if json_func["type"] != "function":
+            raise MF2ValidationError(f"Invalid JSON function type: {json_func}")
+        function = _string(json_func, "name")
+        options = _options(json_func["options"]) if "options" in json_func else {}
+    else:
+        function = None
+        options = {}
+    if arg is None and function is None:
+        raise MF2ValidationError(
+            f"Invalid JSON expression with no operand and no function: {json}"
+        )
+    attributes = _attributes(json["attributes"]) if "attributes" in json else {}
+    return msg.Expression(arg, function, options, attributes)
+
+
+def _markup(json: dict[str, Any]) -> msg.Markup:
+    assert json["type"] == "markup"
+    kind = cast(Literal["open", "standalone", "close"], _string(json, "kind"))
+    if kind not in {"open", "standalone", "close"}:
+        raise MF2ValidationError(f"Invalid JSON markup kind: {json}")
+    name = _string(json, "name")
+    options = _options(json["options"]) if "options" in json else {}
+    attributes = _attributes(json["attributes"]) if "attributes" in json else {}
+    return msg.Markup(kind, name, options, attributes)
+
+
+def _options(json: dict[str, Any]) -> dict[str, str | msg.VariableRef]:
+    return {name: _value(json_value) for name, json_value in json.items()}
+
+
+def _attributes(json: dict[str, Any]) -> dict[str, str | None]:
+    return {
+        name: None if json_value is True else _literal(json_value)
+        for name, json_value in json.items()
+    }
+
+
+def _key(json: dict[str, Any]) -> str | msg.CatchallKey:
+    type = json["type"]
+    if type == "literal":
+        return _string(json, "value")
+    elif json["type"] == "*":
+        value = _string(json, "value") if "value" in json else None
+        return msg.CatchallKey(value)
+    else:
+        raise MF2ValidationError(f"Invalid JSON variant key: {json}")
+
+
+def _value(json: dict[str, Any]) -> str | msg.VariableRef:
+    return _string(json, "value") if json["type"] == "literal" else _variable(json)
+
+
+def _literal(json: dict[str, Any]) -> str:
+    if json["type"] != "literal":
+        raise MF2ValidationError(f"Invalid JSON literal: {json}")
+    return _string(json, "value")
+
+
+def _variable(json: dict[str, Any]) -> msg.VariableRef:
+    if json["type"] != "variable":
+        raise MF2ValidationError(f"Invalid JSON variable: {json}")
+    return msg.VariableRef(_string(json, "name"))
+
+
+def _string(obj: dict[str, Any], key: str | None = None) -> str:
+    value = obj if key is None else obj.get(key, None)
+    if isinstance(value, str):
+        return value
+    else:
+        raise MF2ValidationError(f"Expected a string value for {key} in {obj}")

--- a/moz/l10n/formats/mf2/message_parser.py
+++ b/moz/l10n/formats/mf2/message_parser.py
@@ -41,6 +41,11 @@ space_chars = {
 
 
 def mf2_parse_message(source: bytes | str) -> msg.Message:
+    """
+    Parse MF2 message syntax into a Message.
+
+    May raise `MF2ParseError`.
+    """
     if not isinstance(source, str):
         source = source.decode()
     parser = MF2Parser(source)

--- a/moz/l10n/formats/mf2/message_parser.py
+++ b/moz/l10n/formats/mf2/message_parser.py
@@ -1,0 +1,413 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from re import compile
+from typing import Literal
+
+from ...message import data as msg
+
+_name_start = r"a-zA-Z_\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u061B\u061D-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFC\U00010000-\U000EFFFF"
+name_re = compile(f"[{_name_start}][{_name_start}0-9-.\xb7\u0300-\u036f\u203f-\u2040]*")
+
+number_re = compile(r"-?(?:0|(?:[1-9]\d*))(?:.\d+)?(?:[eE][-+]?\d+)?")
+
+esc_chars = {"\\", "{", "|", "}"}
+
+bidi_chars = {
+    "\u061c",  # ALM
+    "\u200e",  # LRM
+    "\u200f",  # RLM
+    "\u2066",  # LRI
+    "\u2067",  # RLI
+    "\u2068",  # FSI
+    "\u2069",  # PDI
+}
+
+space_chars = {
+    "\t",
+    "\n",
+    "\r",
+    " ",
+    "\u3000",  # ideographic space
+}
+
+
+def mf2_parse_message(source: bytes | str) -> msg.Message:
+    if not isinstance(source, str):
+        source = source.decode()
+    parser = MF2Parser(source)
+    return parser.parse()
+
+
+class MF2ParseError(ValueError):
+    def __init__(self, parser: MF2Parser, message: str):
+        src = parser.source.replace("\n", "¶")
+        message += f"\n{src}\n{' '*parser.pos}^"
+        super().__init__(message)
+        self.pos = parser.pos
+
+
+class MF2Parser:
+    def __init__(self, source: bytes | str):
+        self.source = source if isinstance(source, str) else source.decode()
+        self.pos = 0
+
+    def parse(self) -> msg.Message:
+        ch = self.skip_opt_space()
+        if ch == ".":
+            message = self.complex_message()
+        elif self.source.startswith("{{", self.pos):
+            message = msg.PatternMessage(self.quoted_pattern())
+        else:
+            self.pos = 0
+            message = msg.PatternMessage(self.pattern())
+        if self.pos != len(self.source):
+            raise MF2ParseError(self, "Extra content at message end")
+        return message
+
+    def complex_message(self) -> msg.Message:
+        assert self.char() == "."
+        declarations: dict[str, msg.Expression] = {}
+        declared: set[str] = set()
+        while keyword := self.source[self.pos : self.pos + 6]:
+            if keyword == ".input":
+                name, expr = self.input_declaration()
+            elif keyword == ".local":
+                name, expr = self.local_declaration()
+                if isinstance(expr.arg, msg.VariableRef):
+                    declared.add(expr.arg.name)
+            else:
+                break
+            if expr.function:
+                for opt_value in expr.options.values():
+                    if isinstance(opt_value, msg.VariableRef):
+                        declared.add(opt_value.name)
+            if name in declared:
+                raise MF2ParseError(self, f"Duplicate declaration for ${name}")
+            declarations[name] = expr
+            declared.add(name)
+            self.skip_opt_space()
+        if keyword == ".match":
+            selectors = self.match_statement()
+            for sel in selectors:
+                if sel.name not in declarations:
+                    raise MF2ParseError(
+                        self, f"Missing selector annotation for ${sel.name}"
+                    )
+            variants = {}
+            while self.pos < len(self.source):
+                keys, pattern = self.variant(len(selectors))
+                if keys in variants:
+                    raise MF2ParseError(self, f"Duplicate variant with key ${keys}")
+                variants[keys] = pattern
+            fallback_key = (msg.CatchallKey(),) * len(selectors)
+            if fallback_key not in variants:
+                raise MF2ParseError(self, "Missing fallback variant")
+            return msg.SelectMessage(declarations, selectors, variants)
+        pattern = self.quoted_pattern()
+        return msg.PatternMessage(pattern, declarations)
+
+    def input_declaration(self) -> tuple[str, msg.Expression]:
+        assert self.source.startswith(".input", self.pos)
+        self.pos += 6
+        ch = self.skip_opt_space()
+        self.expect("{", ch)
+        expr = self.expression_or_markup()
+        if not isinstance(expr, msg.Expression) or not isinstance(
+            expr.arg, msg.VariableRef
+        ):
+            raise MF2ParseError(self, "Variable argument required for .input")
+        return expr.arg.name, expr
+
+    def local_declaration(self) -> tuple[str, msg.Expression]:
+        assert self.source.startswith(".local", self.pos)
+        self.pos += 6
+        if not self.req_space() or self.char() != "$":
+            raise MF2ParseError(self, "Expected $ with leading space")
+        name = self.name(1)
+        ch = self.skip_opt_space()
+        self.expect("=", ch)
+        ch = self.skip_opt_space()
+        self.expect("{", ch)
+        expr = self.expression_or_markup()
+        if not isinstance(expr, msg.Expression):
+            raise MF2ParseError(self, "Markup is not a valid .local value")
+        if isinstance(expr.arg, msg.VariableRef) and expr.arg.name == name:
+            raise MF2ParseError(self, "A .local declaration cannot be self-referential")
+        return name, expr
+
+    def match_statement(self) -> tuple[msg.VariableRef, ...]:
+        assert self.source.startswith(".match", self.pos)
+        self.pos += 6
+        names: list[str] = []
+        while (has_space := self.req_space()) and self.char() == "$":
+            names.append(self.name(1))
+        if not names:
+            raise MF2ParseError(
+                self, "At least one variable reference is required for .match"
+            )
+        if not has_space:
+            raise MF2ParseError(self, "Expected space")
+        return tuple(msg.VariableRef(name) for name in names)
+
+    def variant(
+        self, num_sel: int
+    ) -> tuple[tuple[str | msg.CatchallKey, ...], msg.Pattern]:
+        keys: list[str | msg.CatchallKey] = []
+        ch = self.char()
+        while ch != "{" and ch != "":
+            if ch == "*":
+                keys.append(msg.CatchallKey())
+                self.pos += 1
+            else:
+                keys.append(self.literal())
+            has_space = self.req_space()
+            if not has_space:
+                break
+            ch = self.char()
+        if len(keys) != num_sel:
+            raise MF2ParseError(
+                self,
+                f"Variant key mismatch, expected {num_sel} but found {len(keys)}",
+            )
+        return tuple(keys), self.quoted_pattern()
+
+    def quoted_pattern(self) -> msg.Pattern:
+        if not self.source.startswith("{{", self.pos):
+            raise MF2ParseError(self, "Expected {{")
+        self.pos += 2
+        pattern = self.pattern()
+        if not self.source.startswith("}}", self.pos):
+            raise MF2ParseError(self, "Expected }}")
+        self.pos += 2
+        self.skip_opt_space()
+        return pattern
+
+    def pattern(self) -> msg.Pattern:
+        pattern: msg.Pattern = []
+        ch = self.char()
+        while ch != "" and ch != "}":
+            if ch == "{":
+                self.pos += 1
+                pattern.append(self.expression_or_markup())
+            else:
+                pattern.append(self.text())
+            ch = self.char()
+        return pattern
+
+    def text(self) -> str:
+        text = ""
+        at_esc = False
+        for ch in self.source[self.pos :]:
+            if at_esc:
+                if ch not in esc_chars:
+                    raise MF2ParseError(self, f"Invalid escape: \\{ch}")
+                text += ch
+                at_esc = False
+            elif ch == "\x00":
+                raise MF2ParseError(self, "NUL character is not allowed")
+            elif ch == "\\":
+                at_esc = True
+            elif ch == "{" or ch == "}":
+                break
+            else:
+                text += ch
+            self.pos += 1
+        return text
+
+    def expression_or_markup(self) -> msg.Expression | msg.Markup:
+        ch = self.skip_opt_space()
+        value: msg.Expression | msg.Markup = (
+            self.markup_body(ch) if ch == "#" or ch == "/" else self.expression_body(ch)
+        )
+        self.expect("}")
+        return value
+
+    def expression_body(self, ch: str) -> msg.Expression:
+        arg: str | msg.VariableRef | None = None
+        arg_end = self.pos
+        if ch == "$":
+            arg = self.variable()
+            arg_end = self.pos
+            ch = self.skip_opt_space()
+        elif ch != ":":
+            arg = self.literal()
+            arg_end = self.pos
+            ch = self.skip_opt_space()
+        if ch == ":":
+            if self.pos == arg_end:
+                raise MF2ParseError(self, "Espected space")
+            function = self.identifier(1)
+            options = self.options()
+        else:
+            function = None
+            options = {}
+            self.pos = arg_end
+        attributes = self.attributes()
+        self.skip_opt_space()
+        return msg.Expression(arg, function, options, attributes)
+
+    def markup_body(self, ch: str) -> msg.Markup:
+        kind: Literal["open", "standalone", "close"]
+        if ch == "#":
+            kind = "open"
+        elif ch == "/":
+            kind = "close"
+        else:
+            raise MF2ParseError(self, "Expected # or /")
+        id = self.identifier(1)
+        options = self.options()
+        attributes = self.attributes()
+        ch = self.skip_opt_space()
+        if ch == "/":
+            if kind == "open":
+                kind = "standalone"
+            else:
+                raise MF2ParseError(self, "Expected }")
+            self.pos += 1
+        return msg.Markup(kind, id, options, attributes)
+
+    def options(self) -> dict[str, str | msg.VariableRef]:
+        options: dict[str, str | msg.VariableRef] = {}
+        opt_end = self.pos
+        while self.req_space():
+            ch = self.char()
+            if ch == "" or ch == "@" or ch == "/" or ch == "}":
+                self.pos = opt_end
+                break
+            id = self.identifier(0)
+            if id in options:
+                raise MF2ParseError(self, f"Duplicate option name {id}")
+            self.expect("=", self.skip_opt_space())
+            ch = self.skip_opt_space()
+            options[id] = self.variable() if ch == "$" else self.literal()
+            opt_end = self.pos
+        return options
+
+    def attributes(self) -> dict[str, str | None]:
+        attributes: dict[str, str | None] = {}
+        attr_end = self.pos
+        while self.req_space():
+            ch = self.char()
+            if ch != "@":
+                self.pos = attr_end
+                break
+            id = self.identifier(1)
+            id_end = self.pos
+            if id in attributes:
+                raise MF2ParseError(self, f"Duplicate attribute name {id}")
+            if self.skip_opt_space() == "=":
+                self.pos += 1
+                self.skip_opt_space()
+                attributes[id] = self.literal()
+            else:
+                self.pos = id_end
+                attributes[id] = None
+            attr_end = self.pos
+        return attributes
+
+    def variable(self) -> msg.VariableRef:
+        assert self.char() == "$"
+        name = self.name(1)
+        return msg.VariableRef(name)
+
+    def literal(self) -> str:
+        return self.quoted_literal() if self.char() == "|" else self.unquoted_literal()
+
+    def quoted_literal(self) -> str:
+        assert self.char() == "|"
+        self.pos += 1
+        value = ""
+        at_esc = False
+        for ch in self.source[self.pos :]:
+            self.pos += 1
+            if at_esc:
+                if ch not in esc_chars:
+                    raise MF2ParseError(self, f"Invalid escape: \\{ch}")
+                value += ch
+                at_esc = False
+            elif ch == "\x00":
+                raise MF2ParseError(self, "NUL character is not allowed")
+            elif ch == "\\":
+                at_esc = True
+            elif ch == "|":
+                return value
+            else:
+                value += ch
+        raise MF2ParseError(self, "Expected |")
+
+    def unquoted_literal(self) -> str:
+        match = number_re.match(self.source, self.pos) or name_re.match(
+            self.source, self.pos
+        )
+        if match is None:
+            raise MF2ParseError(self, "Invalid name or number")
+        self.pos = match.end()
+        return match[0]
+
+    def identifier(self, offset: int) -> str:
+        ns = self.name(offset)
+        if self.char() != ":":
+            return ns
+        name = self.name(1)
+        return f"{ns}:{name}"
+
+    def name(self, offset: int) -> str:
+        self.pos += offset
+        self.skip_bidi()
+        match = name_re.match(self.source, self.pos)
+        if match is None:
+            raise MF2ParseError(self, "Invalid name")
+        self.pos = match.end()
+        self.skip_bidi()
+        return match[0]
+
+    def req_space(self) -> bool:
+        start = self.pos
+        ch = self.skip_bidi()
+        if ch not in space_chars:
+            self.pos = start
+            return False
+        while ch in space_chars or ch in bidi_chars:
+            self.pos += 1
+            ch = self.char()
+        return True
+
+    def skip_opt_space(self) -> str:
+        ch = self.char()
+        while ch in space_chars or ch in bidi_chars:
+            self.pos += 1
+            ch = self.char()
+        return ch
+
+    def skip_bidi(self) -> str:
+        """Bidirectional marks and isolates"""
+        ch = self.char()
+        while ch in bidi_chars:
+            self.pos += 1
+            ch = self.char()
+        return ch
+
+    def expect(self, exp: str, char: str = "") -> None:
+        if (char or self.char()) != exp:
+            raise MF2ParseError(self, f"Expected {exp}")
+        self.pos += 1
+
+    def char(self) -> str:
+        try:
+            return self.source[self.pos]
+        except IndexError:
+            return ""

--- a/moz/l10n/formats/mf2/message_parser.py
+++ b/moz/l10n/formats/mf2/message_parser.py
@@ -254,8 +254,8 @@ class MF2Parser:
             arg_end = self.pos
             ch = self.skip_opt_space()
         if ch == ":":
-            if self.pos == arg_end:
-                raise MF2ParseError(self, "Espected space")
+            if arg and self.pos == arg_end:
+                raise MF2ParseError(self, "Expected space")
             function = self.identifier(1)
             options = self.options()
         else:

--- a/moz/l10n/formats/mf2/serialize.py
+++ b/moz/l10n/formats/mf2/serialize.py
@@ -18,21 +18,19 @@ from collections.abc import Iterator
 from re import compile
 
 from ...message import data as msg
-from .message_parser import name_re, number_re
+from .validate import name_re, number_re
 
 complex_start_re = compile(r"[\t\n\r \u3000]*\.")
-identifier_re = compile(f"{name_re.pattern}(?::{name_re.pattern})?")
 literal_esc_re = compile(r"[\\|]")
 text_esc_re = compile(r"[\\{}]")
-
-
-class MF2SerializeError(ValueError):
-    pass
 
 
 def mf2_serialize_message(message: msg.Message) -> Iterator[str]:
     """
     Serialize a message using MessageFormat 2 syntax.
+
+    Does not validate the message before serialization;
+    for that, use `mf2_validate_message()`.
     """
     if (
         isinstance(message, msg.PatternMessage)
@@ -52,7 +50,7 @@ def mf2_serialize_message(message: msg.Message) -> Iterator[str]:
         if isinstance(expr.arg, msg.VariableRef) and expr.arg.name == name:
             yield ".input "
         else:
-            yield f".local {_variable(name)} = "
+            yield f".local ${name} = "
         yield from _expression(expr)
         yield "\n"
 
@@ -62,7 +60,7 @@ def mf2_serialize_message(message: msg.Message) -> Iterator[str]:
         assert isinstance(message, msg.SelectMessage)
         yield ".match"
         for sel in message.selectors:
-            yield f" {_variable(sel.name)}"
+            yield f" ${sel.name}"
         for keys, pattern in message.variants.items():
             yield "\n"
             for key in keys:
@@ -94,13 +92,7 @@ def _expression(expr: msg.Expression) -> Iterator[str]:
     if expr.arg:
         yield _value(expr.arg)
     if expr.function:
-        if not identifier_re.fullmatch(expr.function):
-            raise MF2SerializeError(f"Invalid function name: {expr.function}")
         yield f" :{expr.function}" if expr.arg else f":{expr.function}"
-    elif not expr.arg:
-        raise MF2SerializeError("Invalid expression with no operand and no function")
-    elif expr.options:
-        raise MF2SerializeError("Invalid expression with options but no function")
     yield from _options(expr.options)
     yield from _attributes(expr.attributes)
     yield "}"
@@ -108,8 +100,6 @@ def _expression(expr: msg.Expression) -> Iterator[str]:
 
 def _markup(markup: msg.Markup) -> Iterator[str]:
     yield "{/" if markup.kind == "close" else "{#"
-    if not identifier_re.fullmatch(markup.name):
-        raise MF2SerializeError(f"Invalid markup name: {markup.name}")
     yield markup.name
     yield from _options(markup.options)
     yield from _attributes(markup.attributes)
@@ -118,33 +108,16 @@ def _markup(markup: msg.Markup) -> Iterator[str]:
 
 def _options(options: dict[str, str | msg.VariableRef]) -> Iterator[str]:
     for name, value in options.items():
-        if not identifier_re.fullmatch(name):
-            raise MF2SerializeError(f"Invalid option name: {name}")
         yield f" {name}={_value(value)}"
 
 
 def _attributes(attributes: dict[str, str | None]) -> Iterator[str]:
     for name, value in attributes.items():
-        if not identifier_re.fullmatch(name):
-            raise MF2SerializeError(f"Invalid attribute name: {name}")
-        if value is None:
-            yield f" @{name}"
-        else:
-            yield f" @{name}={_literal(value)}"
+        yield f" @{name}" if value is None else f" @{name}={_literal(value)}"
 
 
 def _value(value: str | msg.VariableRef) -> str:
-    if isinstance(value, str):
-        return _literal(value)
-    else:
-        assert isinstance(value, msg.VariableRef)
-        return _variable(value.name)
-
-
-def _variable(name: str) -> str:
-    if not name_re.fullmatch(name):
-        raise MF2SerializeError(f"Invalid variable name: {name}")
-    return f"${name}"
+    return _literal(value) if isinstance(value, str) else f"${value.name}"
 
 
 def _literal(literal: str) -> str:

--- a/moz/l10n/formats/mf2/serialize.py
+++ b/moz/l10n/formats/mf2/serialize.py
@@ -1,0 +1,154 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from re import compile
+
+from ...message import data as msg
+from .message_parser import name_re, number_re
+
+complex_start_re = compile(r"[\t\n\r \u3000]*\.")
+identifier_re = compile(f"{name_re.pattern}(?::{name_re.pattern})?")
+literal_esc_re = compile(r"[\\|]")
+text_esc_re = compile(r"[\\{}]")
+
+
+class MF2SerializeError(ValueError):
+    pass
+
+
+def mf2_serialize_message(message: msg.Message) -> Iterator[str]:
+    """
+    Serialize a message using MessageFormat 2 syntax.
+    """
+    if (
+        isinstance(message, msg.PatternMessage)
+        and not message.declarations
+        and (
+            not message.pattern
+            or not isinstance(part0 := message.pattern[0], str)
+            or not complex_start_re.match(part0)
+        )
+    ):
+        # simple message
+        yield from mf2_serialize_pattern(message.pattern)
+        return
+
+    for name, expr in message.declarations.items():
+        # TODO: Fix order by dependencies
+        if isinstance(expr.arg, msg.VariableRef) and expr.arg.name == name:
+            yield ".input "
+        else:
+            yield f".local {_variable(name)} = "
+        yield from _expression(expr)
+        yield "\n"
+
+    if isinstance(message, msg.PatternMessage):
+        yield from _quoted_pattern(message.pattern)
+    else:
+        assert isinstance(message, msg.SelectMessage)
+        yield ".match"
+        for sel in message.selectors:
+            yield f" {_variable(sel.name)}"
+        for keys, pattern in message.variants.items():
+            yield "\n"
+            for key in keys:
+                yield "* " if isinstance(key, msg.CatchallKey) else f"{_literal(key)} "
+            yield from _quoted_pattern(pattern)
+
+
+def mf2_serialize_pattern(pattern: msg.Pattern) -> Iterator[str]:
+    if not pattern:
+        yield ""
+    for part in pattern:
+        if isinstance(part, msg.Expression):
+            yield from _expression(part)
+        elif isinstance(part, msg.Markup):
+            yield from _markup(part)
+        else:
+            assert isinstance(part, str)
+            yield text_esc_re.sub(r"\\\g<0>", part)
+
+
+def _quoted_pattern(pattern: msg.Pattern) -> Iterator[str]:
+    yield "{{"
+    yield from mf2_serialize_pattern(pattern)
+    yield "}}"
+
+
+def _expression(expr: msg.Expression) -> Iterator[str]:
+    yield "{"
+    if expr.arg:
+        yield _value(expr.arg)
+    if expr.function:
+        if not identifier_re.fullmatch(expr.function):
+            raise MF2SerializeError(f"Invalid function name: {expr.function}")
+        yield f" :{expr.function}" if expr.arg else f":{expr.function}"
+    elif not expr.arg:
+        raise MF2SerializeError("Invalid expression with no operand and no function")
+    elif expr.options:
+        raise MF2SerializeError("Invalid expression with options but no function")
+    yield from _options(expr.options)
+    yield from _attributes(expr.attributes)
+    yield "}"
+
+
+def _markup(markup: msg.Markup) -> Iterator[str]:
+    yield "{/" if markup.kind == "close" else "{#"
+    if not identifier_re.fullmatch(markup.name):
+        raise MF2SerializeError(f"Invalid markup name: {markup.name}")
+    yield markup.name
+    yield from _options(markup.options)
+    yield from _attributes(markup.attributes)
+    yield "/}" if markup.kind == "standalone" else "}"
+
+
+def _options(options: dict[str, str | msg.VariableRef]) -> Iterator[str]:
+    for name, value in options.items():
+        if not identifier_re.fullmatch(name):
+            raise MF2SerializeError(f"Invalid option name: {name}")
+        yield f" {name}={_value(value)}"
+
+
+def _attributes(attributes: dict[str, str | None]) -> Iterator[str]:
+    for name, value in attributes.items():
+        if not identifier_re.fullmatch(name):
+            raise MF2SerializeError(f"Invalid attribute name: {name}")
+        if value is None:
+            yield f" @{name}"
+        else:
+            yield f" @{name}={_literal(value)}"
+
+
+def _value(value: str | msg.VariableRef) -> str:
+    if isinstance(value, str):
+        return _literal(value)
+    else:
+        assert isinstance(value, msg.VariableRef)
+        return _variable(value.name)
+
+
+def _variable(name: str) -> str:
+    if not name_re.fullmatch(name):
+        raise MF2SerializeError(f"Invalid variable name: {name}")
+    return f"${name}"
+
+
+def _literal(literal: str) -> str:
+    if name_re.fullmatch(literal) or number_re.fullmatch(literal):
+        return literal
+    esc_literal = literal_esc_re.sub(r"\\\g<0>", literal)
+    return f"|{esc_literal}|"

--- a/moz/l10n/formats/mf2/to_json.py
+++ b/moz/l10n/formats/mf2/to_json.py
@@ -1,0 +1,130 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from ...message import data as msg
+
+
+def mf2_to_json(message: msg.Message) -> dict[str, Any]:
+    """
+    Represent a message using the MessageFormat 2 data model [JSON Schema](https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json).
+
+    Does not validate the message; for that, use `mf2_validate_message()`.
+    """
+    json_declarations = [
+        {
+            "type": (
+                "input"
+                if isinstance(expr.arg, msg.VariableRef) and expr.arg.name == name
+                else "local"
+            ),
+            "name": name,
+            "value": _expression(expr),
+        }
+        for name, expr in message.declarations.items()
+    ]
+
+    if isinstance(message, msg.PatternMessage):
+        return {
+            "type": "message",
+            "declarations": json_declarations,
+            "pattern": _pattern(message.pattern),
+        }
+    else:
+        assert isinstance(message, msg.SelectMessage)
+        return {
+            "type": "select",
+            "declarations": json_declarations,
+            "selectors": [_variable(sel) for sel in message.selectors],
+            "variants": [
+                {"keys": [_key(key) for key in keys], "value": _pattern(pattern)}
+                for keys, pattern in message.variants.items()
+            ],
+        }
+
+
+def _pattern(pattern: msg.Pattern) -> list[Any]:
+    return [
+        part
+        if isinstance(part, str)
+        else _markup(part)
+        if isinstance(part, msg.Markup)
+        else _expression(part)
+        for part in pattern
+    ]
+
+
+def _expression(expr: msg.Expression) -> dict[str, str | dict[str, Any]]:
+    json: dict[str, Any] = {"type": "expression"}
+    if expr.arg is not None:
+        json["arg"] = _value(expr.arg)
+    if expr.function is not None:
+        json_func: dict[str, Any] = {"type": "function", "name": expr.function}
+        if expr.options:
+            json_func["options"] = _options(expr.options)
+        json["function"] = json_func
+    if expr.attributes:
+        json["attributes"] = _attributes(expr.attributes)
+    return json
+
+
+def _markup(markup: msg.Markup) -> dict[str, str | dict[str, Any]]:
+    json: dict[str, Any] = {
+        "type": "markup",
+        "kind": markup.kind,
+        "name": markup.name,
+    }
+    if markup.options:
+        json["options"] = _options(markup.options)
+    if markup.attributes:
+        json["attributes"] = _attributes(markup.attributes)
+    return json
+
+
+def _options(options: dict[str, str | msg.VariableRef]) -> dict[str, dict[str, str]]:
+    return {name: _value(value) for name, value in options.items()}
+
+
+def _attributes(
+    attributes: dict[str, str | None],
+) -> dict[str, dict[str, str] | Literal[True]]:
+    return {
+        name: True if value is None else _literal(value)
+        for name, value in attributes.items()
+    }
+
+
+def _key(key: str | msg.CatchallKey) -> str | dict[str, str]:
+    if isinstance(key, str):
+        return _literal(key)
+    else:
+        json = {"type": "*"}
+        if key.value is not None:
+            json["value"] = key.value
+        return json
+
+
+def _value(value: str | msg.VariableRef) -> dict[str, str]:
+    return _literal(value) if isinstance(value, str) else _variable(value)
+
+
+def _literal(value: str) -> dict[str, str]:
+    return {"type": "literal", "value": value}
+
+
+def _variable(var: msg.VariableRef) -> dict[str, str]:
+    return {"type": "variable", "name": var.name}

--- a/moz/l10n/formats/mf2/validate.py
+++ b/moz/l10n/formats/mf2/validate.py
@@ -38,7 +38,11 @@ class MF2ValidationError(ValueError):
 
 
 def mf2_validate_message(msg: PatternMessage | SelectMessage) -> None:
-    """Validate that the message satisfies MessageFormat 2 validity constraints."""
+    """
+    Validate that the message satisfies MessageFormat 2 validity constraints.
+
+    May raise `MF2ValidationError`.
+    """
     if isinstance(msg, PatternMessage):
         _validate_declarations(msg.declarations)
         _validate_pattern(msg.pattern)

--- a/moz/l10n/formats/mf2/validate.py
+++ b/moz/l10n/formats/mf2/validate.py
@@ -1,0 +1,166 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from re import compile
+
+from ...message.data import (
+    CatchallKey,
+    Expression,
+    Markup,
+    Pattern,
+    PatternMessage,
+    SelectMessage,
+    VariableRef,
+)
+
+_name_start = r"a-zA-Z_\xC0-\xD6\xD8-\xF6\xF8-\u02FF\u0370-\u037D\u037F-\u061B\u061D-\u1FFF\u200C-\u200D\u2070-\u218F\u2C00-\u2FEF\u3001-\uD7FF\uF900-\uFDCF\uFDF0-\uFFFC\U00010000-\U000EFFFF"
+name_re = compile(f"[{_name_start}][{_name_start}0-9-.\xb7\u0300-\u036f\u203f-\u2040]*")
+identifier_re = compile(f"{name_re.pattern}(?::{name_re.pattern})?")
+number_re = compile(r"-?(?:0|(?:[1-9]\d*))(?:.\d+)?(?:[eE][-+]?\d+)?")
+
+
+class MF2ValidationError(ValueError):
+    pass
+
+
+def mf2_validate_message(msg: PatternMessage | SelectMessage) -> None:
+    """Validate that the message satisfies MessageFormat 2 validity constraints."""
+    if isinstance(msg, PatternMessage):
+        _validate_declarations(msg.declarations)
+        _validate_pattern(msg.pattern)
+    elif isinstance(msg, SelectMessage):
+        _validate_declarations(msg.declarations)
+        if not msg.selectors or not isinstance(msg.selectors, tuple):
+            raise MF2ValidationError(f"Invalid selectors: {msg.selectors}")
+        for sel in msg.selectors:
+            if isinstance(sel, VariableRef):
+                _validate_variable(sel)
+            else:
+                raise MF2ValidationError(f"Invalid selector: {sel}")
+            sel_name = sel.name
+            sel_expr = msg.declarations.get(sel_name, None)
+            while sel_expr is not None and sel_expr.function is None:
+                if (
+                    isinstance(sel_expr.arg, VariableRef)
+                    and sel_expr.arg.name != sel_name
+                ):
+                    sel_name = sel_expr.arg.name
+                    sel_expr = msg.declarations.get(sel_name, None)
+                else:
+                    sel_expr = None
+            if sel_expr is None:
+                raise MF2ValidationError(
+                    msg, f"Missing selector annotation for ${sel.name}"
+                )
+        sel_count = len(msg.selectors)
+        if not isinstance(msg.variants, Mapping):
+            raise MF2ValidationError(f"Invalid variants: {msg.variants}")
+        for keys, pattern in msg.variants.items():
+            if not isinstance(keys, tuple):
+                raise MF2ValidationError(f"Invalid keys: {keys}")
+            for key in keys:
+                if not isinstance(key, str) and not isinstance(key, CatchallKey):
+                    raise MF2ValidationError(f"Invalid key: {key}")
+            if len(keys) != sel_count:
+                raise MF2ValidationError(
+                    f"Variant key mismatch, expected {sel_count} but found {len(keys)}",
+                )
+            _validate_pattern(pattern)
+        if (CatchallKey(),) * sel_count not in msg.variants:
+            raise MF2ValidationError("Missing fallback variant")
+    else:
+        raise MF2ValidationError(f"Invalid message: {msg}")
+
+
+def _validate_declarations(declarations: dict[str, Expression]) -> None:
+    if not isinstance(declarations, Mapping):
+        raise MF2ValidationError(f"Invalid declarations: {declarations}")
+    # TODO: Check for dependency loops
+    for name, expr in declarations.items():
+        if not isinstance(name, str) or not name_re.fullmatch(name):
+            raise MF2ValidationError(f"Invalid declaration name: {name}")
+        if isinstance(expr, Expression):
+            _validate_expression(expr)
+        else:
+            raise MF2ValidationError(f"Invalid declaration expression: {expr}")
+
+
+def _validate_pattern(pattern: Pattern) -> None:
+    if not isinstance(pattern, Iterable) or isinstance(pattern, str):
+        raise MF2ValidationError(f"Invalid pattern: {pattern}")
+    for part in pattern:
+        if isinstance(part, Expression):
+            _validate_expression(part)
+        elif isinstance(part, Markup):
+            _validate_markup(part)
+        elif not isinstance(part, str):
+            raise MF2ValidationError(f"Invalid pattern part: {part}")
+
+
+def _validate_expression(expr: Expression) -> None:
+    if isinstance(expr.arg, VariableRef):
+        _validate_variable(expr.arg)
+    elif expr.arg is not None and not isinstance(expr.arg, str):
+        raise MF2ValidationError(f"Invalid expression operand: {expr.arg}")
+    if expr.function is None:
+        if expr.arg is None:
+            raise MF2ValidationError(
+                "Invalid expression with no operand and no function"
+            )
+        if expr.options:
+            raise MF2ValidationError("Invalid expression with options but no function")
+    elif isinstance(expr.function, str) and identifier_re.fullmatch(expr.function):
+        _validate_options(expr.options)
+    else:
+        raise MF2ValidationError(f"Invalid function name: {expr.function}")
+    _validate_attributes(expr.attributes)
+
+
+def _validate_markup(markup: Markup) -> None:
+    if markup.kind not in {"open", "standalone", "close"}:
+        raise MF2ValidationError(f"Invalid markup kind: {markup.kind}")
+    if not isinstance(markup.name, str) or not identifier_re.fullmatch(markup.name):
+        raise MF2ValidationError(f"Invalid markup name: {markup.name}")
+    _validate_options(markup.options)
+    _validate_attributes(markup.attributes)
+
+
+def _validate_options(options: dict[str, str | VariableRef]) -> None:
+    if not isinstance(options, Mapping):
+        raise MF2ValidationError(f"Invalid options: {options}")
+    for name, value in options.items():
+        if not isinstance(name, str) or not identifier_re.fullmatch(name):
+            raise MF2ValidationError(f"Invalid option name: {name}")
+        if isinstance(value, VariableRef):
+            _validate_variable(value)
+        elif not isinstance(value, str):
+            raise MF2ValidationError(f"Invalid option value: {value}")
+
+
+def _validate_attributes(attributes: dict[str, str | None]) -> None:
+    if not isinstance(attributes, Mapping):
+        raise MF2ValidationError(f"Invalid attributes: {attributes}")
+    for name, value in attributes.items():
+        if not isinstance(name, str) or not identifier_re.fullmatch(name):
+            raise MF2ValidationError(f"Invalid attribute name: {name}")
+        elif value is not None and not isinstance(value, str):
+            raise MF2ValidationError(f"Invalid option value: {value}")
+
+
+def _validate_variable(var: VariableRef) -> None:
+    if not isinstance(var.name, str) or not name_re.fullmatch(var.name):
+        raise MF2ValidationError(f"Invalid variable name: {var.name}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ include = ["moz.l10n*"]
 [tool.uv]
 dev-dependencies = [
     "importlib-resources>=6.4.5",
+    "jsonschema>=4.23.0",
     "mypy>=1.11.2",
     "pytest>=8.3.3",
     "ruff>=0.6.8",

--- a/tests/formats/data/mf2-message-schema.json
+++ b/tests/formats/data/mf2-message-schema.json
@@ -1,0 +1,172 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "https://github.com/unicode-org/message-format-wg/blob/main/spec/data-model/message.json",
+
+  "oneOf": [{ "$ref": "#/$defs/message" }, { "$ref": "#/$defs/select" }],
+
+  "$defs": {
+    "literal": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "literal" },
+        "value": { "type": "string" }
+      },
+      "required": ["type", "value"]
+    },
+    "variable": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "variable" },
+        "name": { "type": "string" }
+      },
+      "required": ["type", "name"]
+    },
+    "literal-or-variable": {
+      "oneOf": [{ "$ref": "#/$defs/literal" }, { "$ref": "#/$defs/variable" }]
+    },
+
+    "options": {
+      "type": "object",
+      "additionalProperties": { "$ref": "#/$defs/literal-or-variable" }
+    },
+    "attributes": {
+      "type": "object",
+      "additionalProperties": {
+        "oneOf": [{ "$ref": "#/$defs/literal" }, { "const": true }]
+      }
+    },
+
+    "function": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "function" },
+        "name": { "type": "string" },
+        "options": { "$ref": "#/$defs/options" }
+      },
+      "required": ["type", "name"]
+    },
+    "expression": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "expression" },
+        "arg": { "$ref": "#/$defs/literal-or-variable" },
+        "function": { "$ref": "#/$defs/function" },
+        "attributes": { "$ref": "#/$defs/attributes" }
+      },
+      "anyOf": [
+        { "required": ["type", "arg"] },
+        { "required": ["type", "function"] }
+      ]
+    },
+
+    "markup": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "markup" },
+        "kind": { "enum": ["open", "standalone", "close"] },
+        "name": { "type": "string" },
+        "options": { "$ref": "#/$defs/options" },
+        "attributes": { "$ref": "#/$defs/attributes" }
+      },
+      "required": ["type", "kind", "name"]
+    },
+
+    "pattern": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "type": "string" },
+          { "$ref": "#/$defs/expression" },
+          { "$ref": "#/$defs/markup" }
+        ]
+      }
+    },
+
+    "input-declaration": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "input" },
+        "name": { "type": "string" },
+        "value": {
+          "allOf": [
+            { "$ref": "#/$defs/expression" },
+            {
+              "properties": {
+                "arg": { "$ref": "#/$defs/variable" }
+              },
+              "required": ["type", "arg"]
+            }
+          ]
+        }
+      },
+      "required": ["type", "name", "value"]
+    },
+    "local-declaration": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "local" },
+        "name": { "type": "string" },
+        "value": { "$ref": "#/$defs/expression" }
+      },
+      "required": ["type", "name", "value"]
+    },
+    "declarations": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/input-declaration" },
+          { "$ref": "#/$defs/local-declaration" }
+        ]
+      }
+    },
+
+    "variant-key": {
+      "oneOf": [
+        { "$ref": "#/$defs/literal" },
+        {
+          "type": "object",
+          "properties": {
+            "type": { "const": "*" },
+            "value": { "type": "string" }
+          },
+          "required": ["type"]
+        }
+      ]
+    },
+    "message": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "message" },
+        "declarations": { "$ref": "#/$defs/declarations" },
+        "pattern": { "$ref": "#/$defs/pattern" }
+      },
+      "required": ["type", "declarations", "pattern"]
+    },
+    "select": {
+      "type": "object",
+      "properties": {
+        "type": { "const": "select" },
+        "declarations": { "$ref": "#/$defs/declarations" },
+        "selectors": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/variable" }
+        },
+        "variants": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "keys": {
+                "type": "array",
+                "items": { "$ref": "#/$defs/variant-key" }
+              },
+              "value": { "$ref": "#/$defs/pattern" }
+            },
+            "required": ["keys", "value"]
+          }
+        }
+      },
+      "required": ["type", "declarations", "selectors", "variants"]
+    }
+  }
+}

--- a/tests/formats/test_mf2.py
+++ b/tests/formats/test_mf2.py
@@ -1,0 +1,443 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from moz.l10n.formats.mf2 import MF2ParseError, mf2_parse_message, mf2_serialize_message
+from moz.l10n.message.data import (
+    CatchallKey,
+    Expression,
+    Markup,
+    Message,
+    PatternMessage,
+    SelectMessage,
+    VariableRef,
+)
+
+
+def fail(src: str) -> None:
+    with pytest.raises(MF2ParseError):
+        mf2_parse_message(src)
+
+
+def msg_str(msg: Message):
+    return "".join(mf2_serialize_message(msg))
+
+
+def test_pattern():
+    msg = mf2_parse_message("pattern")
+    assert msg == PatternMessage(["pattern"])
+    assert msg_str(msg) == "pattern"
+
+    msg = mf2_parse_message(" pattern ")
+    assert msg == PatternMessage([" pattern "])
+    assert msg_str(msg) == " pattern "
+
+    src = "text1 {$var} text2 {#m:open}text3{/m:close}{#m:standalone/}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage(
+        [
+            "text1 ",
+            Expression(VariableRef("var")),
+            " text2 ",
+            Markup("open", "m:open"),
+            "text3",
+            Markup("close", "m:close"),
+            Markup("standalone", "m:standalone"),
+        ]
+    )
+    assert msg_str(msg) == src
+
+    fail("pattern}")
+
+    fail("pattern{{quoted}}")
+
+    fail("pattern}}")
+
+
+def test_quoted_pattern():
+    msg = mf2_parse_message("{{quoted}}")
+    assert msg == PatternMessage(["quoted"])
+    assert msg_str(msg) == "quoted"
+
+    msg = mf2_parse_message(" {{quoted}} ")
+    assert msg == PatternMessage(["quoted"])
+    assert msg_str(msg) == "quoted"
+
+    fail("{{quoted}} x")
+    fail("{{quoted}} {{more}}")
+    fail("{{quoted}")
+    fail("{{quoted")
+
+
+def test_placeholder():
+    fail("{")
+    fail("{}")
+    fail("{ }")
+
+    msg = mf2_parse_message("{name}")
+    assert msg == PatternMessage([Expression("name")])
+    assert msg_str(msg) == "{name}"
+
+    msg = mf2_parse_message("{ name }")
+    assert msg == PatternMessage([Expression("name")])
+    assert msg_str(msg) == "{name}"
+
+    msg = mf2_parse_message("{42}")
+    assert msg == PatternMessage([Expression("42")])
+    assert msg_str(msg) == "{42}"
+
+    msg = mf2_parse_message("{42.99}")
+    assert msg == PatternMessage([Expression("42.99")])
+    assert msg_str(msg) == "{42.99}"
+
+    msg = mf2_parse_message("{-13e-09}")
+    assert msg == PatternMessage([Expression("-13e-09")])
+    assert msg_str(msg) == "{-13e-09}"
+
+    fail("{42.99.13}")
+    fail("{-name}")
+
+    msg = mf2_parse_message("{|quoted|}")
+    assert msg == PatternMessage([Expression("quoted")])
+    assert msg_str(msg) == "{quoted}"
+
+    msg = mf2_parse_message("{|quoted}|}")
+    assert msg == PatternMessage([Expression("quoted}")])
+    assert msg_str(msg) == "{|quoted}|}"
+
+    src = r"{|quoted\\\|escapes|}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage([Expression("quoted\\|escapes")])
+    assert msg_str(msg) == src
+
+    fail("{|quoted}")
+
+    msg = mf2_parse_message("{$var}")
+    assert msg == PatternMessage([Expression(VariableRef("var"))])
+    assert msg_str(msg) == "{$var}"
+
+    msg = mf2_parse_message("{ $var }")
+    assert msg == PatternMessage([Expression(VariableRef("var"))])
+    assert msg_str(msg) == "{$var}"
+
+    msg = mf2_parse_message("{$foo.bar}")
+    assert msg == PatternMessage([Expression(VariableRef("foo.bar"))])
+    assert msg_str(msg) == "{$foo.bar}"
+
+
+def test_placeholder_attributes():
+    fail("{@foo}")
+
+    src = "{42 @foo}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage([Expression("42", attributes={"foo": None})])
+    assert msg_str(msg) == src
+
+    msg = mf2_parse_message("{42 @foo = 13 }")
+    assert msg == PatternMessage([Expression("42", attributes={"foo": "13"})])
+    assert msg_str(msg) == "{42 @foo=13}"
+
+    src = "{42 @foo=| 13 |}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage([Expression("42", attributes={"foo": " 13 "})])
+    assert msg_str(msg) == src
+
+    fail("{42 @foo=$var}")
+
+    src = "{$var @foo @bar=baz}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage(
+        [Expression(VariableRef("var"), attributes={"foo": None, "bar": "baz"})]
+    )
+    assert msg_str(msg) == src
+
+    fail("{$var@foo}")
+    fail("{42 @foo @foo}")
+    fail("{$var :string@foo}")
+    fail("{$var :string @foo opt=42}")
+
+
+def test_placeholder_with_function():
+    msg = mf2_parse_message("{$var :string}")
+    assert msg == PatternMessage([Expression(VariableRef("var"), "string")])
+    assert msg_str(msg) == "{$var :string}"
+
+    msg = mf2_parse_message("{ $var :string }")
+    assert msg == PatternMessage([Expression(VariableRef("var"), "string")])
+    assert msg_str(msg) == "{$var :string}"
+
+    fail("{$var:string}")
+
+    msg = mf2_parse_message("{$var :string opt=42}")
+    assert msg == PatternMessage(
+        [Expression(VariableRef("var"), "string", {"opt": "42"})]
+    )
+    assert msg_str(msg) == "{$var :string opt=42}"
+
+    msg = mf2_parse_message("{$var :string opt = 42}")
+    assert msg == PatternMessage(
+        [Expression(VariableRef("var"), "string", {"opt": "42"})]
+    )
+    assert msg_str(msg) == "{$var :string opt=42}"
+
+    fail("{$var opt=42}")
+
+    src = "{$var :test:string opt-a=42 opt:b=$var}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage(
+        [
+            Expression(
+                VariableRef("var"),
+                "test:string",
+                {"opt-a": "42", "opt:b": VariableRef("var")},
+            )
+        ]
+    )
+    assert msg_str(msg) == src
+
+    fail("{$var :string opt=42 opt=13}")
+    fail("{$var :string opt-a=|x|opt-b=42}")
+
+    src = "{$var :test:string opt-a=42 opt:b=$var @foo @bar=baz}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage(
+        [
+            Expression(
+                VariableRef("var"),
+                "test:string",
+                {"opt-a": "42", "opt:b": VariableRef("var")},
+                attributes={"foo": None, "bar": "baz"},
+            ),
+        ]
+    )
+    assert msg_str(msg) == src
+
+
+def test_markup():
+    src = "{#aa}{/bb}{#cc/}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage(
+        [Markup("open", "aa"), Markup("close", "bb"), Markup("standalone", "cc")]
+    )
+    assert msg_str(msg) == src
+
+    msg = mf2_parse_message("{ #aa }{ /bb }{ #cc /}")
+    assert msg == PatternMessage(
+        [Markup("open", "aa"), Markup("close", "bb"), Markup("standalone", "cc")]
+    )
+    assert msg_str(msg) == "{#aa}{/bb}{#cc/}"
+
+    src = "{#aa:AA}{/bb:BB}{#cc:CC/}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage(
+        [
+            Markup("open", "aa:AA"),
+            Markup("close", "bb:BB"),
+            Markup("standalone", "cc:CC"),
+        ]
+    )
+    assert msg_str(msg) == src
+
+    fail("{#aa")
+    fail("{#cc/ }")
+    fail("{/bb/}")
+    fail("{#aa :string}")
+
+    src = "{#aa opt=42}{/bb opt=42}{#cc opt=42/}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage(
+        [
+            Markup("open", "aa", {"opt": "42"}),
+            Markup("close", "bb", {"opt": "42"}),
+            Markup("standalone", "cc", {"opt": "42"}),
+        ]
+    )
+    assert msg_str(msg) == src
+
+    msg = mf2_parse_message("{#aa @attr}{/bb @attr=42}{#cc @ns:attr=|42|/}")
+    assert msg == PatternMessage(
+        [
+            Markup("open", "aa", attributes={"attr": None}),
+            Markup("close", "bb", attributes={"attr": "42"}),
+            Markup("standalone", "cc", attributes={"ns:attr": "42"}),
+        ]
+    )
+    assert msg_str(msg) == "{#aa @attr}{/bb @attr=42}{#cc @ns:attr=42/}"
+
+    src = "{#aa opt=42 @attr=x}"
+    msg = mf2_parse_message(src)
+    assert msg == PatternMessage([Markup("open", "aa", {"opt": "42"}, {"attr": "x"})])
+    assert msg_str(msg) == src
+
+    fail("{#aa @attr=x opt=42}")
+    fail("{#aa@attr}")
+    fail("{#aa opt=x@attr}")
+    fail("{#aa opt=|x|@attr}")
+
+
+def test_declarations():
+    msg = mf2_parse_message(".input {$var} {{quoted}}")
+    assert msg == PatternMessage(
+        declarations={"var": Expression(VariableRef("var"))},
+        pattern=["quoted"],
+    )
+    assert msg_str(msg) == ".input {$var}\n{{quoted}}"
+
+    msg = mf2_parse_message(".input{$var}{{quoted}}")
+    assert msg == PatternMessage(
+        declarations={"var": Expression(VariableRef("var"))},
+        pattern=["quoted"],
+    )
+    assert msg_str(msg) == ".input {$var}\n{{quoted}}"
+
+    fail(".input {42} {{quoted}}")
+
+    msg = mf2_parse_message(".local $var = {42} {{quoted}}")
+    assert msg == PatternMessage(
+        declarations={"var": Expression("42")},
+        pattern=["quoted"],
+    )
+    assert msg_str(msg) == ".local $var = {42}\n{{quoted}}"
+
+    msg = mf2_parse_message(".local $var2 = {$var1} {{quoted}}")
+    assert msg == PatternMessage(
+        declarations={"var2": Expression(VariableRef("var1"))},
+        pattern=["quoted"],
+    )
+    assert msg_str(msg) == ".local $var2 = {$var1}\n{{quoted}}"
+
+    msg = mf2_parse_message(".input {$var1} .local $var2 = {$var1} {{quoted}}")
+    assert msg == PatternMessage(
+        declarations={
+            "var1": Expression(VariableRef("var1")),
+            "var2": Expression(VariableRef("var1")),
+        },
+        pattern=["quoted"],
+    )
+    assert msg_str(msg) == ".input {$var1}\n.local $var2 = {$var1}\n{{quoted}}"
+
+    msg = mf2_parse_message(
+        ".input {$var1} .local $var2 = {42 :number opt=$var1} {{quoted}}"
+    )
+    assert msg == PatternMessage(
+        declarations={
+            "var1": Expression(VariableRef("var1")),
+            "var2": Expression("42", "number", {"opt": VariableRef("var1")}),
+        },
+        pattern=["quoted"],
+    )
+    assert (
+        msg_str(msg)
+        == ".input {$var1}\n.local $var2 = {42 :number opt=$var1}\n{{quoted}}"
+    )
+
+    fail(".local $var = {$var} {{quoted}}")
+    fail(".input {$var} .input {$var} {{quoted}}")
+    fail(".input {$var} .local $var = {42} {{quoted}}")
+    fail(".local $var = {42} .input {$var} {{quoted}}")
+    fail(".local $var1 = {$var2} .local $var2 = {42} {{quoted}}")
+
+    msg = mf2_parse_message(
+        ".input {$foo :string} .local $bar = {42 :number} {{Hello {$foo}{$bar}}}"
+    )
+    assert msg == PatternMessage(
+        declarations={
+            "foo": Expression(VariableRef("foo"), "string"),
+            "bar": Expression("42", "number"),
+        },
+        pattern=[
+            "Hello ",
+            Expression(VariableRef("foo")),
+            Expression(VariableRef("bar")),
+        ],
+    )
+    assert (
+        msg_str(msg)
+        == ".input {$foo :string}\n.local $bar = {42 :number}\n"
+        + "{{Hello {$foo}{$bar}}}"
+    )
+
+
+def test_select_message():
+    msg = mf2_parse_message(".input{$foo}.match $foo *{{variant}}")
+    assert msg == SelectMessage(
+        declarations={"foo": Expression(VariableRef("foo"))},
+        selectors=(VariableRef("foo"),),
+        variants={(CatchallKey(),): ["variant"]},
+    )
+    assert msg_str(msg) == ".input {$foo}\n.match $foo\n* {{variant}}"
+
+    msg = mf2_parse_message(
+        """
+        .input {$var}
+        .match $var
+        key {{one}}
+        * {{two}}
+        """
+    )
+    assert msg == SelectMessage(
+        declarations={"var": Expression(VariableRef("var"))},
+        selectors=(VariableRef("var"),),
+        variants={("key",): ["one"], (CatchallKey(),): ["two"]},
+    )
+    assert msg_str(msg) == ".input {$var}\n.match $var\nkey {{one}}\n* {{two}}"
+
+    fail(".match $var * {{quoted}}")
+    fail(
+        """
+            .input {$var}
+            .match $var
+            key {{one}}
+            key {{repeat}}
+            * {{other}}
+            """
+    )
+
+    msg = mf2_parse_message(
+        """
+        .input {$foo}
+        .local $bar = {$foo}
+        .match $foo $bar
+        key |quoted key| {{one}}
+        key |*| {{two}}
+        * key {{three}}
+        * * {{four}}
+        """
+    )
+    assert msg == SelectMessage(
+        declarations={
+            "foo": Expression(VariableRef("foo")),
+            "bar": Expression(VariableRef("foo")),
+        },
+        selectors=(VariableRef("foo"), VariableRef("bar")),
+        variants={
+            ("key", "quoted key"): ["one"],
+            ("key", "*"): ["two"],
+            (CatchallKey(), "key"): ["three"],
+            (CatchallKey(), CatchallKey()): ["four"],
+        },
+    )
+    assert (
+        msg_str(msg)
+        == ".input {$foo}\n.local $bar = {$foo}\n.match $foo $bar\n"
+        + "key |quoted key| {{one}}\n"
+        + "key |*| {{two}}\n"
+        + "* key {{three}}\n"
+        + "* * {{four}}"
+    )
+
+    fail(".input {$foo} .match $foo key {{one}}")

--- a/tests/formats/test_mf2_validate.py
+++ b/tests/formats/test_mf2_validate.py
@@ -1,0 +1,291 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import pytest
+
+from moz.l10n.formats.mf2 import MF2ValidationError, mf2_validate_message
+from moz.l10n.message.data import (
+    CatchallKey,
+    Expression,
+    Markup,
+    PatternMessage,
+    SelectMessage,
+    VariableRef,
+)
+
+
+def ok(part: Expression | Markup | PatternMessage | SelectMessage) -> None:
+    mf2_validate_message(
+        PatternMessage([part])
+        if isinstance(part, Expression) or isinstance(part, Markup)
+        else part
+    )
+
+
+def fail(part: Expression | Markup | PatternMessage | SelectMessage) -> None:
+    with pytest.raises(MF2ValidationError):
+        ok(part)
+
+
+def test_validate_expression():
+    ok(Expression("42"))
+    fail(Expression(None))
+    fail(Expression(42))
+
+    ok(Expression(VariableRef("var")))
+    fail(Expression(VariableRef("-var")))
+    fail(Expression(VariableRef(42)))
+
+    ok(Expression(None, "func"))
+    ok(Expression("some arg", "func"))
+    fail(Expression(None, ""))
+    fail(Expression(None, "func badname"))
+
+    ok(Expression(None, "func", {"opt": "some option value"}))
+    ok(Expression(None, "func", {"opt": VariableRef("var")}))
+    fail(Expression("42", None, {"opt": "42"}))
+    fail(Expression("42", "func", "options"))
+    fail(Expression("42", "func", ["opt"]))
+    fail(Expression(None, "func", {"opt": 42}))
+    fail(Expression(None, "func", {42: "opt"}))
+
+    ok(Expression("42", attributes={"attr": None}))
+    ok(Expression("42", attributes={"attr": "some attr value"}))
+    fail(Expression(None, attributes="attr"))
+    fail(Expression(None, attributes=["attr"]))
+    fail(Expression(None, attributes={"attr": None}))
+    fail(Expression("42", None, attributes={"attr": 42}))
+    fail(Expression("42", None, attributes={"attr": VariableRef("var")}))
+    fail(Expression("42", None, attributes={42: "attr"}))
+
+
+def test_validate_markup():
+    ok(Markup("open", "name"))
+    ok(Markup("standalone", "name"))
+    ok(Markup("close", "name"))
+    fail(Markup("foo", "name"))
+    fail(Markup("open", "bad name"))
+
+    ok(Markup("open", "name", {"opt": "42"}))
+    fail(Markup("open", "name", {"opt": 42}))
+
+    ok(Markup("open", "name", attributes={"attr": "x"}))
+    ok(Markup("open", "name", {"opt": "42"}, {"attr": "x"}))
+    fail(Markup("open", "name", attributes={"attr": 42}))
+
+
+def test_validate_patternmessage():
+    ok(PatternMessage(["pattern"]))
+    ok(PatternMessage([Expression(VariableRef("var"))]))
+    ok(
+        PatternMessage(
+            ["first", "second", Expression(VariableRef("var")), Markup("open", "name")]
+        )
+    )
+    fail(PatternMessage("pattern"))
+    fail(PatternMessage([42]))
+    fail(PatternMessage([Expression(42)]))
+
+    ok(
+        PatternMessage(
+            declarations={"var": Expression("var")},
+            pattern=["pattern"],
+        )
+    )
+    fail(PatternMessage(declarations="decl", pattern=["pattern"]))
+    fail(PatternMessage(declarations=["decl"], pattern=["pattern"]))
+    fail(
+        PatternMessage(
+            declarations={42: Expression("var")},
+            pattern=["pattern"],
+        )
+    )
+    ok(
+        PatternMessage(
+            declarations={"var": Expression(VariableRef("var"))},
+            pattern=["pattern"],
+        )
+    )
+    ok(
+        PatternMessage(
+            declarations={"var2": Expression(VariableRef("var1"))},
+            pattern=["pattern"],
+        )
+    )
+    ok(
+        PatternMessage(
+            declarations={
+                "var1": Expression(VariableRef("var1")),
+                "var2": Expression(VariableRef("var1")),
+            },
+            pattern=["pattern"],
+        )
+    )
+    # fail(PatternMessage(
+    #         declarations={
+    #             "var1": Expression(VariableRef("var2")),
+    #             "var2": Expression(VariableRef("var1")),
+    #         },
+    #         pattern=["pattern"],
+    #     ))
+
+
+def test_validate_selectmessage():
+    ok(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"),),
+            variants={(CatchallKey(),): ["variant"]},
+        )
+    )
+    ok(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"), VariableRef("var")),
+            variants={(CatchallKey(), CatchallKey()): ["variant"]},
+        )
+    )
+
+    # No selectors
+    fail(
+        SelectMessage(
+            declarations={},
+            selectors=(),
+            variants={(): ["variant"]},
+        )
+    )
+
+    # Bad declarations
+    fail(
+        SelectMessage(
+            declarations=[],
+            selectors=(VariableRef("var"),),
+            variants={(CatchallKey(),): ["variant"]},
+        )
+    )
+
+    # Bad selectors
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=[VariableRef("var")],
+            variants={(CatchallKey(),): ["variant"]},
+        )
+    )
+
+    # Bad variants
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"),),
+            variants=[],
+        )
+    )
+
+    # Bad variant key
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"),),
+            variants={(42,): ["bad key"], (CatchallKey(),): ["catchall"]},
+        )
+    )
+
+    # No selector declaration
+    fail(
+        SelectMessage(
+            declarations={},
+            selectors=(VariableRef("var"),),
+            variants={(CatchallKey(),): ["variant"]},
+        )
+    )
+
+    # No selector function
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42")},
+            selectors=(VariableRef("var"),),
+            variants={(CatchallKey(),): ["variant"]},
+        )
+    )
+
+    # No variants
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"),),
+            variants={},
+        )
+    )
+
+    # No fallback variant
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"),),
+            variants={("key",): ["variant"]},
+        )
+    )
+
+    # Variant key mismatch
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"), VariableRef("var")),
+            variants={(CatchallKey(),): ["variant"]},
+        )
+    )
+
+    # No fallback variant
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"), VariableRef("var")),
+            variants={(CatchallKey(), "key"): ["variant"]},
+        )
+    )
+
+    # Variant key mismatch
+    fail(
+        SelectMessage(
+            declarations={"var": Expression("42", "func")},
+            selectors=(VariableRef("var"),),
+            variants={(CatchallKey(), CatchallKey()): ["variant"]},
+        )
+    )
+
+    ok(
+        SelectMessage(
+            declarations={
+                "var1": Expression("42", "func"),
+                "var2": Expression(VariableRef("var1")),
+            },
+            selectors=(VariableRef("var2"),),
+            variants={("key",): ["variant"], (CatchallKey(),): ["catchall"]},
+        )
+    )
+
+    # No selector function
+    fail(
+        SelectMessage(
+            declarations={
+                "var1": Expression("42"),
+                "var2": Expression(VariableRef("var1")),
+            },
+            selectors=(VariableRef("var2"),),
+            variants={(CatchallKey(),): ["variant"]},
+        )
+    )

--- a/tests/test_walk_files.py
+++ b/tests/test_walk_files.py
@@ -31,6 +31,7 @@ test_data_files = (
     "hello.xliff",
     "icu-docs.xliff",
     "messages.json",
+    "mf2-message-schema.json",
     "strings.xml",
     "test.properties",
     "xcode.xliff",

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,18 @@
 version = 1
 requires-python = ">=3.8, <4"
+resolution-markers = [
+    "python_full_version >= '3.9'",
+    "python_full_version < '3.9'",
+]
+
+[[package]]
+name = "attrs"
+version = "24.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/c8/6260f8ccc11f0917360fc0da435c5c9c7504e3db174d5a12a1494887b045/attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff", size = 805984 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/89/aa/ab0f7891a01eeb2d2e338ae8fecbe57fcebea1a24dbb64d45801bfab481d/attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308", size = 63397 },
+]
 
 [[package]]
 name = "colorama"
@@ -80,6 +93,57 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/9a/02beaf11fc9ea7829d3a9041536934cd03990e09c359724f99ee6bd2b41b/iniparse-0.5.tar.gz", hash = "sha256:932e5239d526e7acb504017bb707be67019ac428a6932368e6851691093aa842", size = 32233 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/b0/4d357324948188e76154b332e119fb28e374c1ebe4d4f6bca729aaa44309/iniparse-0.5-py3-none-any.whl", hash = "sha256:db6ef1d8a02395448e0e7b17ac0aa28b8d338b632bbd1ffca08c02ddae32cf97", size = 24445 },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.23.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "importlib-resources", marker = "python_full_version < '3.9'" },
+    { name = "jsonschema-specifications", version = "2023.12.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "jsonschema-specifications", version = "2024.10.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "pkgutil-resolve-name", marker = "python_full_version < '3.9'" },
+    { name = "referencing", version = "0.35.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "referencing", version = "0.36.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "rpds-py", version = "0.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+    { name = "rpds-py", version = "0.22.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/38/2e/03362ee4034a4c917f697890ccd4aec0800ccf9ded7f511971c75451deec/jsonschema-4.23.0.tar.gz", hash = "sha256:d71497fef26351a33265337fa77ffeb82423f3ea21283cd9467bb03999266bc4", size = 325778 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/4a/4f9dbeb84e8850557c02365a0eee0649abe5eb1d84af92a25731c6c0f922/jsonschema-4.23.0-py3-none-any.whl", hash = "sha256:fbadb6f8b144a8f8cf9f0b89ba94501d143e50411a1278633f56a7acf7fd5566", size = 88462 },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2023.12.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "importlib-resources", marker = "python_full_version < '3.9'" },
+    { name = "referencing", version = "0.35.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/b9/cc0cc592e7c195fb8a650c1d5990b10175cf13b4c97465c72ec841de9e4b/jsonschema_specifications-2023.12.1.tar.gz", hash = "sha256:48a76787b3e70f5ed53f1160d2b81f586e4ca6d1548c5de7085d1682674764cc", size = 13983 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/07/44bd408781594c4d0a027666ef27fab1e441b109dc3b76b4f836f8fd04fe/jsonschema_specifications-2023.12.1-py3-none-any.whl", hash = "sha256:87e4fdf3a94858b8a2ba2778d9ba57d8a9cafca7c7489c46ba0d30a8bc6a9c3c", size = 18482 },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2024.10.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9'",
+]
+dependencies = [
+    { name = "referencing", version = "0.36.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/db/58f950c996c793472e336ff3655b13fbcf1e3b359dcf52dcf3ed3b52c352/jsonschema_specifications-2024.10.1.tar.gz", hash = "sha256:0f38b83639958ce1152d02a7f062902c41c8fd20d558b0c34344292d417ae272", size = 15561 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/0f/8910b19ac0670a0f80ce1008e5e751c4a57e14d2c4c13a482aa6079fa9d6/jsonschema_specifications-2024.10.1-py3-none-any.whl", hash = "sha256:a09a0680616357d9a0ecf05c12ad234479f549239d0f5b55f3deea67475da9bf", size = 18459 },
 ]
 
 [[package]]
@@ -223,6 +287,7 @@ xml = [
 [package.dev-dependencies]
 dev = [
     { name = "importlib-resources" },
+    { name = "jsonschema" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "ruff" },
@@ -243,6 +308,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "importlib-resources", specifier = ">=6.4.5" },
+    { name = "jsonschema", specifier = ">=4.23.0" },
     { name = "mypy", specifier = ">=1.11.2" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "ruff", specifier = ">=0.6.8" },
@@ -308,6 +374,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pkgutil-resolve-name"
+version = "1.3.10"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/70/f2/f2891a9dc37398696ddd945012b90ef8d0a034f0012e3f83c3f7a70b0f79/pkgutil_resolve_name-1.3.10.tar.gz", hash = "sha256:357d6c9e6a755653cfd78893817c0853af365dd51ec97f3d358a819373bbd174", size = 5054 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c9/5c/3d4882ba113fd55bdba9326c1e4c62a15e674a2501de4869e6bd6301f87e/pkgutil_resolve_name-1.3.10-py3-none-any.whl", hash = "sha256:ca27cc078d25c5ad71a9de0a7a330146c4e014c2462d9af19c6b828280649c5e", size = 4734 },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
@@ -340,6 +415,265 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8b/6c/62bbd536103af674e227c41a8f3dcd022d591f6eed5facb5a0f31ee33bbc/pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181", size = 1442487 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/6b/77/7440a06a8ead44c7757a64362dd22df5760f9b12dc5f11b6188cd2fc27a0/pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2", size = 342341 },
+]
+
+[[package]]
+name = "referencing"
+version = "0.35.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+dependencies = [
+    { name = "attrs", marker = "python_full_version < '3.9'" },
+    { name = "rpds-py", version = "0.20.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.9'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/5b/73ca1f8e72fff6fa52119dbd185f73a907b1989428917b24cff660129b6d/referencing-0.35.1.tar.gz", hash = "sha256:25b42124a6c8b632a425174f24087783efb348a6f1e0008e63cd4466fedf703c", size = 62991 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/59/2056f61236782a2c86b33906c025d4f4a0b17be0161b63b70fd9e8775d36/referencing-0.35.1-py3-none-any.whl", hash = "sha256:eda6d3234d62814d1c64e305c1331c9a3a6132da475ab6382eaa997b21ee75de", size = 26684 },
+]
+
+[[package]]
+name = "referencing"
+version = "0.36.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9'",
+]
+dependencies = [
+    { name = "attrs", marker = "python_full_version >= '3.9'" },
+    { name = "rpds-py", version = "0.22.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.9'" },
+    { name = "typing-extensions", marker = "python_full_version >= '3.9' and python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/32/fd98246df7a0f309b58cae68b10b6b219ef2eb66747f00dfb34422687087/referencing-0.36.1.tar.gz", hash = "sha256:ca2e6492769e3602957e9b831b94211599d2aade9477f5d44110d2530cf9aade", size = 74661 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/fa/9f193ef0c9074b659009f06d7cbacc6f25b072044815bcf799b76533dbb8/referencing-0.36.1-py3-none-any.whl", hash = "sha256:363d9c65f080d0d70bc41c721dce3c7f3e77fc09f269cd5c8813da18069a6794", size = 26777 },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.20.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/cb/8e919951f55d109d658f81c9b49d0cc3b48637c50792c5d2e77032b8c5da/rpds_py-0.20.1.tar.gz", hash = "sha256:e1791c4aabd117653530dccd24108fa03cc6baf21f58b950d0a73c3b3b29a350", size = 25931 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/0e/d7e7e9280988a7bc56fd326042baca27f4f55fad27dc8aa64e5e0e894e5d/rpds_py-0.20.1-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a649dfd735fff086e8a9d0503a9f0c7d01b7912a333c7ae77e1515c08c146dad", size = 327335 },
+    { url = "https://files.pythonhosted.org/packages/4c/72/027185f213d53ae66765c575229829b202fbacf3d55fe2bd9ff4e29bb157/rpds_py-0.20.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f16bc1334853e91ddaaa1217045dd7be166170beec337576818461268a3de67f", size = 318250 },
+    { url = "https://files.pythonhosted.org/packages/2b/e7/b4eb3e6ff541c83d3b46f45f855547e412ab60c45bef64520fafb00b9b42/rpds_py-0.20.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:14511a539afee6f9ab492b543060c7491c99924314977a55c98bfa2ee29ce78c", size = 361206 },
+    { url = "https://files.pythonhosted.org/packages/e7/80/cb9a4b4cad31bcaa37f38dae7a8be861f767eb2ca4f07a146b5ffcfbee09/rpds_py-0.20.1-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3ccb8ac2d3c71cda472b75af42818981bdacf48d2e21c36331b50b4f16930163", size = 369921 },
+    { url = "https://files.pythonhosted.org/packages/95/1b/463b11e7039e18f9e778568dbf7338c29bbc1f8996381115201c668eb8c8/rpds_py-0.20.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c142b88039b92e7e0cb2552e8967077e3179b22359e945574f5e2764c3953dcf", size = 403673 },
+    { url = "https://files.pythonhosted.org/packages/86/98/1ef4028e9d5b76470bf7f8f2459be07ac5c9621270a2a5e093f8d8a8cc2c/rpds_py-0.20.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f19169781dddae7478a32301b499b2858bc52fc45a112955e798ee307e294977", size = 430267 },
+    { url = "https://files.pythonhosted.org/packages/25/8e/41d7e3e6d3a4a6c94375020477705a3fbb6515717901ab8f94821cf0a0d9/rpds_py-0.20.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:13c56de6518e14b9bf6edde23c4c39dac5b48dcf04160ea7bce8fca8397cdf86", size = 360569 },
+    { url = "https://files.pythonhosted.org/packages/4f/6a/8839340464d4e1bbfaf0482e9d9165a2309c2c17427e4dcb72ce3e5cc5d6/rpds_py-0.20.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:925d176a549f4832c6f69fa6026071294ab5910e82a0fe6c6228fce17b0706bd", size = 382584 },
+    { url = "https://files.pythonhosted.org/packages/64/96/7a7f938d3796a6a3ec08ed0e8a5ecd436fbd516a3684ab1fa22d46d6f6cc/rpds_py-0.20.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:78f0b6877bfce7a3d1ff150391354a410c55d3cdce386f862926a4958ad5ab7e", size = 546560 },
+    { url = "https://files.pythonhosted.org/packages/15/c7/19fb4f1247a3c90a99eca62909bf76ee988f9b663e47878a673d9854ec5c/rpds_py-0.20.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3dd645e2b0dcb0fd05bf58e2e54c13875847687d0b71941ad2e757e5d89d4356", size = 549359 },
+    { url = "https://files.pythonhosted.org/packages/d2/4c/445eb597a39a883368ea2f341dd6e48a9d9681b12ebf32f38a827b30529b/rpds_py-0.20.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:4f676e21db2f8c72ff0936f895271e7a700aa1f8d31b40e4e43442ba94973899", size = 527567 },
+    { url = "https://files.pythonhosted.org/packages/4f/71/4c44643bffbcb37311fc7fe221bcf139c8d660bc78f746dd3a05741372c8/rpds_py-0.20.1-cp310-none-win32.whl", hash = "sha256:648386ddd1e19b4a6abab69139b002bc49ebf065b596119f8f37c38e9ecee8ff", size = 200412 },
+    { url = "https://files.pythonhosted.org/packages/f4/33/9d0529d74099e090ec9ab15eb0a049c56cca599eaaca71bfedbdbca656a9/rpds_py-0.20.1-cp310-none-win_amd64.whl", hash = "sha256:d9ecb51120de61e4604650666d1f2b68444d46ae18fd492245a08f53ad2b7711", size = 218563 },
+    { url = "https://files.pythonhosted.org/packages/a0/2e/a6ded84019a05b8f23e0fe6a632f62ae438a8c5e5932d3dfc90c73418414/rpds_py-0.20.1-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:762703bdd2b30983c1d9e62b4c88664df4a8a4d5ec0e9253b0231171f18f6d75", size = 327194 },
+    { url = "https://files.pythonhosted.org/packages/68/11/d3f84c69de2b2086be3d6bd5e9d172825c096b13842ab7e5f8f39f06035b/rpds_py-0.20.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0b581f47257a9fce535c4567782a8976002d6b8afa2c39ff616edf87cbeff712", size = 318126 },
+    { url = "https://files.pythonhosted.org/packages/18/c0/13f1bce9c901511e5e4c0b77a99dbb946bb9a177ca88c6b480e9cb53e304/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:842c19a6ce894493563c3bd00d81d5100e8e57d70209e84d5491940fdb8b9e3a", size = 361119 },
+    { url = "https://files.pythonhosted.org/packages/06/31/3bd721575671f22a37476c2d7b9e34bfa5185bdcee09f7fedde3b29f3adb/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:42cbde7789f5c0bcd6816cb29808e36c01b960fb5d29f11e052215aa85497c93", size = 369532 },
+    { url = "https://files.pythonhosted.org/packages/20/22/3eeb0385f33251b4fd0f728e6a3801dc8acc05e714eb7867cefe635bf4ab/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6c8e9340ce5a52f95fa7d3b552b35c7e8f3874d74a03a8a69279fd5fca5dc751", size = 403703 },
+    { url = "https://files.pythonhosted.org/packages/10/e1/8dde6174e7ac5b9acd3269afca2e17719bc7e5088c68f44874d2ad9e4560/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8ba6f89cac95c0900d932c9efb7f0fb6ca47f6687feec41abcb1bd5e2bd45535", size = 429868 },
+    { url = "https://files.pythonhosted.org/packages/19/51/a3cc1a5238acfc2582033e8934d034301f9d4931b9bf7c7ccfabc4ca0880/rpds_py-0.20.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4a916087371afd9648e1962e67403c53f9c49ca47b9680adbeef79da3a7811b0", size = 360539 },
+    { url = "https://files.pythonhosted.org/packages/cd/8c/3c87471a44bd4114e2b0aec90f298f6caaac4e8db6af904d5dd2279f5c61/rpds_py-0.20.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:200a23239781f46149e6a415f1e870c5ef1e712939fe8fa63035cd053ac2638e", size = 382467 },
+    { url = "https://files.pythonhosted.org/packages/d0/9b/95073fe3e0f130e6d561e106818b6568ef1f2df3352e7f162ab912da837c/rpds_py-0.20.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:58b1d5dd591973d426cbb2da5e27ba0339209832b2f3315928c9790e13f159e8", size = 546669 },
+    { url = "https://files.pythonhosted.org/packages/de/4c/7ab3669e02bb06fedebcfd64d361b7168ba39dfdf385e4109440f2e7927b/rpds_py-0.20.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:6b73c67850ca7cae0f6c56f71e356d7e9fa25958d3e18a64927c2d930859b8e4", size = 549304 },
+    { url = "https://files.pythonhosted.org/packages/f1/e8/ad5da336cd42adbdafe0ecd40dcecdae01fd3d703c621c7637615a008d3a/rpds_py-0.20.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:d8761c3c891cc51e90bc9926d6d2f59b27beaf86c74622c8979380a29cc23ac3", size = 527637 },
+    { url = "https://files.pythonhosted.org/packages/02/f1/1b47b9e5b941c2659c9b7e4ef41b6f07385a6500c638fa10c066e4616ecb/rpds_py-0.20.1-cp311-none-win32.whl", hash = "sha256:cd945871335a639275eee904caef90041568ce3b42f402c6959b460d25ae8732", size = 200488 },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c751c1adfa31610055acfa1cc667cf2c2d7011a73070679c448cf5856905/rpds_py-0.20.1-cp311-none-win_amd64.whl", hash = "sha256:7e21b7031e17c6b0e445f42ccc77f79a97e2687023c5746bfb7a9e45e0921b84", size = 218475 },
+    { url = "https://files.pythonhosted.org/packages/e7/10/4e8dcc08b58a548098dbcee67a4888751a25be7a6dde0a83d4300df48bfa/rpds_py-0.20.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:36785be22066966a27348444b40389f8444671630063edfb1a2eb04318721e17", size = 329749 },
+    { url = "https://files.pythonhosted.org/packages/d2/e4/61144f3790e12fd89e6153d77f7915ad26779735fef8ee9c099cba6dfb4a/rpds_py-0.20.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:142c0a5124d9bd0e2976089484af5c74f47bd3298f2ed651ef54ea728d2ea42c", size = 321032 },
+    { url = "https://files.pythonhosted.org/packages/fa/e0/99205aabbf3be29ef6c58ef9b08feed51ba6532fdd47461245cb58dd9897/rpds_py-0.20.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbddc10776ca7ebf2a299c41a4dde8ea0d8e3547bfd731cb87af2e8f5bf8962d", size = 363931 },
+    { url = "https://files.pythonhosted.org/packages/ac/bd/bce2dddb518b13a7e77eed4be234c9af0c9c6d403d01c5e6ae8eb447ab62/rpds_py-0.20.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:15a842bb369e00295392e7ce192de9dcbf136954614124a667f9f9f17d6a216f", size = 373343 },
+    { url = "https://files.pythonhosted.org/packages/43/15/112b7c553066cb91264691ba7fb119579c440a0ae889da222fa6fc0d411a/rpds_py-0.20.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be5ef2f1fc586a7372bfc355986226484e06d1dc4f9402539872c8bb99e34b01", size = 406304 },
+    { url = "https://files.pythonhosted.org/packages/af/8d/2da52aef8ae5494a382b0c0025ba5b68f2952db0f2a4c7534580e8ca83cc/rpds_py-0.20.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbcf360c9e3399b056a238523146ea77eeb2a596ce263b8814c900263e46031a", size = 423022 },
+    { url = "https://files.pythonhosted.org/packages/c8/1b/f23015cb293927c93bdb4b94a48bfe77ad9d57359c75db51f0ff0cf482ff/rpds_py-0.20.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecd27a66740ffd621d20b9a2f2b5ee4129a56e27bfb9458a3bcc2e45794c96cb", size = 364937 },
+    { url = "https://files.pythonhosted.org/packages/7b/8b/6da8636b2ea2e2f709e56656e663b6a71ecd9a9f9d9dc21488aade122026/rpds_py-0.20.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0b937b2a1988f184a3e9e577adaa8aede21ec0b38320d6009e02bd026db04fa", size = 386301 },
+    { url = "https://files.pythonhosted.org/packages/20/af/2ae192797bffd0d6d558145b5a36e7245346ff3e44f6ddcb82f0eb8512d4/rpds_py-0.20.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6889469bfdc1eddf489729b471303739bf04555bb151fe8875931f8564309afc", size = 549452 },
+    { url = "https://files.pythonhosted.org/packages/07/dd/9f6520712a5108cd7d407c9db44a3d59011b385c58e320d58ebf67757a9e/rpds_py-0.20.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:19b73643c802f4eaf13d97f7855d0fb527fbc92ab7013c4ad0e13a6ae0ed23bd", size = 554370 },
+    { url = "https://files.pythonhosted.org/packages/5e/0e/b1bdc7ea0db0946d640ab8965146099093391bb5d265832994c47461e3c5/rpds_py-0.20.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3c6afcf2338e7f374e8edc765c79fbcb4061d02b15dd5f8f314a4af2bdc7feb5", size = 530940 },
+    { url = "https://files.pythonhosted.org/packages/ae/d3/ffe907084299484fab60a7955f7c0e8a295c04249090218c59437010f9f4/rpds_py-0.20.1-cp312-none-win32.whl", hash = "sha256:dc73505153798c6f74854aba69cc75953888cf9866465196889c7cdd351e720c", size = 203164 },
+    { url = "https://files.pythonhosted.org/packages/1f/ba/9cbb57423c4bfbd81c473913bebaed151ad4158ee2590a4e4b3e70238b48/rpds_py-0.20.1-cp312-none-win_amd64.whl", hash = "sha256:8bbe951244a838a51289ee53a6bae3a07f26d4e179b96fc7ddd3301caf0518eb", size = 220750 },
+    { url = "https://files.pythonhosted.org/packages/b5/01/fee2e1d1274c92fff04aa47d805a28d62c2aa971d1f49f5baea1c6e670d9/rpds_py-0.20.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:6ca91093a4a8da4afae7fe6a222c3b53ee4eef433ebfee4d54978a103435159e", size = 329359 },
+    { url = "https://files.pythonhosted.org/packages/b0/cf/4aeffb02b7090029d7aeecbffb9a10e1c80f6f56d7e9a30e15481dc4099c/rpds_py-0.20.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:b9c2fe36d1f758b28121bef29ed1dee9b7a2453e997528e7d1ac99b94892527c", size = 320543 },
+    { url = "https://files.pythonhosted.org/packages/17/69/85cf3429e9ccda684ba63ff36b5866d5f9451e921cc99819341e19880334/rpds_py-0.20.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f009c69bc8c53db5dfab72ac760895dc1f2bc1b62ab7408b253c8d1ec52459fc", size = 363107 },
+    { url = "https://files.pythonhosted.org/packages/ef/de/7df88dea9c3eeb832196d23b41f0f6fc5f9a2ee9b2080bbb1db8731ead9c/rpds_py-0.20.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:6740a3e8d43a32629bb9b009017ea5b9e713b7210ba48ac8d4cb6d99d86c8ee8", size = 372027 },
+    { url = "https://files.pythonhosted.org/packages/d1/b8/88675399d2038580743c570a809c43a900e7090edc6553f8ffb66b23c965/rpds_py-0.20.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:32b922e13d4c0080d03e7b62991ad7f5007d9cd74e239c4b16bc85ae8b70252d", size = 405031 },
+    { url = "https://files.pythonhosted.org/packages/e1/aa/cca639f6d17caf00bab51bdc70fcc0bdda3063e5662665c4fdf60443c474/rpds_py-0.20.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fe00a9057d100e69b4ae4a094203a708d65b0f345ed546fdef86498bf5390982", size = 422271 },
+    { url = "https://files.pythonhosted.org/packages/c4/07/bf8a949d2ec4626c285579c9d6b356c692325f1a4126e947736b416e1fc4/rpds_py-0.20.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:49fe9b04b6fa685bd39237d45fad89ba19e9163a1ccaa16611a812e682913496", size = 363625 },
+    { url = "https://files.pythonhosted.org/packages/11/f0/06675c6a58d6ce34547879138810eb9aab0c10e5607ea6c2e4dc56b703c8/rpds_py-0.20.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:aa7ac11e294304e615b43f8c441fee5d40094275ed7311f3420d805fde9b07b4", size = 385906 },
+    { url = "https://files.pythonhosted.org/packages/bf/ac/2d1f50374eb8e41030fad4e87f81751e1c39e3b5d4bee8c5618830d8a6ac/rpds_py-0.20.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6aa97af1558a9bef4025f8f5d8c60d712e0a3b13a2fe875511defc6ee77a1ab7", size = 549021 },
+    { url = "https://files.pythonhosted.org/packages/f7/d4/a7d70a7cc71df772eeadf4bce05e32e780a9fe44a511a5b091c7a85cb767/rpds_py-0.20.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:483b29f6f7ffa6af845107d4efe2e3fa8fb2693de8657bc1849f674296ff6a5a", size = 553800 },
+    { url = "https://files.pythonhosted.org/packages/87/81/dc30bc449ccba63ad23a0f6633486d4e0e6955f45f3715a130dacabd6ad0/rpds_py-0.20.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:37fe0f12aebb6a0e3e17bb4cd356b1286d2d18d2e93b2d39fe647138458b4bcb", size = 531076 },
+    { url = "https://files.pythonhosted.org/packages/50/80/fb62ab48f3b5cfe704ead6ad372da1922ddaa76397055e02eb507054c979/rpds_py-0.20.1-cp313-none-win32.whl", hash = "sha256:a624cc00ef2158e04188df5e3016385b9353638139a06fb77057b3498f794782", size = 202804 },
+    { url = "https://files.pythonhosted.org/packages/d9/30/a3391e76d0b3313f33bdedd394a519decae3a953d2943e3dabf80ae32447/rpds_py-0.20.1-cp313-none-win_amd64.whl", hash = "sha256:b71b8666eeea69d6363248822078c075bac6ed135faa9216aa85f295ff009b1e", size = 220502 },
+    { url = "https://files.pythonhosted.org/packages/53/ef/b1883734ea0cd9996de793cdc38c32a28143b04911d1e570090acd8a9162/rpds_py-0.20.1-cp38-cp38-macosx_10_12_x86_64.whl", hash = "sha256:5b48e790e0355865197ad0aca8cde3d8ede347831e1959e158369eb3493d2191", size = 327757 },
+    { url = "https://files.pythonhosted.org/packages/54/63/47d34dc4ddb3da73e78e10c9009dcf8edc42d355a221351c05c822c2a50b/rpds_py-0.20.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:3e310838a5801795207c66c73ea903deda321e6146d6f282e85fa7e3e4854804", size = 318785 },
+    { url = "https://files.pythonhosted.org/packages/f7/e1/d6323be4afbe3013f28725553b7bfa80b3f013f91678af258f579f8ea8f9/rpds_py-0.20.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2249280b870e6a42c0d972339e9cc22ee98730a99cd7f2f727549af80dd5a963", size = 361511 },
+    { url = "https://files.pythonhosted.org/packages/ab/d3/c40e4d9ecd571f0f50fe69bc53fe608d7b2c49b30738b480044990260838/rpds_py-0.20.1-cp38-cp38-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e79059d67bea28b53d255c1437b25391653263f0e69cd7dec170d778fdbca95e", size = 370201 },
+    { url = "https://files.pythonhosted.org/packages/f1/b6/96a4a9977a8a06c2c49d90aa571346aff1642abf15066a39a0b4817bf049/rpds_py-0.20.1-cp38-cp38-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2b431c777c9653e569986ecf69ff4a5dba281cded16043d348bf9ba505486f36", size = 403866 },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/702b52287949314b498a311f92b5ee0ba30c702a27e0e6b560e2da43b8d5/rpds_py-0.20.1-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:da584ff96ec95e97925174eb8237e32f626e7a1a97888cdd27ee2f1f24dd0ad8", size = 430163 },
+    { url = "https://files.pythonhosted.org/packages/c4/ce/af016c81fda833bf125b20d1677d816f230cad2ab189f46bcbfea3c7a375/rpds_py-0.20.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:02a0629ec053fc013808a85178524e3cb63a61dbc35b22499870194a63578fb9", size = 360776 },
+    { url = "https://files.pythonhosted.org/packages/08/a7/988e179c9bef55821abe41762228d65077e0570ca75c9efbcd1bc6e263b4/rpds_py-0.20.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fbf15aff64a163db29a91ed0868af181d6f68ec1a3a7d5afcfe4501252840bad", size = 383008 },
+    { url = "https://files.pythonhosted.org/packages/96/b0/e4077f7f1b9622112ae83254aedfb691490278793299bc06dcf54ec8c8e4/rpds_py-0.20.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:07924c1b938798797d60c6308fa8ad3b3f0201802f82e4a2c41bb3fafb44cc28", size = 546371 },
+    { url = "https://files.pythonhosted.org/packages/e4/5e/1d4dd08ec0352cfe516ea93ea1993c2f656f893c87dafcd9312bd07f65f7/rpds_py-0.20.1-cp38-cp38-musllinux_1_2_i686.whl", hash = "sha256:4a5a844f68776a7715ecb30843b453f07ac89bad393431efbf7accca3ef599c1", size = 549809 },
+    { url = "https://files.pythonhosted.org/packages/57/ac/a716b4729ff23ec034b7d2ff76a86e6f0753c4098401bdfdf55b2efe90e6/rpds_py-0.20.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:518d2ca43c358929bf08f9079b617f1c2ca6e8848f83c1225c88caeac46e6cbc", size = 528492 },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/a0b58a9ecef79918169eacdabd14eb4c5c86ce71184ed56b80c6eb425828/rpds_py-0.20.1-cp38-none-win32.whl", hash = "sha256:3aea7eed3e55119635a74bbeb80b35e776bafccb70d97e8ff838816c124539f1", size = 200512 },
+    { url = "https://files.pythonhosted.org/packages/5f/c3/222e25124283afc76c473fcd2c547e82ec57683fa31cb4d6c6eb44e5d57a/rpds_py-0.20.1-cp38-none-win_amd64.whl", hash = "sha256:7dca7081e9a0c3b6490a145593f6fe3173a94197f2cb9891183ef75e9d64c425", size = 218627 },
+    { url = "https://files.pythonhosted.org/packages/d6/87/e7e0fcbfdc0d0e261534bcc885f6ae6253095b972e32f8b8b1278c78a2a9/rpds_py-0.20.1-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:b41b6321805c472f66990c2849e152aff7bc359eb92f781e3f606609eac877ad", size = 327867 },
+    { url = "https://files.pythonhosted.org/packages/93/a0/17836b7961fc82586e9b818abdee2a27e2e605a602bb8c0d43f02092f8c2/rpds_py-0.20.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:0a90c373ea2975519b58dece25853dbcb9779b05cc46b4819cb1917e3b3215b6", size = 318893 },
+    { url = "https://files.pythonhosted.org/packages/dc/03/deb81d8ea3a8b974e7b03cfe8c8c26616ef8f4980dd430d8dd0a2f1b4d8e/rpds_py-0.20.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16d4477bcb9fbbd7b5b0e4a5d9b493e42026c0bf1f06f723a9353f5153e75d30", size = 361664 },
+    { url = "https://files.pythonhosted.org/packages/16/49/d9938603731745c7b6babff97ca61ff3eb4619e7128b5ab0111ad4e91d6d/rpds_py-0.20.1-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:84b8382a90539910b53a6307f7c35697bc7e6ffb25d9c1d4e998a13e842a5e83", size = 369796 },
+    { url = "https://files.pythonhosted.org/packages/87/d2/480b36c69cdc373853401b6aab6a281cf60f6d72b1545d82c0d23d9dd77c/rpds_py-0.20.1-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4888e117dd41b9d34194d9e31631af70d3d526efc363085e3089ab1a62c32ed1", size = 403860 },
+    { url = "https://files.pythonhosted.org/packages/31/7c/f6d909cb57761293308dbef14f1663d84376f2e231892a10aafc57b42037/rpds_py-0.20.1-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5265505b3d61a0f56618c9b941dc54dc334dc6e660f1592d112cd103d914a6db", size = 430793 },
+    { url = "https://files.pythonhosted.org/packages/d4/62/c9bd294c4b5f84d9cc2c387b548ae53096ad7e71ac5b02b6310e9dc85aa4/rpds_py-0.20.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e75ba609dba23f2c95b776efb9dd3f0b78a76a151e96f96cc5b6b1b0004de66f", size = 360927 },
+    { url = "https://files.pythonhosted.org/packages/c1/a7/15d927d83a44da8307a432b1cac06284b6657706d099a98cc99fec34ad51/rpds_py-0.20.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1791ff70bc975b098fe6ecf04356a10e9e2bd7dc21fa7351c1742fdeb9b4966f", size = 382660 },
+    { url = "https://files.pythonhosted.org/packages/4c/28/0630719c18456238bb07d59c4302fed50a13aa8035ec23dbfa80d116f9bc/rpds_py-0.20.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:d126b52e4a473d40232ec2052a8b232270ed1f8c9571aaf33f73a14cc298c24f", size = 546888 },
+    { url = "https://files.pythonhosted.org/packages/b9/75/3c9bda11b9c15d680b315f898af23825159314d4b56568f24b53ace8afcd/rpds_py-0.20.1-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c14937af98c4cc362a1d4374806204dd51b1e12dded1ae30645c298e5a5c4cb1", size = 550088 },
+    { url = "https://files.pythonhosted.org/packages/70/f1/8fe7d04c194218171220a412057429defa9e2da785de0777c4d39309337e/rpds_py-0.20.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:3d089d0b88996df627693639d123c8158cff41c0651f646cd8fd292c7da90eaf", size = 528270 },
+    { url = "https://files.pythonhosted.org/packages/d6/62/41b0020f4b00af042b008e679dbe25a2f5bce655139a81f8b812f9068e52/rpds_py-0.20.1-cp39-none-win32.whl", hash = "sha256:653647b8838cf83b2e7e6a0364f49af96deec64d2a6578324db58380cff82aca", size = 200658 },
+    { url = "https://files.pythonhosted.org/packages/05/01/e64bb8889f2dcc951e53de33d8b8070456397ae4e10edc35e6cb9908f5c8/rpds_py-0.20.1-cp39-none-win_amd64.whl", hash = "sha256:fa41a64ac5b08b292906e248549ab48b69c5428f3987b09689ab2441f267d04d", size = 218883 },
+    { url = "https://files.pythonhosted.org/packages/b6/fa/7959429e69569d0f6e7d27f80451402da0409349dd2b07f6bcbdd5fad2d3/rpds_py-0.20.1-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:7a07ced2b22f0cf0b55a6a510078174c31b6d8544f3bc00c2bcee52b3d613f74", size = 328209 },
+    { url = "https://files.pythonhosted.org/packages/25/97/5dfdb091c30267ff404d2fd9e70c7a6d6ffc65ca77fffe9456e13b719066/rpds_py-0.20.1-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:68cb0a499f2c4a088fd2f521453e22ed3527154136a855c62e148b7883b99f9a", size = 319499 },
+    { url = "https://files.pythonhosted.org/packages/7c/98/cf2608722400f5f9bb4c82aa5ac09026f3ac2ebea9d4059d3533589ed0b6/rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fa3060d885657abc549b2a0f8e1b79699290e5d83845141717c6c90c2df38311", size = 361795 },
+    { url = "https://files.pythonhosted.org/packages/89/de/0e13dd43c785c60e63933e96fbddda0b019df6862f4d3019bb49c3861131/rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:95f3b65d2392e1c5cec27cff08fdc0080270d5a1a4b2ea1d51d5f4a2620ff08d", size = 370604 },
+    { url = "https://files.pythonhosted.org/packages/8a/fc/fe3c83c77f82b8059eeec4e998064913d66212b69b3653df48f58ad33d3d/rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2cc3712a4b0b76a1d45a9302dd2f53ff339614b1c29603a911318f2357b04dd2", size = 404177 },
+    { url = "https://files.pythonhosted.org/packages/94/30/5189518bfb80a41f664daf32b46645c7fbdcc89028a0f1bfa82e806e0fbb/rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5d4eea0761e37485c9b81400437adb11c40e13ef513375bbd6973e34100aeb06", size = 430108 },
+    { url = "https://files.pythonhosted.org/packages/67/0e/6f069feaff5c298375cd8c55e00ecd9bd79c792ce0893d39448dc0097857/rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f5179583d7a6cdb981151dd349786cbc318bab54963a192692d945dd3f6435d", size = 361184 },
+    { url = "https://files.pythonhosted.org/packages/27/9f/ce3e2ae36f392c3ef1988c06e9e0b4c74f64267dad7c223003c34da11adb/rpds_py-0.20.1-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fbb0ffc754490aff6dabbf28064be47f0f9ca0b9755976f945214965b3ace7e", size = 384140 },
+    { url = "https://files.pythonhosted.org/packages/5f/d5/89d44504d0bc7a1135062cb520a17903ff002f458371b8d9160af3b71e52/rpds_py-0.20.1-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:a94e52537a0e0a85429eda9e49f272ada715506d3b2431f64b8a3e34eb5f3e75", size = 546589 },
+    { url = "https://files.pythonhosted.org/packages/8f/8f/e1c2db4fcca3947d9a28ec9553700b4dc8038f0eff575f579e75885b0661/rpds_py-0.20.1-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:92b68b79c0da2a980b1c4197e56ac3dd0c8a149b4603747c4378914a68706979", size = 550059 },
+    { url = "https://files.pythonhosted.org/packages/67/29/00a9e986df36721b5def82fff60995c1ee8827a7d909a6ec8929fb4cc668/rpds_py-0.20.1-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:93da1d3db08a827eda74356f9f58884adb254e59b6664f64cc04cdff2cc19b0d", size = 529131 },
+    { url = "https://files.pythonhosted.org/packages/a3/32/95364440560ec476b19c6a2704259e710c223bf767632ebaa72cc2a1760f/rpds_py-0.20.1-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:754bbed1a4ca48479e9d4182a561d001bbf81543876cdded6f695ec3d465846b", size = 219677 },
+    { url = "https://files.pythonhosted.org/packages/ed/bf/ad8492e972c90a3d48a38e2b5095c51a8399d5b57e83f2d5d1649490f72b/rpds_py-0.20.1-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:ca449520e7484534a2a44faf629362cae62b660601432d04c482283c47eaebab", size = 328046 },
+    { url = "https://files.pythonhosted.org/packages/75/fd/84f42386165d6d555acb76c6d39c90b10c9dcf25116daf4f48a0a9d6867a/rpds_py-0.20.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:9c4cb04a16b0f199a8c9bf807269b2f63b7b5b11425e4a6bd44bd6961d28282c", size = 319306 },
+    { url = "https://files.pythonhosted.org/packages/6c/8a/abcd5119a0573f9588ad71a3fde3c07ddd1d1393cfee15a6ba7495c256f1/rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63804105143c7e24cee7db89e37cb3f3941f8e80c4379a0b355c52a52b6780", size = 362558 },
+    { url = "https://files.pythonhosted.org/packages/9d/65/1c2bb10afd4bd32800227a658ae9097bc1d08a4e5048a57a9bd2efdf6306/rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:55cd1fa4ecfa6d9f14fbd97ac24803e6f73e897c738f771a9fe038f2f11ff07c", size = 370811 },
+    { url = "https://files.pythonhosted.org/packages/6c/ee/f4bab2b9e51ced30351cfd210647885391463ae682028c79760e7db28e4e/rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f8f741b6292c86059ed175d80eefa80997125b7c478fb8769fd9ac8943a16c0", size = 404660 },
+    { url = "https://files.pythonhosted.org/packages/48/0f/9d04d0939682f0c97be827fc51ff986555ffb573e6781bd5132441f0ce25/rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0fc212779bf8411667234b3cdd34d53de6c2b8b8b958e1e12cb473a5f367c338", size = 430490 },
+    { url = "https://files.pythonhosted.org/packages/0d/f2/e9b90fd8416d59941b6a12f2c2e1d898b63fd092f5a7a6f98236cb865764/rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0ad56edabcdb428c2e33bbf24f255fe2b43253b7d13a2cdbf05de955217313e6", size = 361448 },
+    { url = "https://files.pythonhosted.org/packages/0b/83/1cc776dce7bedb17d6f4ea62eafccee8a57a4678f4fac414ab69fb9b6b0b/rpds_py-0.20.1-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:0a3a1e9ee9728b2c1734f65d6a1d376c6f2f6fdcc13bb007a08cc4b1ff576dc5", size = 383681 },
+    { url = "https://files.pythonhosted.org/packages/17/5c/e0cdd6b0a8373fdef3667af2778dd9ff3abf1bbb9c7bd92c603c91440eb0/rpds_py-0.20.1-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:e13de156137b7095442b288e72f33503a469aa1980ed856b43c353ac86390519", size = 546203 },
+    { url = "https://files.pythonhosted.org/packages/1b/a8/81fc9cbc01e7ef6d10652aedc1de4e8473934773e2808ba49094e03575df/rpds_py-0.20.1-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:07f59760ef99f31422c49038964b31c4dfcfeb5d2384ebfc71058a7c9adae2d2", size = 549855 },
+    { url = "https://files.pythonhosted.org/packages/b3/87/99648693d3c1bbce088119bc61ecaab62e5f9c713894edc604ffeca5ae88/rpds_py-0.20.1-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:59240685e7da61fb78f65a9f07f8108e36a83317c53f7b276b4175dc44151684", size = 528625 },
+    { url = "https://files.pythonhosted.org/packages/05/c3/10c68a08849f1fa45d205e54141fa75d316013e3d701ef01770ee1220bb8/rpds_py-0.20.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:83cba698cfb3c2c5a7c3c6bac12fe6c6a51aae69513726be6411076185a8b24a", size = 219991 },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.22.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.9'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/01/80/cce854d0921ff2f0a9fa831ba3ad3c65cee3a46711addf39a2af52df2cfd/rpds_py-0.22.3.tar.gz", hash = "sha256:e32fee8ab45d3c2db6da19a5323bc3362237c8b653c70194414b892fd06a080d", size = 26771 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/42/2a/ead1d09e57449b99dcc190d8d2323e3a167421d8f8fdf0f217c6f6befe47/rpds_py-0.22.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:6c7b99ca52c2c1752b544e310101b98a659b720b21db00e65edca34483259967", size = 359514 },
+    { url = "https://files.pythonhosted.org/packages/8f/7e/1254f406b7793b586c68e217a6a24ec79040f85e030fff7e9049069284f4/rpds_py-0.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:be2eb3f2495ba669d2a985f9b426c1797b7d48d6963899276d22f23e33d47e37", size = 349031 },
+    { url = "https://files.pythonhosted.org/packages/aa/da/17c6a2c73730d426df53675ff9cc6653ac7a60b6438d03c18e1c822a576a/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70eb60b3ae9245ddea20f8a4190bd79c705a22f8028aaf8bbdebe4716c3fab24", size = 381485 },
+    { url = "https://files.pythonhosted.org/packages/aa/13/2dbacd820466aa2a3c4b747afb18d71209523d353cf865bf8f4796c969ea/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4041711832360a9b75cfb11b25a6a97c8fb49c07b8bd43d0d02b45d0b499a4ff", size = 386794 },
+    { url = "https://files.pythonhosted.org/packages/6d/62/96905d0a35ad4e4bc3c098b2f34b2e7266e211d08635baa690643d2227be/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64607d4cbf1b7e3c3c8a14948b99345eda0e161b852e122c6bb71aab6d1d798c", size = 423523 },
+    { url = "https://files.pythonhosted.org/packages/eb/1b/d12770f2b6a9fc2c3ec0d810d7d440f6d465ccd8b7f16ae5385952c28b89/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e69b0a0e2537f26d73b4e43ad7bc8c8efb39621639b4434b76a3de50c6966e", size = 446695 },
+    { url = "https://files.pythonhosted.org/packages/4d/cf/96f1fd75512a017f8e07408b6d5dbeb492d9ed46bfe0555544294f3681b3/rpds_py-0.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc27863442d388870c1809a87507727b799c8460573cfbb6dc0eeaef5a11b5ec", size = 381959 },
+    { url = "https://files.pythonhosted.org/packages/ab/f0/d1c5b501c8aea85aeb938b555bfdf7612110a2f8cdc21ae0482c93dd0c24/rpds_py-0.22.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e79dd39f1e8c3504be0607e5fc6e86bb60fe3584bec8b782578c3b0fde8d932c", size = 410420 },
+    { url = "https://files.pythonhosted.org/packages/33/3b/45b6c58fb6aad5a569ae40fb890fc494c6b02203505a5008ee6dc68e65f7/rpds_py-0.22.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e0fa2d4ec53dc51cf7d3bb22e0aa0143966119f42a0c3e4998293a3dd2856b09", size = 557620 },
+    { url = "https://files.pythonhosted.org/packages/83/62/3fdd2d3d47bf0bb9b931c4c73036b4ab3ec77b25e016ae26fab0f02be2af/rpds_py-0.22.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fda7cb070f442bf80b642cd56483b5548e43d366fe3f39b98e67cce780cded00", size = 584202 },
+    { url = "https://files.pythonhosted.org/packages/04/f2/5dced98b64874b84ca824292f9cee2e3f30f3bcf231d15a903126684f74d/rpds_py-0.22.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cff63a0272fcd259dcc3be1657b07c929c466b067ceb1c20060e8d10af56f5bf", size = 552787 },
+    { url = "https://files.pythonhosted.org/packages/67/13/2273dea1204eda0aea0ef55145da96a9aa28b3f88bb5c70e994f69eda7c3/rpds_py-0.22.3-cp310-cp310-win32.whl", hash = "sha256:9bd7228827ec7bb817089e2eb301d907c0d9827a9e558f22f762bb690b131652", size = 220088 },
+    { url = "https://files.pythonhosted.org/packages/4e/80/8c8176b67ad7f4a894967a7a4014ba039626d96f1d4874d53e409b58d69f/rpds_py-0.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:9beeb01d8c190d7581a4d59522cd3d4b6887040dcfc744af99aa59fef3e041a8", size = 231737 },
+    { url = "https://files.pythonhosted.org/packages/15/ad/8d1ddf78f2805a71253fcd388017e7b4a0615c22c762b6d35301fef20106/rpds_py-0.22.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d20cfb4e099748ea39e6f7b16c91ab057989712d31761d3300d43134e26e165f", size = 359773 },
+    { url = "https://files.pythonhosted.org/packages/c8/75/68c15732293a8485d79fe4ebe9045525502a067865fa4278f178851b2d87/rpds_py-0.22.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:68049202f67380ff9aa52f12e92b1c30115f32e6895cd7198fa2a7961621fc5a", size = 349214 },
+    { url = "https://files.pythonhosted.org/packages/3c/4c/7ce50f3070083c2e1b2bbd0fb7046f3da55f510d19e283222f8f33d7d5f4/rpds_py-0.22.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb4f868f712b2dd4bcc538b0a0c1f63a2b1d584c925e69a224d759e7070a12d5", size = 380477 },
+    { url = "https://files.pythonhosted.org/packages/9a/e9/835196a69cb229d5c31c13b8ae603bd2da9a6695f35fe4270d398e1db44c/rpds_py-0.22.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bc51abd01f08117283c5ebf64844a35144a0843ff7b2983e0648e4d3d9f10dbb", size = 386171 },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/33fc4eba6683db71e91e6d594a2cf3a8fbceb5316629f0477f7ece5e3f75/rpds_py-0.22.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f3cec041684de9a4684b1572fe28c7267410e02450f4561700ca5a3bc6695a2", size = 422676 },
+    { url = "https://files.pythonhosted.org/packages/37/47/2e82d58f8046a98bb9497a8319604c92b827b94d558df30877c4b3c6ccb3/rpds_py-0.22.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7ef9d9da710be50ff6809fed8f1963fecdfecc8b86656cadfca3bc24289414b0", size = 446152 },
+    { url = "https://files.pythonhosted.org/packages/e1/78/79c128c3e71abbc8e9739ac27af11dc0f91840a86fce67ff83c65d1ba195/rpds_py-0.22.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59f4a79c19232a5774aee369a0c296712ad0e77f24e62cad53160312b1c1eaa1", size = 381300 },
+    { url = "https://files.pythonhosted.org/packages/c9/5b/2e193be0e8b228c1207f31fa3ea79de64dadb4f6a4833111af8145a6bc33/rpds_py-0.22.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a60bce91f81ddaac922a40bbb571a12c1070cb20ebd6d49c48e0b101d87300d", size = 409636 },
+    { url = "https://files.pythonhosted.org/packages/c2/3f/687c7100b762d62186a1c1100ffdf99825f6fa5ea94556844bbbd2d0f3a9/rpds_py-0.22.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e89391e6d60251560f0a8f4bd32137b077a80d9b7dbe6d5cab1cd80d2746f648", size = 556708 },
+    { url = "https://files.pythonhosted.org/packages/8c/a2/c00cbc4b857e8b3d5e7f7fc4c81e23afd8c138b930f4f3ccf9a41a23e9e4/rpds_py-0.22.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e3fb866d9932a3d7d0c82da76d816996d1667c44891bd861a0f97ba27e84fc74", size = 583554 },
+    { url = "https://files.pythonhosted.org/packages/d0/08/696c9872cf56effdad9ed617ac072f6774a898d46b8b8964eab39ec562d2/rpds_py-0.22.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1352ae4f7c717ae8cba93421a63373e582d19d55d2ee2cbb184344c82d2ae55a", size = 552105 },
+    { url = "https://files.pythonhosted.org/packages/18/1f/4df560be1e994f5adf56cabd6c117e02de7c88ee238bb4ce03ed50da9d56/rpds_py-0.22.3-cp311-cp311-win32.whl", hash = "sha256:b0b4136a252cadfa1adb705bb81524eee47d9f6aab4f2ee4fa1e9d3cd4581f64", size = 220199 },
+    { url = "https://files.pythonhosted.org/packages/b8/1b/c29b570bc5db8237553002788dc734d6bd71443a2ceac2a58202ec06ef12/rpds_py-0.22.3-cp311-cp311-win_amd64.whl", hash = "sha256:8bd7c8cfc0b8247c8799080fbff54e0b9619e17cdfeb0478ba7295d43f635d7c", size = 231775 },
+    { url = "https://files.pythonhosted.org/packages/75/47/3383ee3bd787a2a5e65a9b9edc37ccf8505c0a00170e3a5e6ea5fbcd97f7/rpds_py-0.22.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:27e98004595899949bd7a7b34e91fa7c44d7a97c40fcaf1d874168bb652ec67e", size = 352334 },
+    { url = "https://files.pythonhosted.org/packages/40/14/aa6400fa8158b90a5a250a77f2077c0d0cd8a76fce31d9f2b289f04c6dec/rpds_py-0.22.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1978d0021e943aae58b9b0b196fb4895a25cc53d3956b8e35e0b7682eefb6d56", size = 342111 },
+    { url = "https://files.pythonhosted.org/packages/7d/06/395a13bfaa8a28b302fb433fb285a67ce0ea2004959a027aea8f9c52bad4/rpds_py-0.22.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:655ca44a831ecb238d124e0402d98f6212ac527a0ba6c55ca26f616604e60a45", size = 384286 },
+    { url = "https://files.pythonhosted.org/packages/43/52/d8eeaffab047e6b7b7ef7f00d5ead074a07973968ffa2d5820fa131d7852/rpds_py-0.22.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:feea821ee2a9273771bae61194004ee2fc33f8ec7db08117ef9147d4bbcbca8e", size = 391739 },
+    { url = "https://files.pythonhosted.org/packages/83/31/52dc4bde85c60b63719610ed6f6d61877effdb5113a72007679b786377b8/rpds_py-0.22.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22bebe05a9ffc70ebfa127efbc429bc26ec9e9b4ee4d15a740033efda515cf3d", size = 427306 },
+    { url = "https://files.pythonhosted.org/packages/70/d5/1bab8e389c2261dba1764e9e793ed6830a63f830fdbec581a242c7c46bda/rpds_py-0.22.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3af6e48651c4e0d2d166dc1b033b7042ea3f871504b6805ba5f4fe31581d8d38", size = 442717 },
+    { url = "https://files.pythonhosted.org/packages/82/a1/a45f3e30835b553379b3a56ea6c4eb622cf11e72008229af840e4596a8ea/rpds_py-0.22.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e67ba3c290821343c192f7eae1d8fd5999ca2dc99994114643e2f2d3e6138b15", size = 385721 },
+    { url = "https://files.pythonhosted.org/packages/a6/27/780c942de3120bdd4d0e69583f9c96e179dfff082f6ecbb46b8d6488841f/rpds_py-0.22.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:02fbb9c288ae08bcb34fb41d516d5eeb0455ac35b5512d03181d755d80810059", size = 415824 },
+    { url = "https://files.pythonhosted.org/packages/94/0b/aa0542ca88ad20ea719b06520f925bae348ea5c1fdf201b7e7202d20871d/rpds_py-0.22.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f56a6b404f74ab372da986d240e2e002769a7d7102cc73eb238a4f72eec5284e", size = 561227 },
+    { url = "https://files.pythonhosted.org/packages/0d/92/3ed77d215f82c8f844d7f98929d56cc321bb0bcfaf8f166559b8ec56e5f1/rpds_py-0.22.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0a0461200769ab3b9ab7e513f6013b7a97fdeee41c29b9db343f3c5a8e2b9e61", size = 587424 },
+    { url = "https://files.pythonhosted.org/packages/09/42/cacaeb047a22cab6241f107644f230e2935d4efecf6488859a7dd82fc47d/rpds_py-0.22.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8633e471c6207a039eff6aa116e35f69f3156b3989ea3e2d755f7bc41754a4a7", size = 555953 },
+    { url = "https://files.pythonhosted.org/packages/e6/52/c921dc6d5f5d45b212a456c1f5b17df1a471127e8037eb0972379e39dff4/rpds_py-0.22.3-cp312-cp312-win32.whl", hash = "sha256:593eba61ba0c3baae5bc9be2f5232430453fb4432048de28399ca7376de9c627", size = 221339 },
+    { url = "https://files.pythonhosted.org/packages/f2/c7/f82b5be1e8456600395366f86104d1bd8d0faed3802ad511ef6d60c30d98/rpds_py-0.22.3-cp312-cp312-win_amd64.whl", hash = "sha256:d115bffdd417c6d806ea9069237a4ae02f513b778e3789a359bc5856e0404cc4", size = 235786 },
+    { url = "https://files.pythonhosted.org/packages/d0/bf/36d5cc1f2c609ae6e8bf0fc35949355ca9d8790eceb66e6385680c951e60/rpds_py-0.22.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ea7433ce7e4bfc3a85654aeb6747babe3f66eaf9a1d0c1e7a4435bbdf27fea84", size = 351657 },
+    { url = "https://files.pythonhosted.org/packages/24/2a/f1e0fa124e300c26ea9382e59b2d582cba71cedd340f32d1447f4f29fa4e/rpds_py-0.22.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6dd9412824c4ce1aca56c47b0991e65bebb7ac3f4edccfd3f156150c96a7bf25", size = 341829 },
+    { url = "https://files.pythonhosted.org/packages/cf/c2/0da1231dd16953845bed60d1a586fcd6b15ceaeb965f4d35cdc71f70f606/rpds_py-0.22.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20070c65396f7373f5df4005862fa162db5d25d56150bddd0b3e8214e8ef45b4", size = 384220 },
+    { url = "https://files.pythonhosted.org/packages/c7/73/a4407f4e3a00a9d4b68c532bf2d873d6b562854a8eaff8faa6133b3588ec/rpds_py-0.22.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0b09865a9abc0ddff4e50b5ef65467cd94176bf1e0004184eb915cbc10fc05c5", size = 391009 },
+    { url = "https://files.pythonhosted.org/packages/a9/c3/04b7353477ab360fe2563f5f0b176d2105982f97cd9ae80a9c5a18f1ae0f/rpds_py-0.22.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3453e8d41fe5f17d1f8e9c383a7473cd46a63661628ec58e07777c2fff7196dc", size = 426989 },
+    { url = "https://files.pythonhosted.org/packages/8d/e6/e4b85b722bcf11398e17d59c0f6049d19cd606d35363221951e6d625fcb0/rpds_py-0.22.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f5d36399a1b96e1a5fdc91e0522544580dbebeb1f77f27b2b0ab25559e103b8b", size = 441544 },
+    { url = "https://files.pythonhosted.org/packages/27/fc/403e65e56f65fff25f2973216974976d3f0a5c3f30e53758589b6dc9b79b/rpds_py-0.22.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:009de23c9c9ee54bf11303a966edf4d9087cd43a6003672e6aa7def643d06518", size = 385179 },
+    { url = "https://files.pythonhosted.org/packages/57/9b/2be9ff9700d664d51fd96b33d6595791c496d2778cb0b2a634f048437a55/rpds_py-0.22.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1aef18820ef3e4587ebe8b3bc9ba6e55892a6d7b93bac6d29d9f631a3b4befbd", size = 415103 },
+    { url = "https://files.pythonhosted.org/packages/bb/a5/03c2ad8ca10994fcf22dd2150dd1d653bc974fa82d9a590494c84c10c641/rpds_py-0.22.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f60bd8423be1d9d833f230fdbccf8f57af322d96bcad6599e5a771b151398eb2", size = 560916 },
+    { url = "https://files.pythonhosted.org/packages/ba/2e/be4fdfc8b5b576e588782b56978c5b702c5a2307024120d8aeec1ab818f0/rpds_py-0.22.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:62d9cfcf4948683a18a9aff0ab7e1474d407b7bab2ca03116109f8464698ab16", size = 587062 },
+    { url = "https://files.pythonhosted.org/packages/67/e0/2034c221937709bf9c542603d25ad43a68b4b0a9a0c0b06a742f2756eb66/rpds_py-0.22.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9253fc214112405f0afa7db88739294295f0e08466987f1d70e29930262b4c8f", size = 555734 },
+    { url = "https://files.pythonhosted.org/packages/ea/ce/240bae07b5401a22482b58e18cfbabaa392409b2797da60223cca10d7367/rpds_py-0.22.3-cp313-cp313-win32.whl", hash = "sha256:fb0ba113b4983beac1a2eb16faffd76cb41e176bf58c4afe3e14b9c681f702de", size = 220663 },
+    { url = "https://files.pythonhosted.org/packages/cb/f0/d330d08f51126330467edae2fa4efa5cec8923c87551a79299380fdea30d/rpds_py-0.22.3-cp313-cp313-win_amd64.whl", hash = "sha256:c58e2339def52ef6b71b8f36d13c3688ea23fa093353f3a4fee2556e62086ec9", size = 235503 },
+    { url = "https://files.pythonhosted.org/packages/f7/c4/dbe1cc03df013bf2feb5ad00615038050e7859f381e96fb5b7b4572cd814/rpds_py-0.22.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f82a116a1d03628a8ace4859556fb39fd1424c933341a08ea3ed6de1edb0283b", size = 347698 },
+    { url = "https://files.pythonhosted.org/packages/a4/3a/684f66dd6b0f37499cad24cd1c0e523541fd768576fa5ce2d0a8799c3cba/rpds_py-0.22.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3dfcbc95bd7992b16f3f7ba05af8a64ca694331bd24f9157b49dadeeb287493b", size = 337330 },
+    { url = "https://files.pythonhosted.org/packages/82/eb/e022c08c2ce2e8f7683baa313476492c0e2c1ca97227fe8a75d9f0181e95/rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59259dc58e57b10e7e18ce02c311804c10c5a793e6568f8af4dead03264584d1", size = 380022 },
+    { url = "https://files.pythonhosted.org/packages/e4/21/5a80e653e4c86aeb28eb4fea4add1f72e1787a3299687a9187105c3ee966/rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5725dd9cc02068996d4438d397e255dcb1df776b7ceea3b9cb972bdb11260a83", size = 390754 },
+    { url = "https://files.pythonhosted.org/packages/37/a4/d320a04ae90f72d080b3d74597074e62be0a8ecad7d7321312dfe2dc5a6a/rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99b37292234e61325e7a5bb9689e55e48c3f5f603af88b1642666277a81f1fbd", size = 423840 },
+    { url = "https://files.pythonhosted.org/packages/87/70/674dc47d93db30a6624279284e5631be4c3a12a0340e8e4f349153546728/rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:27b1d3b3915a99208fee9ab092b8184c420f2905b7d7feb4aeb5e4a9c509b8a1", size = 438970 },
+    { url = "https://files.pythonhosted.org/packages/3f/64/9500f4d66601d55cadd21e90784cfd5d5f4560e129d72e4339823129171c/rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f612463ac081803f243ff13cccc648578e2279295048f2a8d5eb430af2bae6e3", size = 383146 },
+    { url = "https://files.pythonhosted.org/packages/4d/45/630327addb1d17173adcf4af01336fd0ee030c04798027dfcb50106001e0/rpds_py-0.22.3-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f73d3fef726b3243a811121de45193c0ca75f6407fe66f3f4e183c983573e130", size = 408294 },
+    { url = "https://files.pythonhosted.org/packages/5f/ef/8efb3373cee54ea9d9980b772e5690a0c9e9214045a4e7fa35046e399fee/rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3f21f0495edea7fdbaaa87e633a8689cd285f8f4af5c869f27bc8074638ad69c", size = 556345 },
+    { url = "https://files.pythonhosted.org/packages/54/01/151d3b9ef4925fc8f15bfb131086c12ec3c3d6dd4a4f7589c335bf8e85ba/rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1e9663daaf7a63ceccbbb8e3808fe90415b0757e2abddbfc2e06c857bf8c5e2b", size = 582292 },
+    { url = "https://files.pythonhosted.org/packages/30/89/35fc7a6cdf3477d441c7aca5e9bbf5a14e0f25152aed7f63f4e0b141045d/rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a76e42402542b1fae59798fab64432b2d015ab9d0c8c47ba7addddbaf7952333", size = 553855 },
+    { url = "https://files.pythonhosted.org/packages/8f/e0/830c02b2457c4bd20a8c5bb394d31d81f57fbefce2dbdd2e31feff4f7003/rpds_py-0.22.3-cp313-cp313t-win32.whl", hash = "sha256:69803198097467ee7282750acb507fba35ca22cc3b85f16cf45fb01cb9097730", size = 219100 },
+    { url = "https://files.pythonhosted.org/packages/f8/30/7ac943f69855c2db77407ae363484b915d861702dbba1aa82d68d57f42be/rpds_py-0.22.3-cp313-cp313t-win_amd64.whl", hash = "sha256:f5cf2a0c2bdadf3791b5c205d55a37a54025c6e18a71c71f82bb536cf9a454bf", size = 233794 },
+    { url = "https://files.pythonhosted.org/packages/db/0f/a8ad17ddac7c880f48d5da50733dd25bfc35ba2be1bec9f23453e8c7a123/rpds_py-0.22.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:378753b4a4de2a7b34063d6f95ae81bfa7b15f2c1a04a9518e8644e81807ebea", size = 359735 },
+    { url = "https://files.pythonhosted.org/packages/0c/41/430903669397ea3ee76865e0b53ea236e8dc0ffbecde47b2c4c783ad6759/rpds_py-0.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3445e07bf2e8ecfeef6ef67ac83de670358abf2996916039b16a218e3d95e97e", size = 348724 },
+    { url = "https://files.pythonhosted.org/packages/c9/5c/3496f4f0ee818297544f2d5f641c49dde8ae156392e6834b79c0609ba006/rpds_py-0.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b2513ba235829860b13faa931f3b6846548021846ac808455301c23a101689d", size = 381782 },
+    { url = "https://files.pythonhosted.org/packages/b6/dc/db0523ce0cd16ce579185cc9aa9141992de956d0a9c469ecfd1fb5d54ddc/rpds_py-0.22.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eaf16ae9ae519a0e237a0f528fd9f0197b9bb70f40263ee57ae53c2b8d48aeb3", size = 387036 },
+    { url = "https://files.pythonhosted.org/packages/85/2a/9525c2427d2c257f877348918136a5d4e1b945c205a256e53bec61e54551/rpds_py-0.22.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:583f6a1993ca3369e0f80ba99d796d8e6b1a3a2a442dd4e1a79e652116413091", size = 424566 },
+    { url = "https://files.pythonhosted.org/packages/b9/1c/f8c012a39794b84069635709f559c0309103d5d74b3f5013916e6ca4f174/rpds_py-0.22.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4617e1915a539a0d9a9567795023de41a87106522ff83fbfaf1f6baf8e85437e", size = 447203 },
+    { url = "https://files.pythonhosted.org/packages/93/f5/c1c772364570d35b98ba64f36ec90c3c6d0b932bc4d8b9b4efef6dc64b07/rpds_py-0.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c150c7a61ed4a4f4955a96626574e9baf1adf772c2fb61ef6a5027e52803543", size = 382283 },
+    { url = "https://files.pythonhosted.org/packages/10/06/f94f61313f94fc75c3c3aa74563f80bbd990e5b25a7c1a38cee7d5d0309b/rpds_py-0.22.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fa4331c200c2521512595253f5bb70858b90f750d39b8cbfd67465f8d1b596d", size = 410022 },
+    { url = "https://files.pythonhosted.org/packages/3f/b0/37ab416a9528419920dfb64886c220f58fcbd66b978e0a91b66e9ee9a993/rpds_py-0.22.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:214b7a953d73b5e87f0ebece4a32a5bd83c60a3ecc9d4ec8f1dca968a2d91e99", size = 557817 },
+    { url = "https://files.pythonhosted.org/packages/2c/5d/9daa18adcd676dd3b2817c8a7cec3f3ebeeb0ce0d05a1b63bf994fc5114f/rpds_py-0.22.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f47ad3d5f3258bd7058d2d506852217865afefe6153a36eb4b6928758041d831", size = 585099 },
+    { url = "https://files.pythonhosted.org/packages/41/3f/ad4e58035d3f848410aa3d59857b5f238bafab81c8b4a844281f80445d62/rpds_py-0.22.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f276b245347e6e36526cbd4a266a417796fc531ddf391e43574cf6466c492520", size = 552818 },
+    { url = "https://files.pythonhosted.org/packages/b8/19/123acae8f4cab3c9463097c3ced3cc87c46f405056e249c874940e045309/rpds_py-0.22.3-cp39-cp39-win32.whl", hash = "sha256:bbb232860e3d03d544bc03ac57855cd82ddf19c7a07651a7c0fdb95e9efea8b9", size = 220246 },
+    { url = "https://files.pythonhosted.org/packages/8b/8d/9db93e48d96ace1f6713c71ce72e2d94b71d82156c37b6a54e0930486f00/rpds_py-0.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:cfbc454a2880389dbb9b5b398e50d439e2e58669160f27b60e5eca11f68ae17c", size = 231932 },
+    { url = "https://files.pythonhosted.org/packages/8b/63/e29f8ee14fcf383574f73b6bbdcbec0fbc2e5fc36b4de44d1ac389b1de62/rpds_py-0.22.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d48424e39c2611ee1b84ad0f44fb3b2b53d473e65de061e3f460fc0be5f1939d", size = 360786 },
+    { url = "https://files.pythonhosted.org/packages/d3/e0/771ee28b02a24e81c8c0e645796a371350a2bb6672753144f36ae2d2afc9/rpds_py-0.22.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:24e8abb5878e250f2eb0d7859a8e561846f98910326d06c0d51381fed59357bd", size = 350589 },
+    { url = "https://files.pythonhosted.org/packages/cf/49/abad4c4a1e6f3adf04785a99c247bfabe55ed868133e2d1881200aa5d381/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b232061ca880db21fa14defe219840ad9b74b6158adb52ddf0e87bead9e8493", size = 381848 },
+    { url = "https://files.pythonhosted.org/packages/3a/7d/f4bc6d6fbe6af7a0d2b5f2ee77079efef7c8528712745659ec0026888998/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac0a03221cdb5058ce0167ecc92a8c89e8d0decdc9e99a2ec23380793c4dcb96", size = 387879 },
+    { url = "https://files.pythonhosted.org/packages/13/b0/575c797377fdcd26cedbb00a3324232e4cb2c5d121f6e4b0dbf8468b12ef/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb0c341fa71df5a4595f9501df4ac5abfb5a09580081dffbd1ddd4654e6e9123", size = 423916 },
+    { url = "https://files.pythonhosted.org/packages/54/78/87157fa39d58f32a68d3326f8a81ad8fb99f49fe2aa7ad9a1b7d544f9478/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf9db5488121b596dbfc6718c76092fda77b703c1f7533a226a5a9f65248f8ad", size = 448410 },
+    { url = "https://files.pythonhosted.org/packages/59/69/860f89996065a88be1b6ff2d60e96a02b920a262d8aadab99e7903986597/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b8db6b5b2d4491ad5b6bdc2bc7c017eec108acbf4e6785f42a9eb0ba234f4c9", size = 382841 },
+    { url = "https://files.pythonhosted.org/packages/bd/d7/bc144e10d27e3cb350f98df2492a319edd3caaf52ddfe1293f37a9afbfd7/rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b3d504047aba448d70cf6fa22e06cb09f7cbd761939fdd47604f5e007675c24e", size = 409662 },
+    { url = "https://files.pythonhosted.org/packages/14/2a/6bed0b05233c291a94c7e89bc76ffa1c619d4e1979fbfe5d96024020c1fb/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:e61b02c3f7a1e0b75e20c3978f7135fd13cb6cf551bf4a6d29b999a88830a338", size = 558221 },
+    { url = "https://files.pythonhosted.org/packages/11/23/cd8f566de444a137bc1ee5795e47069a947e60810ba4152886fe5308e1b7/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:e35ba67d65d49080e8e5a1dd40101fccdd9798adb9b050ff670b7d74fa41c566", size = 583780 },
+    { url = "https://files.pythonhosted.org/packages/8d/63/79c3602afd14d501f751e615a74a59040328da5ef29ed5754ae80d236b84/rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:26fd7cac7dd51011a245f29a2cc6489c4608b5a8ce8d75661bb4a1066c52dfbe", size = 553619 },
+    { url = "https://files.pythonhosted.org/packages/9f/2e/c5c1689e80298d4e94c75b70faada4c25445739d91b94c211244a3ed7ed1/rpds_py-0.22.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:177c7c0fce2855833819c98e43c262007f42ce86651ffbb84f37883308cb0e7d", size = 233338 },
+    { url = "https://files.pythonhosted.org/packages/bc/b7/d2c205723e3b4d75b03215694f0297a1b4b395bf834cb5896ad9bbb90f90/rpds_py-0.22.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:bb47271f60660803ad11f4c61b42242b8c1312a31c98c578f79ef9387bbde21c", size = 360594 },
+    { url = "https://files.pythonhosted.org/packages/d8/8f/c3515f5234cf6055046d4cfe9c80a3742a20acfa7d0b1b290f0d7f56a8db/rpds_py-0.22.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:70fb28128acbfd264eda9bf47015537ba3fe86e40d046eb2963d75024be4d055", size = 349594 },
+    { url = "https://files.pythonhosted.org/packages/6b/98/5b487cb06afc484befe350c87fda37f4ce11333f04f3380aba43dcf5bce2/rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44d61b4b7d0c2c9ac019c314e52d7cbda0ae31078aabd0f22e583af3e0d79723", size = 381138 },
+    { url = "https://files.pythonhosted.org/packages/5e/3a/12308d2c51b3fdfc173619943b7dc5ba41b4850c47112eeda38d9c54ed12/rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f0e260eaf54380380ac3808aa4ebe2d8ca28b9087cf411649f96bad6900c728", size = 387828 },
+    { url = "https://files.pythonhosted.org/packages/17/b2/c242241ab5a2a206e093f24ccbfa519c4bbf10a762ac90bffe1766c225e0/rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b25bc607423935079e05619d7de556c91fb6adeae9d5f80868dde3468657994b", size = 424634 },
+    { url = "https://files.pythonhosted.org/packages/d5/c7/52a1b15012139f3ba740f291f1d03c6b632938ba61bc605f24c101952493/rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fb6116dfb8d1925cbdb52595560584db42a7f664617a1f7d7f6e32f138cdf37d", size = 447862 },
+    { url = "https://files.pythonhosted.org/packages/55/3e/4d3ed8fd01bad77e8ed101116fe63b03f1011940d9596a8f4d82ac80cacd/rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a63cbdd98acef6570c62b92a1e43266f9e8b21e699c363c0fef13bd530799c11", size = 382506 },
+    { url = "https://files.pythonhosted.org/packages/30/78/df59d6f92470a84369a3757abeae1cfd7f7239c8beb6d948949bf78317d2/rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2b8f60e1b739a74bab7e01fcbe3dddd4657ec685caa04681df9d562ef15b625f", size = 410534 },
+    { url = "https://files.pythonhosted.org/packages/38/97/ea45d1edd9b753b20084b52dd5db6ee5e1ac3e036a27149972398a413858/rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2e8b55d8517a2fda8d95cb45d62a5a8bbf9dd0ad39c5b25c8833efea07b880ca", size = 557453 },
+    { url = "https://files.pythonhosted.org/packages/08/cd/3a1b35eb9da27ffbb981cfffd32a01c7655c4431ccb278cb3064f8887462/rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:2de29005e11637e7a2361fa151f780ff8eb2543a0da1413bb951e9f14b699ef3", size = 584412 },
+    { url = "https://files.pythonhosted.org/packages/87/91/31d1c5aeb1606f71188259e0ba6ed6f5c21a3c72f58b51db6a8bd0aa2b5d/rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:666ecce376999bf619756a24ce15bb14c5bfaf04bf00abc7e663ce17c3f34fe7", size = 553446 },
+    { url = "https://files.pythonhosted.org/packages/e7/ad/03b5ccd1ab492c9dece85b3bf1c96453ab8c47983936fae6880f688f60b3/rpds_py-0.22.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:5246b14ca64a8675e0a7161f7af68fe3e910e6b90542b4bfb5439ba752191df6", size = 233013 },
 ]
 
 [[package]]


### PR DESCRIPTION
Add support for MF2 messages, with a parser, serialiser, validator, and transforms to & from the MF2 data model JSON Schema representation.

~Filing initially as a draft, as I may need to iterate on this for a bit still.~

Edit: Looks like the follow-up work isn't on MF2 directly, so this is good to review.