### PR TITLE
Always use Message as Entry.value

### DIFF
--- a/python/moz/l10n/bin/build.py
+++ b/python/moz/l10n/bin/build.py
@@ -23,7 +23,7 @@ from shutil import copyfile
 from textwrap import dedent
 
 from moz.l10n.formats import Format
-from moz.l10n.model import Comment, Entry, Message, Resource, Section
+from moz.l10n.model import Comment, Entry, Resource, Section
 from moz.l10n.paths.config import L10nConfigPaths
 from moz.l10n.resource import UnsupportedResource, parse_resource, serialize_resource
 
@@ -122,7 +122,7 @@ def cli() -> None:
 
 def write_target_file(
     name: str,
-    source_res: Resource[Message],
+    source_res: Resource,
     l10n_path: str,
     tgt_path: str,
 ) -> int:
@@ -143,8 +143,8 @@ def write_target_file(
     msg_delta = 0
 
     def get_entry(
-        section_id: tuple[str, ...], source_entry: Entry[Message] | Comment
-    ) -> Entry[Message] | Comment | None:
+        section_id: tuple[str, ...], source_entry: Entry | Comment
+    ) -> Entry | Comment | None:
         nonlocal msg_delta
         if isinstance(source_entry, Comment):
             return None

--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -69,7 +69,7 @@ xml_name = compile(f"[{xml_name_start}][{xml_name_start}{xml_name_rest}]*")
 # https://developer.android.com/guide/topics/resources/localization#mark-message-parts
 
 
-def android_parse(source: str | bytes) -> Resource[Message]:
+def android_parse(source: str | bytes) -> Resource:
     """
     Parse an Android strings XML file into a message resource.
 
@@ -94,7 +94,7 @@ def android_parse(source: str | bytes) -> Resource[Message]:
         raise ValueError(f"Unsupported root node: {root}")
     if root.text and not root.text.isspace():
         raise ValueError(f"Unexpected text in resource: {root.text}")
-    res: Resource[Message] = Resource(Format.android, [Section((), [])])
+    res: Resource = Resource(Format.android, [Section((), [])])
     root_comments = [c.text for c in root.itersiblings(etree.Comment, preceding=True)]
     if root_comments:
         root_comments.reverse()
@@ -106,7 +106,7 @@ def android_parse(source: str | bytes) -> Resource[Message]:
 
     dtd = root.getroottree().docinfo.internalDTD
     if dtd:
-        entities: list[Entry[Message] | Comment] = []
+        entities: list[Entry | Comment] = []
         for entity in dtd.iterentities():
             name = entity.name
             if not name:

--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -24,7 +24,6 @@ from ...model import (
     CatchallKey,
     Entry,
     Expression,
-    Message,
     Metadata,
     Pattern,
     PatternMessage,
@@ -35,10 +34,7 @@ from ...model import (
 from .parse import plural_categories, resource_ref, xliff_g, xliff_ns, xml_name
 
 
-def android_serialize(
-    resource: Resource[str] | Resource[Message],
-    trim_comments: bool = False,
-) -> Iterator[str]:
+def android_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
     """
     Serialize a resource as an Android strings XML file.
 
