### PR TITLE
Allow `//` line comments in messages.json

### DIFF
--- a/python/moz/l10n/formats/__init__.py
+++ b/python/moz/l10n/formats/__init__.py
@@ -20,6 +20,8 @@ from json import JSONDecodeError, loads
 from os.path import splitext
 from typing import Any
 
+from ..util.loads import json_linecomment_loads
+
 # from moz.l10n.formats.xliff.common import xliff_ns
 xliff_ns = {
     "urn:oasis:names:tc:xliff:document:1.0",
@@ -108,6 +110,16 @@ def detect_format(name: str | None, source: bytes | str) -> Format | None:
             if all(is_webext_message(m) for m in json.values()):
                 return Format.webext
             return Format.plain_json
+        except JSONDecodeError:
+            pass
+
+        try:
+            json = json_linecomment_loads(source)
+            if is_object_of_strings(json) and all(
+                is_webext_message(m) for m in json.values()
+            ):
+                return Format.webext
+            return None
         except JSONDecodeError:
             pass
 

--- a/python/moz/l10n/formats/webext/parse.py
+++ b/python/moz/l10n/formats/webext/parse.py
@@ -14,7 +14,6 @@
 
 from __future__ import annotations
 
-from json import loads
 from re import compile
 from typing import Any
 
@@ -29,6 +28,7 @@ from ...model import (
     Section,
     VariableRef,
 )
+from ...util.loads import json_linecomment_loads
 from .. import Format
 
 placeholder = compile(r"\$([a-zA-Z0-9_@]+)\$|(\$[1-9])|\$(\$+)")
@@ -44,7 +44,7 @@ def webext_parse(source: str | bytes) -> Resource[Message]:
 
     The parsed resource will not include any metadata.
     """
-    json: dict[str, dict[str, Any]] = loads(source)
+    json: dict[str, dict[str, Any]] = json_linecomment_loads(source)
     entries: list[Entry[Message] | Comment] = []
     for key, msg in json.items():
         src: str = msg["message"]

--- a/python/moz/l10n/util/loads.py
+++ b/python/moz/l10n/util/loads.py
@@ -1,0 +1,32 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from json import loads
+from re import MULTILINE, compile
+from typing import Any
+
+str_comment = compile(r'^((?:[^"\n]|"(?:[^"\\\n]|\\.)*")*?)//.*', MULTILINE)
+bytes_comment = compile(rb'^((?:[^"\n]|"(?:[^"\\\n]|\\.)*")*?)//.*', MULTILINE)
+
+
+def json_linecomment_loads(source: str | bytes) -> Any:
+    """
+    Line comments // are supported in `webext` messages.json files.
+    """
+    if isinstance(source, str):
+        return loads(str_comment.sub(r"\1", source))
+    else:
+        return loads(bytes_comment.sub(rb"\1", source))

--- a/python/tests/formats/data/messages.json
+++ b/python/tests/formats/data/messages.json
@@ -1,4 +1,6 @@
 {
+  // Line comments are supported,
+  // and ignored.
   "SourceString": {
     "message": "Translated String",
     "description": "Sample comment"

--- a/python/tests/formats/data/plain.json
+++ b/python/tests/formats/data/plain.json
@@ -1,0 +1,16 @@
+{
+  "SourceString": "Translated String",
+  "NoCommentsorSources": {
+    "message": "Translated No Comments or Sources"
+  },
+  "placeholders": {
+    "message": "Hello$$$ $1YOUR_NAME$ at $2",
+    "description": "Peer greeting",
+    "placeholders": {
+      "1your_name": {
+        "content": "$1",
+        "example": "Cira"
+      }
+    }
+  }
+}

--- a/python/tests/formats/test_plain_json.py
+++ b/python/tests/formats/test_plain_json.py
@@ -22,7 +22,7 @@ from moz.l10n.formats import Format
 from moz.l10n.formats.plain_json import plain_json_parse, plain_json_serialize
 from moz.l10n.model import Entry, PatternMessage, Resource, Section
 
-source = files("tests.formats.data").joinpath("messages.json").read_bytes()
+source = files("tests.formats.data").joinpath("plain.json").read_bytes()
 
 
 class TestPlain(TestCase):
@@ -35,20 +35,8 @@ class TestPlain(TestCase):
                     (),
                     [
                         Entry(
-                            ("SourceString", "message"),
+                            ("SourceString",),
                             PatternMessage(["Translated String"]),
-                        ),
-                        Entry(
-                            ("SourceString", "description"),
-                            PatternMessage(["Sample comment"]),
-                        ),
-                        Entry(
-                            ("MultipleComments", "message"),
-                            PatternMessage(["Translated Multiple Comments"]),
-                        ),
-                        Entry(
-                            ("MultipleComments", "description"),
-                            PatternMessage(["Second comment"]),
                         ),
                         Entry(
                             ("NoCommentsorSources", "message"),
@@ -80,14 +68,6 @@ class TestPlain(TestCase):
                             ),
                             PatternMessage(["Cira"]),
                         ),
-                        Entry(
-                            ("repeated_ref", "message"),
-                            PatternMessage(["$foo$ and $Foo$"]),
-                        ),
-                        Entry(
-                            ("repeated_ref", "placeholders", "foo", "content"),
-                            PatternMessage(["$1"]),
-                        ),
                     ],
                 )
             ],
@@ -98,14 +78,7 @@ class TestPlain(TestCase):
         assert "".join(plain_json_serialize(res)) == dedent(
             """\
             {
-              "SourceString": {
-                "message": "Translated String",
-                "description": "Sample comment"
-              },
-              "MultipleComments": {
-                "message": "Translated Multiple Comments",
-                "description": "Second comment"
-              },
+              "SourceString": "Translated String",
               "NoCommentsorSources": {
                 "message": "Translated No Comments or Sources"
               },
@@ -116,14 +89,6 @@ class TestPlain(TestCase):
                   "1your_name": {
                     "content": "$1",
                     "example": "Cira"
-                  }
-                }
-              },
-              "repeated_ref": {
-                "message": "$foo$ and $Foo$",
-                "placeholders": {
-                  "foo": {
-                    "content": "$1"
                   }
                 }
               }

--- a/python/tests/test_walk_files.py
+++ b/python/tests/test_walk_files.py
@@ -33,6 +33,7 @@ test_data_files = (
     "icu-docs.xliff",
     "messages.json",
     "mf2-message-schema.json",
+    "plain.json",
     "strings.xml",
     "test.properties",
     "xcode.xliff",


### PR DESCRIPTION
Closes #47, ping @nijel

As discussed in the issue, this discards `//` line comments when parsing a file with them, and does not include them in the serialization.

The regular expression has been adapted from the one [used by Firefox](https://searchfox.org/mozilla-central/rev/0f754bb4607893ad58df525601334a18f9650d57/toolkit/components/extensions/Extension.sys.mjs#398).

At least for now, comments in JSON are not supported for the `plain_json` format.