### PR TITLE
Add paths.all_locales

### DIFF
--- a/python/moz/l10n/paths/config.py
+++ b/python/moz/l10n/paths/config.py
@@ -208,6 +208,24 @@ class L10nConfigPaths:
             incl.locales = locales
 
     @property
+    def all_locales(self) -> set[str]:
+        """
+        All locales for the config,
+        including locales set in its imports and paths.
+        """
+        return set(self._all_locales)
+
+    @property
+    def _all_locales(self) -> Iterator[str]:
+        if self._locales is not None:
+            yield from self._locales
+        for _, locales in self._path_data.values():
+            if locales is not None:
+                yield from locales
+        for incl in self._includes:
+            yield from incl._all_locales
+
+    @property
     def ref_root(self) -> str:
         """The reference root directory."""
         return self._ref_root

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -185,6 +185,13 @@ class L10nDiscoverPaths:
             )
 
     @property
+    def all_locales(self) -> set[str]:
+        """
+        All locales for the config.
+        """
+        return set() if self.locales is None else set(self.locales)
+
+    @property
     def ref_root(self) -> str:
         """The reference root directory."""
         return self._ref_root

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -262,6 +262,7 @@ class TestL10nConfigPaths(TestCase):
             paths = L10nConfigPaths(join(root, "l10n.toml"))
         assert paths.base == join(root, "foundation", "translations", "networkapi")
         assert paths.locales == ["de", "es", "fr", "fy-NL", "nl", "pl", "pt-BR", "sw"]
+        assert paths.all_locales == set(paths.locales)
         path_locales = ["de", "es", "fr", "pt-BR"]
         assert paths.all() == {
             (
@@ -290,6 +291,7 @@ class TestL10nConfigPaths(TestCase):
 
         paths.locales = ["es", "fr", "nl"]
         assert paths.target(res_source)[1] == set(("es", "fr"))
+        assert paths.all_locales == {"es", "fr", "nl", "de", "pt-BR"}
         paths.locales = []
         assert paths.target(res_source)[1] == path_locales
 

--- a/python/tests/test_discover.py
+++ b/python/tests/test_discover.py
@@ -74,6 +74,7 @@ class TestL10nDiscover(TestCase):
         assert paths.ref_root == join(root, "en")
         assert paths.base is None
         assert paths.locales is None
+        assert paths.all_locales == set()
         with self.assertRaises(ValueError):
             paths.all()
         with self.assertRaises(ValueError):
@@ -134,6 +135,7 @@ class TestL10nDiscover(TestCase):
             assert paths.ref_root == join(root, "source", "en")
             assert paths.base == join(root, "target")
             assert paths.locales == ["yy-Latn", "zz"]
+            assert paths.all_locales == {"yy-Latn", "zz"}
             assert paths.all() == {
                 (
                     join(paths.ref_root, "a.ftl"),


### PR DESCRIPTION
Fixes #49 by adding a property `all_locales` with a similar signature and behaviour as in compare-locales. Note that the value returned here is a set, rather than a sorted list.