@@ -120,7 +116,7 @@ def android_serialize(
                         if entry.comment and not trim_comments:
                             add_comment(root, entry.comment, False)
                         el = etree.SubElement(root, "string", attrib=attrib)
-                        set_pattern_message(el, entry.value)
+                        set_pattern(el, entry.value.pattern)
                 else:
                     # <string-array>
                     if string_array is None or name != string_array.get("name"):
@@ -190,7 +186,7 @@ def add_comment(el: etree._Element, content: str, standalone: bool) -> None:
     el.append(comment)
 
 
-def entity_definition(entry: Entry[str] | Entry[Message]) -> str:
+def entity_definition(entry: Entry) -> str:
     if len(entry.id) != 1 or not xml_name.fullmatch(entry.id[0]):
         raise ValueError(f"Invalid entity identifier: {entry.id}")
     name = entry.id[0]
@@ -200,9 +196,7 @@ def entity_definition(entry: Entry[str] | Entry[Message]) -> str:
     # Characters not allowed in XML EntityValue text
     escape = str.maketrans({"&": "&amp;", "%": "&#37;", '"': "&quot;"})
 
-    if isinstance(entry.value, str):
-        value = entry.value.translate(escape)
-    elif isinstance(entry.value, PatternMessage) and not entry.value.declarations:
+    if isinstance(entry.value, PatternMessage) and not entry.value.declarations:
         value = ""
         for part in entry.value.pattern:
             if isinstance(part, str):
@@ -219,9 +213,7 @@ def entity_definition(entry: Entry[str] | Entry[Message]) -> str:
     return f'<!ENTITY {name} "{value}">'
 
 
-def set_string_array_item(
-    parent: etree._Element, entry: Entry[str] | Entry[Message]
-) -> None:
+def set_string_array_item(parent: etree._Element, entry: Entry) -> None:
     try:
         num = int(entry.id[1])
     except ValueError:
@@ -231,7 +223,7 @@ def set_string_array_item(
     if isinstance(entry.value, SelectMessage):
         raise ValueError(f"Unsupported message type for {entry.id}: {entry.value}")
     item = etree.SubElement(parent, "item")
-    set_pattern_message(item, entry.value)
+    set_pattern(item, entry.value.pattern)
 
 
 def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
@@ -248,16 +240,6 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
         set_pattern(item, value)
         item.tail = "\n    "
     item.tail = "\n  "
-
-
-def set_pattern_message(el: etree._Element, msg: PatternMessage | str) -> None:
-    if isinstance(msg, str):
-        el.text = escape_backslash(msg)
-        escape_doublequote(el)
-    elif isinstance(msg, PatternMessage) and not msg.declarations:
-        set_pattern(el, msg.pattern)
-    else:
-        raise ValueError(f"Unsupported message: {msg}")
 
 
 def set_pattern(el: etree._Element, pattern: Pattern) -> None:

--- a/python/moz/l10n/formats/dtd/parse.py
+++ b/python/moz/l10n/formats/dtd/parse.py
@@ -21,7 +21,7 @@ from collections.abc import Iterator
 from re import DOTALL, MULTILINE, UNICODE, compile
 from sys import maxsize
 
-from ...model import Comment, Entry, Message, PatternMessage, Resource, Section
+from ...model import Comment, Entry, PatternMessage, Resource, Section
 from .. import Format
 
 name_start_char = (
@@ -39,13 +39,13 @@ re_entity = compile(
 re_comment = compile(r"\<!\s*--(.*?)--\s*\>", MULTILINE | DOTALL)
 
 
-def dtd_parse(source: str | bytes) -> Resource[Message]:
+def dtd_parse(source: str | bytes) -> Resource:
     """
     Parse a .dtd file into a message resource.
 
     The parsed resource will not include any metadata.
     """
-    entries: list[Entry[Message] | Comment] = []
+    entries: list[Entry | Comment] = []
     resource = Resource(Format.dtd, [Section((), entries)])
     pos = 0
     at_newline = True
@@ -100,9 +100,7 @@ def dtd_parse(source: str | bytes) -> Resource[Message]:
     return resource
 
 
-def dtd_iter(
-    text: str, pos: int, endpos: int = maxsize
-) -> Iterator[str | Entry[Message]]:
+def dtd_iter(text: str, pos: int, endpos: int = maxsize) -> Iterator[str | Entry]:
     for match in re_entity.finditer(text, pos, endpos):
         yield text[pos : match.start(0)]
         id, value = match.groups()

--- a/python/moz/l10n/formats/dtd/serialize.py
+++ b/python/moz/l10n/formats/dtd/serialize.py
@@ -18,16 +18,13 @@ from collections.abc import Iterator
 from re import UNICODE, compile
 from typing import Any
 
-from ...model import Entry, Message, PatternMessage, Resource
+from ...model import Entry, PatternMessage, Resource
 from .parse import name, re_comment
 
 re_name = compile(name, UNICODE)
 
 
-def dtd_serialize(
-    resource: Resource[str] | Resource[Message],
-    trim_comments: bool = False,
-) -> Iterator[str]:
+def dtd_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
     """
     Serialize a resource as the contents of a DTD file.
 
@@ -81,9 +78,7 @@ def dtd_serialize(
                 if not re_name.fullmatch(name):
                     raise ValueError(f"Unsupported DTD name: {name}")
                 msg = entry.value
-                if isinstance(msg, str):
-                    value = msg
-                elif isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/inc/parse.py
+++ b/python/moz/l10n/formats/inc/parse.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 
 from re import compile
 
-from ...model import Comment, Entry, Message, PatternMessage, Resource, Section
+from ...model import Comment, Entry, PatternMessage, Resource, Section
 from .. import Format
 
 re_define = compile(r"#define[ \t]+(\w+)(?:[ \t](.*))?")
 
 
-def inc_parse(source: str | bytes) -> Resource[Message]:
+def inc_parse(source: str | bytes) -> Resource:
     """
     Parse a .inc file into a message resource.
 
@@ -30,7 +30,7 @@ def inc_parse(source: str | bytes) -> Resource[Message]:
 
     The parsed resource will not include any metadata.
     """
-    entries: list[Entry[Message] | Comment] = []
+    entries: list[Entry | Comment] = []
     comment: str = ""
     if not isinstance(source, str):
         source = source.decode()

--- a/python/moz/l10n/formats/inc/serialize.py
+++ b/python/moz/l10n/formats/inc/serialize.py
@@ -17,13 +17,10 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Any
 
-from ...model import Entry, Message, PatternMessage, Resource
+from ...model import Entry, PatternMessage, Resource
 
 
-def inc_serialize(
-    resource: Resource[str] | Resource[Message],
-    trim_comments: bool = False,
-) -> Iterator[str]:
+def inc_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
     """
     Serialize a resource as the contents of a .inc file.
 
@@ -61,9 +58,7 @@ def inc_serialize(
                 if len(entry.id) != 1:
                     raise ValueError(f"Unsupported identifier: {entry.id}")
                 msg = entry.value
-                if isinstance(msg, str):
-                    value = msg
-                elif isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/ini/parse.py
+++ b/python/moz/l10n/formats/ini/parse.py
@@ -19,11 +19,11 @@ from typing import Generator, TextIO
 
 from iniparse import ini  # type: ignore[import-untyped]
 
-from ...model import Comment, Entry, Message, PatternMessage, Resource, Section
+from ...model import Comment, Entry, PatternMessage, Resource, Section
 from .. import Format
 
 
-def ini_parse(source: TextIO | str | bytes) -> Resource[Message]:
+def ini_parse(source: TextIO | str | bytes) -> Resource:
     """
     Parse an .ini file into a message resource.
 
@@ -37,8 +37,8 @@ def ini_parse(source: TextIO | str | bytes) -> Resource[Message]:
         file = source
     cfg = ini.INIConfig(file, optionxformvalue=None)
 
-    resource = Resource[Message](Format.ini, [])
-    section: Section[Message] | None = None
+    resource = Resource(Format.ini, [])
+    section: Section | None = None
     pattern: list[str] | None = None
     comment = ""
 

--- a/python/moz/l10n/formats/ini/serialize.py
+++ b/python/moz/l10n/formats/ini/serialize.py
@@ -18,13 +18,10 @@ from collections.abc import Iterator
 from re import search
 from typing import Any
 
-from ...model import Entry, Message, PatternMessage, Resource
+from ...model import Entry, PatternMessage, Resource
 
 
-def ini_serialize(
-    resource: Resource[str] | Resource[Message],
-    trim_comments: bool = False,
-) -> Iterator[str]:
+def ini_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
     """
     Serialize a resource as the contents of an .ini file.
 
@@ -72,9 +69,7 @@ def ini_serialize(
             if isinstance(entry, Entry):
                 yield from comment(entry.comment, entry.meta, False)
                 msg = entry.value
-                if isinstance(msg, str):
-                    value = msg
-                elif isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/plain_json/parse.py
+++ b/python/moz/l10n/formats/plain_json/parse.py
@@ -18,11 +18,11 @@ from collections.abc import Iterator
 from json import loads
 from typing import Any
 
-from ...model import Entry, Message, PatternMessage, Resource, Section
+from ...model import Entry, PatternMessage, Resource, Section
 from .. import Format
 
 
-def plain_json_parse(source: str | bytes) -> Resource[Message]:
+def plain_json_parse(source: str | bytes) -> Resource:
     """
     Parse a JSON file into a message resource.
 
@@ -38,7 +38,7 @@ def plain_json_parse(source: str | bytes) -> Resource[Message]:
     )
 
 
-def plain_object(path: list[str], obj: dict[str, Any]) -> Iterator[Entry[Message]]:
+def plain_object(path: list[str], obj: dict[str, Any]) -> Iterator[Entry]:
     for k, value in obj.items():
         key = [*path, k]
         if isinstance(value, str):

--- a/python/moz/l10n/formats/plain_json/serialize.py
+++ b/python/moz/l10n/formats/plain_json/serialize.py
@@ -19,12 +19,11 @@ from collections.abc import Iterator
 from json import dumps
 from typing import Any
 
-from ...model import Entry, Message, PatternMessage, Resource
+from ...model import Entry, PatternMessage, Resource
 
 
 def plain_json_serialize(
-    resource: Resource[str] | Resource[Message],
-    trim_comments: bool = False,
+    resource: Resource, trim_comments: bool = False
 ) -> Iterator[str]:
     """
     Serialize a resource as a nested JSON object.
@@ -58,9 +57,7 @@ def plain_json_serialize(
                 if not entry.id:
                     raise ValueError(f"Unsupported empty identifier in {section.id}")
                 msg = entry.value
-                if isinstance(msg, str):
-                    value = msg
-                elif isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/po/parse.py
+++ b/python/moz/l10n/formats/po/parse.py
@@ -32,7 +32,7 @@ from ...model import (
 from .. import Format
 
 
-def po_parse(source: str | bytes) -> Resource[Message]:
+def po_parse(source: str | bytes) -> Resource:
     """
     Parse a .po or .pot file into a message resource
 
@@ -49,7 +49,7 @@ def po_parse(source: str | bytes) -> Resource[Message]:
     res_meta: list[Metadata] = [
         Metadata(key, value.strip()) for key, value in pf.metadata.items()
     ]
-    sections: dict[str | None, Section[Message]] = OrderedDict()
+    sections: dict[str | None, Section] = OrderedDict()
     for pe in pf:
         meta: list[Metadata] = []
         if pe.tcomment:

--- a/python/moz/l10n/formats/po/serialize.py
+++ b/python/moz/l10n/formats/po/serialize.py
@@ -18,13 +18,11 @@ from collections.abc import Iterator
 
 from polib import POEntry, POFile
 
-from ...model import Entry, Message, PatternMessage, Resource, SelectMessage
+from ...model import Entry, PatternMessage, Resource, SelectMessage
 
 
 def po_serialize(
-    resource: Resource[str] | Resource[Message],
-    trim_comments: bool = False,
-    wrapwidth: int = 78,
+    resource: Resource, trim_comments: bool = False, wrapwidth: int = 78
 ) -> Iterator[str]:
     """
     Serialize a resource as the contents of a .po file.
@@ -54,9 +52,7 @@ def po_serialize(
             if isinstance(entry, Entry):
                 pe = POEntry(msgctxt=context, msgid=".".join(entry.id))
                 msg = entry.value
-                if isinstance(msg, str):
-                    pe.msgstr = msg
-                elif isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     pe.msgstr = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/properties/parse.py
+++ b/python/moz/l10n/formats/properties/parse.py
@@ -53,7 +53,7 @@ def properties_parse(
     source: bytes | str,
     encoding: str = "utf-8",
     parse_message: Callable[[str], Message] | None = None,
-) -> Resource[Message]:
+) -> Resource:
     """
     Parse a .properties file into a message resource.
 
@@ -65,13 +65,13 @@ def properties_parse(
     if not isinstance(source, str):
         source = source.decode(encoding)
     parser = PropertiesParser(source)
-    entries: list[Entry[Message] | Comment] = []
+    entries: list[Entry | Comment] = []
     resource = Resource(Format.properties, [Section((), entries)])
 
     start_line = 0
     comment = ""
     prev_linepos: LinePos | None = None
-    entry: Entry[Message] | None = None
+    entry: Entry | None = None
     for kind, line, value in parser:
         if kind == LineKind.VALUE:
             assert entry

--- a/python/moz/l10n/formats/properties/serialize.py
+++ b/python/moz/l10n/formats/properties/serialize.py
@@ -40,7 +40,7 @@ def encode_char(m: Match[str]) -> str:
 
 
 def properties_serialize(
-    resource: Resource[str] | Resource[Message],
+    resource: Resource,
     encoding: Literal["iso-8859-1", "utf-8", "utf-16"] = "utf-8",
     serialize_message: Callable[[Message], str] | None = None,
     trim_comments: bool = False,
@@ -51,7 +51,8 @@ def properties_serialize(
     Section identifiers will be prepended to their constituent message identifiers.
     Multi-part message identifiers will be joined with `.` between each part.
 
-    For non-string message values, a `serialize_message` callable must be provided.
+    A `serialize_message` callable may be provided to customize the serialization,
+    as a .properties file may contain messages in any format.
 
     Metadata is not supported.
 
@@ -98,9 +99,7 @@ def properties_serialize(
 
                 value: str
                 msg = entry.value
-                if isinstance(msg, str):
-                    value = msg
-                elif serialize_message:
+                if serialize_message:
                     value = serialize_message(msg)
                 elif isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern

--- a/python/moz/l10n/formats/webext/parse.py
+++ b/python/moz/l10n/formats/webext/parse.py
@@ -22,7 +22,6 @@ from ...model import (
     Comment,
     Entry,
     Expression,
-    Message,
     Pattern,
     PatternMessage,
     Resource,
@@ -35,7 +34,7 @@ placeholder = compile(r"\$([a-zA-Z0-9_@]+)\$|(\$[1-9])|\$(\$+)")
 pos_arg = compile(r"\$([1-9])")
 
 
-def webext_parse(source: str | bytes) -> Resource[Message]:
+def webext_parse(source: str | bytes) -> Resource:
     """
     Parse a messages.json file into a message resource.
 
@@ -45,7 +44,7 @@ def webext_parse(source: str | bytes) -> Resource[Message]:
     The parsed resource will not include any metadata.
     """
     json: dict[str, dict[str, Any]] = loads(source)
-    entries: list[Entry[Message] | Comment] = []
+    entries: list[Entry | Comment] = []
     for key, msg in json.items():
         src: str = msg["message"]
         comment: str = msg.get("description", "")

--- a/python/moz/l10n/formats/xliff/parse.py
+++ b/python/moz/l10n/formats/xliff/parse.py
@@ -25,7 +25,6 @@ from ...model import (
     Comment,
     Entry,
     Expression,
-    Message,
     Metadata,
     PatternMessage,
     Resource,
@@ -37,7 +36,7 @@ from .parse_trans_unit import parse_trans_unit
 from .parse_xcode import parse_xliff_stringsdict
 
 
-def xliff_parse(source: str | bytes) -> Resource[Message]:
+def xliff_parse(source: str | bytes) -> Resource:
     """
     Parse an XLIFF 1.2 file into a message resource.
 
@@ -67,7 +66,7 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
     if root.text and not root.text.isspace():
         raise ValueError(f"Unexpected text in <xliff>: {root.text}")
 
-    res: Resource[Message] = Resource(Format.xliff, [])
+    res = Resource(Format.xliff, [])
     root_comments = [
         c.text for c in root.itersiblings(etree.Comment, preceding=True) if c.text
     ]
@@ -89,7 +88,7 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
             if file_name is None:
                 raise ValueError(f'Missing "original" attribute for <file>: {file}')
             meta = attrib_as_metadata(file, None, ("original",))
-            entries: list[Entry[Message] | Comment] = []
+            entries: list[Entry | Comment] = []
             body = None
             for child in file:
                 if isinstance(child, etree._Comment):
@@ -121,9 +120,7 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
             if file_name.endswith(".stringsdict"):
                 plural_entries = parse_xliff_stringsdict(ns, body)
                 if plural_entries is not None:
-                    entries += cast(
-                        List[Union[Entry[Message], Comment]], plural_entries
-                    )
+                    entries += cast(List[Union[Entry, Comment]], plural_entries)
                     continue
 
             for unit in body:
@@ -144,13 +141,11 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
     return res
 
 
-def parse_group(
-    ns: str, parent: list[str], group: etree._Element
-) -> Iterator[Section[Message]]:
+def parse_group(ns: str, parent: list[str], group: etree._Element) -> Iterator[Section]:
     id = group.attrib.get("id", "")
     path = [*parent, id]
     meta = attrib_as_metadata(group, None, ("id",))
-    entries: list[Entry[Message] | Comment] = []
+    entries: list[Entry | Comment] = []
     if group.text and not group.text.isspace():
         raise ValueError(f"Unexpected text in <group>: {group.text}")
 
@@ -178,7 +173,7 @@ def parse_group(
             raise ValueError(f"Unexpected text in <group>: {unit.tail}")
 
 
-def parse_bin_unit(unit: etree._Element) -> Entry[Message]:
+def parse_bin_unit(unit: etree._Element) -> Entry:
     id = unit.attrib.get("id", None)
     if id is None:
         raise ValueError(f'Missing "id" attribute for <bin-unit>: {unit}')

--- a/python/moz/l10n/formats/xliff/parse_trans_unit.py
+++ b/python/moz/l10n/formats/xliff/parse_trans_unit.py
@@ -19,11 +19,11 @@ from collections.abc import Iterator
 
 from lxml import etree
 
-from ...model import Entry, Markup, Message, Metadata, PatternMessage, VariableRef
+from ...model import Entry, Markup, Metadata, PatternMessage, VariableRef
 from .common import attrib_as_metadata, element_as_metadata, pretty_name, xliff_ns
 
 
-def parse_trans_unit(unit: etree._Element) -> Entry[Message]:
+def parse_trans_unit(unit: etree._Element) -> Entry:
     id = unit.attrib.get("id", None)
     if id is None:
         raise ValueError(f'Missing "id" attribute for <trans-unit>: {unit}')

--- a/python/moz/l10n/formats/xliff/parse_xcode.py
+++ b/python/moz/l10n/formats/xliff/parse_xcode.py
@@ -54,9 +54,7 @@ printf = compile(
 )
 
 
-def parse_xliff_stringsdict(
-    ns: str, body: etree._Element
-) -> list[Entry[SelectMessage]] | None:
+def parse_xliff_stringsdict(ns: str, body: etree._Element) -> list[Entry] | None:
     plurals: dict[str, XcodePlural] = {}
     for unit in body:
         if unit.tag != f"{ns}trans-unit":

--- a/python/moz/l10n/formats/xliff/serialize.py
+++ b/python/moz/l10n/formats/xliff/serialize.py
@@ -25,7 +25,6 @@ from ...model import (
     Entry,
     Expression,
     Markup,
-    Message,
     Metadata,
     Pattern,
     PatternMessage,
@@ -36,10 +35,7 @@ from ...model import (
 from .common import clark_name
 
 
-def xliff_serialize(
-    resource: Resource[str] | Resource[Message],
-    trim_comments: bool = False,
-) -> Iterator[str]:
+def xliff_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
     """
     Serialize a resource as an XLIFF 1.2 file.
 
@@ -131,7 +127,7 @@ def xliff_serialize(
 
             if isinstance(entry.value, SelectMessage):
                 if section.id[0].endswith(".stringsdict"):
-                    add_xliff_stringsdict_plural(parent, entry, trim_comments)  # type: ignore [arg-type]
+                    add_xliff_stringsdict_plural(parent, entry, trim_comments)
                     continue
                 else:
                     fn = section.id[0]
@@ -151,9 +147,7 @@ def xliff_serialize(
                         raise ValueError(f"Invalid entry with no source: {entry}")
                     target = etree.Element("target")
                     source.addnext(target)
-                if isinstance(msg, str):
-                    target.text = msg
-                elif isinstance(msg, PatternMessage) and not msg.declarations:
+                if isinstance(msg, PatternMessage) and not msg.declarations:
                     set_pattern(target, msg.pattern)
                 else:
                     raise ValueError(f"Unsupported message: {msg}")
@@ -175,8 +169,9 @@ def xliff_serialize(
 
 
 def add_xliff_stringsdict_plural(
-    parent: etree._Element, entry: Entry[SelectMessage], trim_comments: bool
+    parent: etree._Element, entry: Entry, trim_comments: bool
 ) -> None:
+    assert isinstance(entry.value, SelectMessage)
     if entry.comment:
         raise ValueError(f"Unsupported comment on SelectMessage: {entry.comment}")
     msg = entry.value

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, Generic, List, Literal, Tuple, TypeVar, Union
+from typing import Dict, List, Literal, Tuple, Union
 
 from .formats import Format
 
@@ -191,14 +191,8 @@ class Comment:
     """
 
 
-V = TypeVar("V")
-"""
-The Message value type.
-"""
-
-
 @dataclass
-class Entry(Generic[V]):
+class Entry:
     """
     A message entry.
 
@@ -219,7 +213,7 @@ class Entry(Generic[V]):
     i.e. the concatenation of its section header identifier (if any) and its own.
     """
 
-    value: V
+    value: Message
     """
     The value of an entry, i.e. the message.
 
@@ -250,7 +244,7 @@ class Entry(Generic[V]):
 
 
 @dataclass
-class Section(Generic[V]):
+class Section:
     """
     A section of a resource.
 
@@ -275,7 +269,7 @@ class Section(Generic[V]):
     i.e. they do not include this identifier.
     """
 
-    entries: list[Entry[V] | Comment]
+    entries: list[Entry | Comment]
     """
     Section entries consist of message entries and comments.
 
@@ -306,7 +300,7 @@ class Section(Generic[V]):
 
 
 @dataclass
-class Resource(Generic[V]):
+class Resource:
     """
     A message resource.
 
@@ -319,7 +313,7 @@ class Resource(Generic[V]):
     The serialization format for the resource, if any.
     """
 
-    sections: list[Section[V]]
+    sections: list[Section]
     """
     The body of a resource, consisting of an array of sections.
 

--- a/python/moz/l10n/resource/add_entries.py
+++ b/python/moz/l10n/resource/add_entries.py
@@ -15,23 +15,13 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from typing import Any
 
-from ..model import (
-    Comment,
-    Entry,
-    Resource,
-    Section,
-    V,
-)
-
-RS = Section[Any]
-RE = Entry[Any]
+from ..model import Comment, Entry, Resource, Section
 
 
 def add_entries(
-    target: Resource[V],
-    source: Resource[V],
+    target: Resource,
+    source: Resource,
     *,
     use_source_entries: bool = False,
 ) -> int:
@@ -48,11 +38,11 @@ def add_entries(
     """
 
     change_count = 0
-    cur_tgt_section: RS | None = None
+    cur_tgt_section: Section | None = None
     for src_section in source.sections:
         tgt_match = [s for s in target.sections if s.id == src_section.id]
-        prev_pos: tuple[RS, int] | None = None
-        new_entries: list[RE | Comment] = []
+        prev_pos: tuple[Section, int] | None = None
+        new_entries: list[Entry | Comment] = []
         for entry in src_section.entries:
             if isinstance(entry, Entry):
                 target_pos = next(

--- a/python/moz/l10n/resource/l10n_equal.py
+++ b/python/moz/l10n/resource/l10n_equal.py
@@ -15,17 +15,17 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Any, Dict, List, Set, Tuple, TypeVar
+from typing import Dict, List, Set, Tuple, TypeVar
 
-from ..model import Entry, Resource, Section
+from ..model import Entry, Message, Resource, Section
 
 _T = TypeVar("_T")
 _L10nData = List[
-    Tuple[Tuple[str, ...], str, Dict[str, Set[Any]], _T]
+    Tuple[Tuple[str, ...], str, Dict[str, Set[str]], _T]
 ]  # id, comment, value
 
 
-def l10n_equal(a: Resource[Any], b: Resource[Any]) -> bool:
+def l10n_equal(a: Resource, b: Resource) -> bool:
     """
     Compares the localization-relevant content
     (id, comment, metadata, message values) of two resources.
@@ -41,7 +41,7 @@ def l10n_equal(a: Resource[Any], b: Resource[Any]) -> bool:
     )
 
 
-def l10n_sections(resource: Resource[Any]) -> _L10nData[_L10nData[Any]]:
+def l10n_sections(resource: Resource) -> _L10nData[_L10nData[Message]]:
     ls = [
         (section.id, section.comment.strip(), l10n_meta(section), l10n_entries(section))
         for section in resource.sections
@@ -62,7 +62,7 @@ def l10n_sections(resource: Resource[Any]) -> _L10nData[_L10nData[Any]]:
     return ls
 
 
-def l10n_entries(section: Section[Any]) -> _L10nData[Any]:
+def l10n_entries(section: Section) -> _L10nData[Message]:
     le = [
         (entry.id, entry.comment.strip(), l10n_meta(entry), entry.value)
         for entry in section.entries
@@ -73,9 +73,9 @@ def l10n_entries(section: Section[Any]) -> _L10nData[Any]:
 
 
 def l10n_meta(
-    x: Entry[Any] | Section[Any] | Resource[Any],
-) -> dict[str, set[Any]]:
-    md: dict[str, set[Any]] = defaultdict(set)
+    x: Entry | Section | Resource,
+) -> dict[str, set[str]]:
+    md: dict[str, set[str]] = defaultdict(set)
     for m in x.meta:
         md[m.key].add(m.value)
     return md

--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -25,10 +25,10 @@ from ..formats.plain_json.parse import plain_json_parse
 from ..formats.po.parse import po_parse
 from ..formats.properties.parse import properties_parse
 from ..formats.webext.parse import webext_parse
-from ..model import Message, Resource
+from ..model import Resource
 
-android_parse: Callable[[str | bytes], Resource[Message]] | None
-xliff_parse: Callable[[str | bytes], Resource[Message]] | None
+android_parse: Callable[[str | bytes], Resource] | None
+xliff_parse: Callable[[str | bytes], Resource] | None
 try:
     from ..formats.android.parse import android_parse
     from ..formats.xliff.parse import xliff_parse
@@ -43,7 +43,7 @@ class UnsupportedResource(Exception):
 
 def parse_resource(
     input: Format | str | None, source: str | bytes | None = None
-) -> Resource[Message]:
+) -> Resource:
     """
     Parse a Resource from its string representation.
 

--- a/python/moz/l10n/resource/serialize_resource.py
+++ b/python/moz/l10n/resource/serialize_resource.py
@@ -26,14 +26,10 @@ from ..formats.plain_json.serialize import plain_json_serialize
 from ..formats.po.serialize import po_serialize
 from ..formats.properties.serialize import properties_serialize
 from ..formats.webext.serialize import webext_serialize
-from ..model import Message, Resource
+from ..model import Resource
 
-android_serialize: (
-    Callable[[Resource[str] | Resource[Message], bool], Iterator[str]] | None
-)
-xliff_serialize: (
-    Callable[[Resource[str] | Resource[Message], bool], Iterator[str]] | None
-)
+android_serialize: Callable[[Resource, bool], Iterator[str]] | None
+xliff_serialize: Callable[[Resource, bool], Iterator[str]] | None
 try:
     from ..formats.android.serialize import android_serialize
     from ..formats.xliff.serialize import xliff_serialize
@@ -43,7 +39,7 @@ except ImportError:
 
 
 def serialize_resource(
-    resource: Resource[str] | Resource[Message],
+    resource: Resource,
     format: Format | None = None,
     trim_comments: bool = False,
 ) -> Iterator[str]:

--- a/python/tests/formats/test_dtd.py
+++ b/python/tests/formats/test_dtd.py
@@ -133,7 +133,7 @@ class TestDtd(TestCase):
 
     def test_serialize(self):
         res = dtd_parse(source)
-        res.sections[0].entries.insert(0, Entry(("foo",), '"bar"'))
+        res.sections[0].entries.insert(0, Entry(("foo",), PatternMessage(['"bar"'])))
         assert "".join(dtd_serialize(res)) == dedent(
             """\
             <!-- This Source Code Form is subject to the terms of the Mozilla Public

--- a/python/tests/formats/test_fluent.py
+++ b/python/tests/formats/test_fluent.py
@@ -18,7 +18,6 @@ from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 
-from fluent.syntax import ast as ftl
 from moz.l10n.formats import Format
 from moz.l10n.formats.fluent import fluent_parse, fluent_serialize
 from moz.l10n.model import (
@@ -39,29 +38,6 @@ from . import get_linepos
 
 
 class TestFluent(TestCase):
-    def test_fluent_value(self):
-        source = dedent(
-            """\
-            key =
-                pre { $a ->
-                    [1] One
-                   *[2] Two
-                } mid { $b ->
-                   *[bb] BB
-                    [cc] CC
-                } post
-                .attr = foo
-            """
-        )
-        res = fluent_parse(source, as_ftl_patterns=True)
-        assert len(res.sections) == 1
-        assert len(res.sections[0].entries) == 2
-        assert res.sections[0].entries[0].id == ("key",)
-        assert isinstance(res.sections[0].entries[0].value, ftl.Pattern)
-        assert res.sections[0].entries[1].id == ("key", "attr")
-        assert isinstance(res.sections[0].entries[1].value, ftl.Pattern)
-        assert "".join(fluent_serialize(res)) == source
-
     def test_equality_same(self):
         source = 'progress = Progress: { NUMBER($num, style: "percent") }.'
         res1 = fluent_parse(source)
@@ -515,7 +491,7 @@ class TestFluent(TestCase):
 
     def test_junk(self):
         with self.assertRaisesRegex(Exception, 'Expected token: "="'):
-            fluent_parse("msg = value\n# Comment\nLine of junk", as_ftl_patterns=True)
+            fluent_parse("msg = value\n# Comment\nLine of junk")
 
     def test_file(self):
         bytes = files("tests.formats.data").joinpath("demo.ftl").read_bytes()


### PR DESCRIPTION
Resources are easier to work with if their structure is fixed, and `Entry.value` is always a `Message`. Currently, this optionality is only used by `fluent_parse(..., as_ftl_patterns=True)`, and it adds a bit of complexity everywhere.

Most of the code changes here are in the serialisers, which no longer need to support Resources with string values.