### PR TITLE
Revert "Always use Message as Entry.value"

### DIFF
--- a/python/moz/l10n/bin/build.py
+++ b/python/moz/l10n/bin/build.py
@@ -23,7 +23,7 @@ from shutil import copyfile
 from textwrap import dedent
 
 from moz.l10n.formats import Format
-from moz.l10n.model import Comment, Entry, Resource, Section
+from moz.l10n.model import Comment, Entry, Message, Resource, Section
 from moz.l10n.paths.config import L10nConfigPaths
 from moz.l10n.resource import UnsupportedResource, parse_resource, serialize_resource
 
@@ -122,7 +122,7 @@ def cli() -> None:
 
 def write_target_file(
     name: str,
-    source_res: Resource,
+    source_res: Resource[Message],
     l10n_path: str,
     tgt_path: str,
 ) -> int:
@@ -143,8 +143,8 @@ def write_target_file(
     msg_delta = 0
 
     def get_entry(
-        section_id: tuple[str, ...], source_entry: Entry | Comment
-    ) -> Entry | Comment | None:
+        section_id: tuple[str, ...], source_entry: Entry[Message] | Comment
+    ) -> Entry[Message] | Comment | None:
         nonlocal msg_delta
         if isinstance(source_entry, Comment):
             return None

--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -69,7 +69,7 @@ xml_name = compile(f"[{xml_name_start}][{xml_name_start}{xml_name_rest}]*")
 # https://developer.android.com/guide/topics/resources/localization#mark-message-parts
 
 
-def android_parse(source: str | bytes) -> Resource:
+def android_parse(source: str | bytes) -> Resource[Message]:
     """
     Parse an Android strings XML file into a message resource.
 
@@ -94,7 +94,7 @@ def android_parse(source: str | bytes) -> Resource:
         raise ValueError(f"Unsupported root node: {root}")
     if root.text and not root.text.isspace():
         raise ValueError(f"Unexpected text in resource: {root.text}")
-    res: Resource = Resource(Format.android, [Section((), [])])
+    res: Resource[Message] = Resource(Format.android, [Section((), [])])
     root_comments = [c.text for c in root.itersiblings(etree.Comment, preceding=True)]
     if root_comments:
         root_comments.reverse()
@@ -106,7 +106,7 @@ def android_parse(source: str | bytes) -> Resource:
 
     dtd = root.getroottree().docinfo.internalDTD
     if dtd:
-        entities: list[Entry | Comment] = []
+        entities: list[Entry[Message] | Comment] = []
         for entity in dtd.iterentities():
             name = entity.name
             if not name:

--- a/python/moz/l10n/formats/dtd/parse.py
+++ b/python/moz/l10n/formats/dtd/parse.py
@@ -21,7 +21,7 @@ from collections.abc import Iterator
 from re import DOTALL, MULTILINE, UNICODE, compile
 from sys import maxsize
 
-from ...model import Comment, Entry, PatternMessage, Resource, Section
+from ...model import Comment, Entry, Message, PatternMessage, Resource, Section
 from .. import Format
 
 name_start_char = (
@@ -39,13 +39,13 @@ re_entity = compile(
 re_comment = compile(r"\<!\s*--(.*?)--\s*\>", MULTILINE | DOTALL)
 
 
-def dtd_parse(source: str | bytes) -> Resource:
+def dtd_parse(source: str | bytes) -> Resource[Message]:
     """
     Parse a .dtd file into a message resource.
 
     The parsed resource will not include any metadata.
     """
-    entries: list[Entry | Comment] = []
+    entries: list[Entry[Message] | Comment] = []
     resource = Resource(Format.dtd, [Section((), entries)])
     pos = 0
     at_newline = True
@@ -100,7 +100,9 @@ def dtd_parse(source: str | bytes) -> Resource:
     return resource
 
 
-def dtd_iter(text: str, pos: int, endpos: int = maxsize) -> Iterator[str | Entry]:
+def dtd_iter(
+    text: str, pos: int, endpos: int = maxsize
+) -> Iterator[str | Entry[Message]]:
     for match in re_entity.finditer(text, pos, endpos):
         yield text[pos : match.start(0)]
         id, value = match.groups()

--- a/python/moz/l10n/formats/dtd/serialize.py
+++ b/python/moz/l10n/formats/dtd/serialize.py
@@ -18,13 +18,16 @@ from collections.abc import Iterator
 from re import UNICODE, compile
 from typing import Any
 
-from ...model import Entry, PatternMessage, Resource
+from ...model import Entry, Message, PatternMessage, Resource
 from .parse import name, re_comment
 
 re_name = compile(name, UNICODE)
 
 
-def dtd_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
+def dtd_serialize(
+    resource: Resource[str] | Resource[Message],
+    trim_comments: bool = False,
+) -> Iterator[str]:
     """
     Serialize a resource as the contents of a DTD file.
 
@@ -78,7 +81,9 @@ def dtd_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[s
                 if not re_name.fullmatch(name):
                     raise ValueError(f"Unsupported DTD name: {name}")
                 msg = entry.value
-                if isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, str):
+                    value = msg
+                elif isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/fluent/parse.py
+++ b/python/moz/l10n/formats/fluent/parse.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 from collections.abc import Generator
 from itertools import product
 from re import finditer
-from typing import Tuple, cast
+from typing import Any, Literal, Tuple, cast, overload
 
 from fluent.syntax import FluentParser
 from fluent.syntax import ast as ftl
@@ -40,14 +40,38 @@ from ...model import (
 from .. import Format
 
 
+@overload
 def fluent_parse(
-    source: bytes | str | ftl.Resource, *, with_linepos: bool = True
-) -> Resource:
+    source: bytes | str | ftl.Resource,
+    *,
+    as_ftl_patterns: Literal[False] = False,
+    with_linepos: bool = True,
+) -> Resource[Message]: ...
+
+
+@overload
+def fluent_parse(
+    source: bytes | str | ftl.Resource,
+    *,
+    as_ftl_patterns: Literal[True],
+    with_linepos: bool = True,
+) -> Resource[ftl.Pattern]: ...
+
+
+def fluent_parse(
+    source: bytes | str | ftl.Resource,
+    *,
+    as_ftl_patterns: bool = False,
+    with_linepos: bool = True,
+) -> Resource[Message] | Resource[ftl.Pattern]:
     """
     Parse a .ftl file into a message resource.
 
     Message and term references are represented by `message` function annotations,
     with term identifiers prefixed with a `-`.
+
+    By default, messages are parsed as Messages;
+    to keep them as Fluent Patterns, use `as_ftl_patterns=True`.
 
     Function names are lower-cased, so e.g. the Fluent `NUMBER` is `number` in the Resource.
 
@@ -62,7 +86,7 @@ def fluent_parse(
         fluent_res = FluentParser(with_spans=with_linepos).parse(source_str)
         lpm = LinePosMapper(source_str) if with_linepos else None
 
-    entries: list[Entry | Comment] = []
+    entries: list[Entry[Any] | Comment] = []
     section = Section((), entries)
     resource = Resource(Format.fluent, [section])
     fluent_body = fluent_res.body
@@ -71,7 +95,7 @@ def fluent_parse(
         fluent_body = fluent_body[1:]
     for entry in fluent_body:
         if isinstance(entry, ftl.Message) or isinstance(entry, ftl.Term):
-            entries.extend(patterns(entry, lpm))
+            entries.extend(patterns(entry, as_ftl_patterns, lpm))
         elif isinstance(entry, ftl.ResourceComment):
             if entry.content:
                 resource.comment = (
@@ -110,15 +134,17 @@ def fluent_parse(
 
 def patterns(
     ftl_entry: ftl.Message | ftl.Term,
+    as_ftl_patterns: bool,
     lpm: LinePosMapper | None,
-) -> Generator[Entry, None, None]:
+) -> Generator[Entry[Message] | Entry[ftl.Pattern], None, None]:
+    message = (lambda m: m) if as_ftl_patterns else fluent_parse_message
     id = ftl_entry.id.name
     if isinstance(ftl_entry, ftl.Term):
         id = "-" + id
     comment = ftl_entry.comment.content or "" if ftl_entry.comment else ""
     if ftl_entry.value:
-        entry = Entry(
-            id=(id,), value=fluent_parse_message(ftl_entry.value), comment=comment
+        entry: Entry[Any] = Entry(
+            id=(id,), value=message(ftl_entry.value), comment=comment
         )
         if lpm and ftl_entry.span and ftl_entry.value.span:
             v_span = ftl_entry.value.span
@@ -135,11 +161,7 @@ def patterns(
         if comment:
             comment = ""
     for attr in ftl_entry.attributes:
-        entry = Entry(
-            id=(id, attr.id.name),
-            value=fluent_parse_message(attr.value),
-            comment=comment,
-        )
+        entry = Entry(id=(id, attr.id.name), value=message(attr.value), comment=comment)
         if lpm and attr.span:
             span = attr.span
             c_span = (

--- a/python/moz/l10n/formats/inc/parse.py
+++ b/python/moz/l10n/formats/inc/parse.py
@@ -16,13 +16,13 @@ from __future__ import annotations
 
 from re import compile
 
-from ...model import Comment, Entry, PatternMessage, Resource, Section
+from ...model import Comment, Entry, Message, PatternMessage, Resource, Section
 from .. import Format
 
 re_define = compile(r"#define[ \t]+(\w+)(?:[ \t](.*))?")
 
 
-def inc_parse(source: str | bytes) -> Resource:
+def inc_parse(source: str | bytes) -> Resource[Message]:
     """
     Parse a .inc file into a message resource.
 
@@ -30,7 +30,7 @@ def inc_parse(source: str | bytes) -> Resource:
 
     The parsed resource will not include any metadata.
     """
-    entries: list[Entry | Comment] = []
+    entries: list[Entry[Message] | Comment] = []
     comment: str = ""
     if not isinstance(source, str):
         source = source.decode()

--- a/python/moz/l10n/formats/inc/serialize.py
+++ b/python/moz/l10n/formats/inc/serialize.py
@@ -17,10 +17,13 @@ from __future__ import annotations
 from collections.abc import Iterator
 from typing import Any
 
-from ...model import Entry, PatternMessage, Resource
+from ...model import Entry, Message, PatternMessage, Resource
 
 
-def inc_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
+def inc_serialize(
+    resource: Resource[str] | Resource[Message],
+    trim_comments: bool = False,
+) -> Iterator[str]:
     """
     Serialize a resource as the contents of a .inc file.
 
@@ -58,7 +61,9 @@ def inc_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[s
                 if len(entry.id) != 1:
                     raise ValueError(f"Unsupported identifier: {entry.id}")
                 msg = entry.value
-                if isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, str):
+                    value = msg
+                elif isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/ini/parse.py
+++ b/python/moz/l10n/formats/ini/parse.py
@@ -19,11 +19,11 @@ from typing import Generator, TextIO
 
 from iniparse import ini  # type: ignore[import-untyped]
 
-from ...model import Comment, Entry, PatternMessage, Resource, Section
+from ...model import Comment, Entry, Message, PatternMessage, Resource, Section
 from .. import Format
 
 
-def ini_parse(source: TextIO | str | bytes) -> Resource:
+def ini_parse(source: TextIO | str | bytes) -> Resource[Message]:
     """
     Parse an .ini file into a message resource.
 
@@ -37,8 +37,8 @@ def ini_parse(source: TextIO | str | bytes) -> Resource:
         file = source
     cfg = ini.INIConfig(file, optionxformvalue=None)
 
-    resource = Resource(Format.ini, [])
-    section: Section | None = None
+    resource = Resource[Message](Format.ini, [])
+    section: Section[Message] | None = None
     pattern: list[str] | None = None
     comment = ""
 

--- a/python/moz/l10n/formats/ini/serialize.py
+++ b/python/moz/l10n/formats/ini/serialize.py
@@ -18,10 +18,13 @@ from collections.abc import Iterator
 from re import search
 from typing import Any
 
-from ...model import Entry, PatternMessage, Resource
+from ...model import Entry, Message, PatternMessage, Resource
 
 
-def ini_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[str]:
+def ini_serialize(
+    resource: Resource[str] | Resource[Message],
+    trim_comments: bool = False,
+) -> Iterator[str]:
     """
     Serialize a resource as the contents of an .ini file.
 
@@ -69,7 +72,9 @@ def ini_serialize(resource: Resource, trim_comments: bool = False) -> Iterator[s
             if isinstance(entry, Entry):
                 yield from comment(entry.comment, entry.meta, False)
                 msg = entry.value
-                if isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, str):
+                    value = msg
+                elif isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/plain_json/parse.py
+++ b/python/moz/l10n/formats/plain_json/parse.py
@@ -18,11 +18,11 @@ from collections.abc import Iterator
 from json import loads
 from typing import Any
 
-from ...model import Entry, PatternMessage, Resource, Section
+from ...model import Entry, Message, PatternMessage, Resource, Section
 from .. import Format
 
 
-def plain_json_parse(source: str | bytes) -> Resource:
+def plain_json_parse(source: str | bytes) -> Resource[Message]:
     """
     Parse a JSON file into a message resource.
 
@@ -38,7 +38,7 @@ def plain_json_parse(source: str | bytes) -> Resource:
     )
 
 
-def plain_object(path: list[str], obj: dict[str, Any]) -> Iterator[Entry]:
+def plain_object(path: list[str], obj: dict[str, Any]) -> Iterator[Entry[Message]]:
     for k, value in obj.items():
         key = [*path, k]
         if isinstance(value, str):

--- a/python/moz/l10n/formats/plain_json/serialize.py
+++ b/python/moz/l10n/formats/plain_json/serialize.py
@@ -19,11 +19,12 @@ from collections.abc import Iterator
 from json import dumps
 from typing import Any
 
-from ...model import Entry, PatternMessage, Resource
+from ...model import Entry, Message, PatternMessage, Resource
 
 
 def plain_json_serialize(
-    resource: Resource, trim_comments: bool = False
+    resource: Resource[str] | Resource[Message],
+    trim_comments: bool = False,
 ) -> Iterator[str]:
     """
     Serialize a resource as a nested JSON object.
@@ -57,7 +58,9 @@ def plain_json_serialize(
                 if not entry.id:
                     raise ValueError(f"Unsupported empty identifier in {section.id}")
                 msg = entry.value
-                if isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, str):
+                    value = msg
+                elif isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     value = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/po/parse.py
+++ b/python/moz/l10n/formats/po/parse.py
@@ -32,7 +32,7 @@ from ...model import (
 from .. import Format
 
 
-def po_parse(source: str | bytes) -> Resource:
+def po_parse(source: str | bytes) -> Resource[Message]:
     """
     Parse a .po or .pot file into a message resource
 
@@ -49,7 +49,7 @@ def po_parse(source: str | bytes) -> Resource:
     res_meta: list[Metadata] = [
         Metadata(key, value.strip()) for key, value in pf.metadata.items()
     ]
-    sections: dict[str | None, Section] = OrderedDict()
+    sections: dict[str | None, Section[Message]] = OrderedDict()
     for pe in pf:
         meta: list[Metadata] = []
         if pe.tcomment:

--- a/python/moz/l10n/formats/po/serialize.py
+++ b/python/moz/l10n/formats/po/serialize.py
@@ -18,11 +18,13 @@ from collections.abc import Iterator
 
 from polib import POEntry, POFile
 
-from ...model import Entry, PatternMessage, Resource, SelectMessage
+from ...model import Entry, Message, PatternMessage, Resource, SelectMessage
 
 
 def po_serialize(
-    resource: Resource, trim_comments: bool = False, wrapwidth: int = 78
+    resource: Resource[str] | Resource[Message],
+    trim_comments: bool = False,
+    wrapwidth: int = 78,
 ) -> Iterator[str]:
     """
     Serialize a resource as the contents of a .po file.
@@ -52,7 +54,9 @@ def po_serialize(
             if isinstance(entry, Entry):
                 pe = POEntry(msgctxt=context, msgid=".".join(entry.id))
                 msg = entry.value
-                if isinstance(msg, PatternMessage) and all(
+                if isinstance(msg, str):
+                    pe.msgstr = msg
+                elif isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern
                 ):
                     pe.msgstr = "".join(msg.pattern)  # type: ignore[arg-type]

--- a/python/moz/l10n/formats/properties/parse.py
+++ b/python/moz/l10n/formats/properties/parse.py
@@ -53,7 +53,7 @@ def properties_parse(
     source: bytes | str,
     encoding: str = "utf-8",
     parse_message: Callable[[str], Message] | None = None,
-) -> Resource:
+) -> Resource[Message]:
     """
     Parse a .properties file into a message resource.
 
@@ -65,13 +65,13 @@ def properties_parse(
     if not isinstance(source, str):
         source = source.decode(encoding)
     parser = PropertiesParser(source)
-    entries: list[Entry | Comment] = []
+    entries: list[Entry[Message] | Comment] = []
     resource = Resource(Format.properties, [Section((), entries)])
 
     start_line = 0
     comment = ""
     prev_linepos: LinePos | None = None
-    entry: Entry | None = None
+    entry: Entry[Message] | None = None
     for kind, line, value in parser:
         if kind == LineKind.VALUE:
             assert entry

--- a/python/moz/l10n/formats/properties/serialize.py
+++ b/python/moz/l10n/formats/properties/serialize.py
@@ -40,7 +40,7 @@ def encode_char(m: Match[str]) -> str:
 
 
 def properties_serialize(
-    resource: Resource,
+    resource: Resource[str] | Resource[Message],
     encoding: Literal["iso-8859-1", "utf-8", "utf-16"] = "utf-8",
     serialize_message: Callable[[Message], str] | None = None,
     trim_comments: bool = False,
@@ -51,8 +51,7 @@ def properties_serialize(
     Section identifiers will be prepended to their constituent message identifiers.
     Multi-part message identifiers will be joined with `.` between each part.
 
-    A `serialize_message` callable may be provided to customize the serialization,
-    as a .properties file may contain messages in any format.
+    For non-string message values, a `serialize_message` callable must be provided.
 
     Metadata is not supported.
 
@@ -99,7 +98,9 @@ def properties_serialize(
 
                 value: str
                 msg = entry.value
-                if serialize_message:
+                if isinstance(msg, str):
+                    value = msg
+                elif serialize_message:
                     value = serialize_message(msg)
                 elif isinstance(msg, PatternMessage) and all(
                     isinstance(p, str) for p in msg.pattern

--- a/python/moz/l10n/formats/webext/parse.py
+++ b/python/moz/l10n/formats/webext/parse.py
@@ -21,6 +21,7 @@ from ...model import (
     Comment,
     Entry,
     Expression,
+    Message,
     Pattern,
     PatternMessage,
     Resource,
@@ -34,7 +35,7 @@ placeholder = compile(r"\$([a-zA-Z0-9_@]+)\$|(\$[1-9])|\$(\$+)")
 pos_arg = compile(r"\$([1-9])")
 
 
-def webext_parse(source: str | bytes) -> Resource:
+def webext_parse(source: str | bytes) -> Resource[Message]:
     """
     Parse a messages.json file into a message resource.
 
@@ -44,7 +45,7 @@ def webext_parse(source: str | bytes) -> Resource:
     The parsed resource will not include any metadata.
     """
     json: dict[str, dict[str, Any]] = json_linecomment_loads(source)
-    entries: list[Entry | Comment] = []
+    entries: list[Entry[Message] | Comment] = []
     for key, msg in json.items():
         src: str = msg["message"]
         comment: str = msg.get("description", "")

--- a/python/moz/l10n/formats/xliff/parse.py
+++ b/python/moz/l10n/formats/xliff/parse.py
@@ -25,6 +25,7 @@ from ...model import (
     Comment,
     Entry,
     Expression,
+    Message,
     Metadata,
     PatternMessage,
     Resource,
@@ -36,7 +37,7 @@ from .parse_trans_unit import parse_trans_unit
 from .parse_xcode import parse_xliff_stringsdict
 
 
-def xliff_parse(source: str | bytes) -> Resource:
+def xliff_parse(source: str | bytes) -> Resource[Message]:
     """
     Parse an XLIFF 1.2 file into a message resource.
 
@@ -66,7 +67,7 @@ def xliff_parse(source: str | bytes) -> Resource:
     if root.text and not root.text.isspace():
         raise ValueError(f"Unexpected text in <xliff>: {root.text}")
 
-    res = Resource(Format.xliff, [])
+    res: Resource[Message] = Resource(Format.xliff, [])
     root_comments = [
         c.text for c in root.itersiblings(etree.Comment, preceding=True) if c.text
     ]
@@ -88,7 +89,7 @@ def xliff_parse(source: str | bytes) -> Resource:
             if file_name is None:
                 raise ValueError(f'Missing "original" attribute for <file>: {file}')
             meta = attrib_as_metadata(file, None, ("original",))
-            entries: list[Entry | Comment] = []
+            entries: list[Entry[Message] | Comment] = []
             body = None
             for child in file:
                 if isinstance(child, etree._Comment):
@@ -120,7 +121,9 @@ def xliff_parse(source: str | bytes) -> Resource:
             if file_name.endswith(".stringsdict"):
                 plural_entries = parse_xliff_stringsdict(ns, body)
                 if plural_entries is not None:
-                    entries += cast(List[Union[Entry, Comment]], plural_entries)
+                    entries += cast(
+                        List[Union[Entry[Message], Comment]], plural_entries
+                    )
                     continue
 
             for unit in body:
@@ -141,11 +144,13 @@ def xliff_parse(source: str | bytes) -> Resource:
     return res
 
 
-def parse_group(ns: str, parent: list[str], group: etree._Element) -> Iterator[Section]:
+def parse_group(
+    ns: str, parent: list[str], group: etree._Element
+) -> Iterator[Section[Message]]:
     id = group.attrib.get("id", "")
     path = [*parent, id]
     meta = attrib_as_metadata(group, None, ("id",))
-    entries: list[Entry | Comment] = []
+    entries: list[Entry[Message] | Comment] = []
     if group.text and not group.text.isspace():
         raise ValueError(f"Unexpected text in <group>: {group.text}")
 
@@ -173,7 +178,7 @@ def parse_group(ns: str, parent: list[str], group: etree._Element) -> Iterator[S
             raise ValueError(f"Unexpected text in <group>: {unit.tail}")
 
 
-def parse_bin_unit(unit: etree._Element) -> Entry:
+def parse_bin_unit(unit: etree._Element) -> Entry[Message]:
     id = unit.attrib.get("id", None)
     if id is None:
         raise ValueError(f'Missing "id" attribute for <bin-unit>: {unit}')

--- a/python/moz/l10n/formats/xliff/parse_trans_unit.py
+++ b/python/moz/l10n/formats/xliff/parse_trans_unit.py
@@ -19,11 +19,11 @@ from collections.abc import Iterator
 
 from lxml import etree
 
-from ...model import Entry, Markup, Metadata, PatternMessage, VariableRef
+from ...model import Entry, Markup, Message, Metadata, PatternMessage, VariableRef
 from .common import attrib_as_metadata, element_as_metadata, pretty_name, xliff_ns
 
 
-def parse_trans_unit(unit: etree._Element) -> Entry:
+def parse_trans_unit(unit: etree._Element) -> Entry[Message]:
     id = unit.attrib.get("id", None)
     if id is None:
         raise ValueError(f'Missing "id" attribute for <trans-unit>: {unit}')

--- a/python/moz/l10n/formats/xliff/parse_xcode.py
+++ b/python/moz/l10n/formats/xliff/parse_xcode.py
@@ -54,7 +54,9 @@ printf = compile(
 )
 
 
-def parse_xliff_stringsdict(ns: str, body: etree._Element) -> list[Entry] | None:
+def parse_xliff_stringsdict(
+    ns: str, body: etree._Element
+) -> list[Entry[SelectMessage]] | None:
     plurals: dict[str, XcodePlural] = {}
     for unit in body:
         if unit.tag != f"{ns}trans-unit":

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Literal, Tuple, Union
+from typing import Dict, Generic, List, Literal, Tuple, TypeVar, Union
 
 from .formats import Format
 
@@ -191,8 +191,14 @@ class Comment:
     """
 
 
+V = TypeVar("V")
+"""
+The Message value type.
+"""
+
+
 @dataclass
-class Entry:
+class Entry(Generic[V]):
     """
     A message entry.
 
@@ -213,7 +219,7 @@ class Entry:
     i.e. the concatenation of its section header identifier (if any) and its own.
     """
 
-    value: Message
+    value: V
     """
     The value of an entry, i.e. the message.
 
@@ -244,7 +250,7 @@ class Entry:
 
 
 @dataclass
-class Section:
+class Section(Generic[V]):
     """
     A section of a resource.
 
@@ -269,7 +275,7 @@ class Section:
     i.e. they do not include this identifier.
     """
 
-    entries: list[Entry | Comment]
+    entries: list[Entry[V] | Comment]
     """
     Section entries consist of message entries and comments.
 
@@ -300,7 +306,7 @@ class Section:
 
 
 @dataclass
-class Resource:
+class Resource(Generic[V]):
     """
     A message resource.
 
@@ -313,7 +319,7 @@ class Resource:
     The serialization format for the resource, if any.
     """
 
-    sections: list[Section]
+    sections: list[Section[V]]
     """
     The body of a resource, consisting of an array of sections.
 

--- a/python/moz/l10n/resource/add_entries.py
+++ b/python/moz/l10n/resource/add_entries.py
@@ -15,13 +15,23 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from typing import Any
 
-from ..model import Comment, Entry, Resource, Section
+from ..model import (
+    Comment,
+    Entry,
+    Resource,
+    Section,
+    V,
+)
+
+RS = Section[Any]
+RE = Entry[Any]
 
 
 def add_entries(
-    target: Resource,
-    source: Resource,
+    target: Resource[V],
+    source: Resource[V],
     *,
     use_source_entries: bool = False,
 ) -> int:
@@ -38,11 +48,11 @@ def add_entries(
     """
 
     change_count = 0
-    cur_tgt_section: Section | None = None
+    cur_tgt_section: RS | None = None
     for src_section in source.sections:
         tgt_match = [s for s in target.sections if s.id == src_section.id]
-        prev_pos: tuple[Section, int] | None = None
-        new_entries: list[Entry | Comment] = []
+        prev_pos: tuple[RS, int] | None = None
+        new_entries: list[RE | Comment] = []
         for entry in src_section.entries:
             if isinstance(entry, Entry):
                 target_pos = next(

--- a/python/moz/l10n/resource/l10n_equal.py
+++ b/python/moz/l10n/resource/l10n_equal.py
@@ -15,17 +15,17 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from typing import Dict, List, Set, Tuple, TypeVar
+from typing import Any, Dict, List, Set, Tuple, TypeVar
 
-from ..model import Entry, Message, Resource, Section
+from ..model import Entry, Resource, Section
 
 _T = TypeVar("_T")
 _L10nData = List[
-    Tuple[Tuple[str, ...], str, Dict[str, Set[str]], _T]
+    Tuple[Tuple[str, ...], str, Dict[str, Set[Any]], _T]
 ]  # id, comment, value
 
 
-def l10n_equal(a: Resource, b: Resource) -> bool:
+def l10n_equal(a: Resource[Any], b: Resource[Any]) -> bool:
     """
     Compares the localization-relevant content
     (id, comment, metadata, message values) of two resources.
@@ -41,7 +41,7 @@ def l10n_equal(a: Resource, b: Resource) -> bool:
     )
 
 
-def l10n_sections(resource: Resource) -> _L10nData[_L10nData[Message]]:
+def l10n_sections(resource: Resource[Any]) -> _L10nData[_L10nData[Any]]:
     ls = [
         (section.id, section.comment.strip(), l10n_meta(section), l10n_entries(section))
         for section in resource.sections
@@ -62,7 +62,7 @@ def l10n_sections(resource: Resource) -> _L10nData[_L10nData[Message]]:
     return ls
 
 
-def l10n_entries(section: Section) -> _L10nData[Message]:
+def l10n_entries(section: Section[Any]) -> _L10nData[Any]:
     le = [
         (entry.id, entry.comment.strip(), l10n_meta(entry), entry.value)
         for entry in section.entries
@@ -73,9 +73,9 @@ def l10n_entries(section: Section) -> _L10nData[Message]:
 
 
 def l10n_meta(
-    x: Entry | Section | Resource,
-) -> dict[str, set[str]]:
-    md: dict[str, set[str]] = defaultdict(set)
+    x: Entry[Any] | Section[Any] | Resource[Any],
+) -> dict[str, set[Any]]:
+    md: dict[str, set[Any]] = defaultdict(set)
     for m in x.meta:
         md[m.key].add(m.value)
     return md

--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -25,10 +25,10 @@ from ..formats.plain_json.parse import plain_json_parse
 from ..formats.po.parse import po_parse
 from ..formats.properties.parse import properties_parse
 from ..formats.webext.parse import webext_parse
-from ..model import Resource
+from ..model import Message, Resource
 
-android_parse: Callable[[str | bytes], Resource] | None
-xliff_parse: Callable[[str | bytes], Resource] | None
+android_parse: Callable[[str | bytes], Resource[Message]] | None
+xliff_parse: Callable[[str | bytes], Resource[Message]] | None
 try:
     from ..formats.android.parse import android_parse
     from ..formats.xliff.parse import xliff_parse
@@ -43,7 +43,7 @@ class UnsupportedResource(Exception):
 
 def parse_resource(
     input: Format | str | None, source: str | bytes | None = None
-) -> Resource:
+) -> Resource[Message]:
     """
     Parse a Resource from its string representation.
 

--- a/python/moz/l10n/resource/serialize_resource.py
+++ b/python/moz/l10n/resource/serialize_resource.py
@@ -26,10 +26,14 @@ from ..formats.plain_json.serialize import plain_json_serialize
 from ..formats.po.serialize import po_serialize
 from ..formats.properties.serialize import properties_serialize
 from ..formats.webext.serialize import webext_serialize
-from ..model import Resource
+from ..model import Message, Resource
 
-android_serialize: Callable[[Resource, bool], Iterator[str]] | None
-xliff_serialize: Callable[[Resource, bool], Iterator[str]] | None
+android_serialize: (
+    Callable[[Resource[str] | Resource[Message], bool], Iterator[str]] | None
+)
+xliff_serialize: (
+    Callable[[Resource[str] | Resource[Message], bool], Iterator[str]] | None
+)
 try:
     from ..formats.android.serialize import android_serialize
     from ..formats.xliff.serialize import xliff_serialize
@@ -39,7 +43,7 @@ except ImportError:
 
 
 def serialize_resource(
-    resource: Resource,
+    resource: Resource[str] | Resource[Message],
     format: Format | None = None,
     trim_comments: bool = False,
 ) -> Iterator[str]:

--- a/python/tests/formats/test_dtd.py
+++ b/python/tests/formats/test_dtd.py
@@ -133,7 +133,7 @@ class TestDtd(TestCase):
 
     def test_serialize(self):
         res = dtd_parse(source)
-        res.sections[0].entries.insert(0, Entry(("foo",), PatternMessage(['"bar"'])))
+        res.sections[0].entries.insert(0, Entry(("foo",), '"bar"'))
         assert "".join(dtd_serialize(res)) == dedent(
             """\
             <!-- This Source Code Form is subject to the terms of the Mozilla Public

--- a/python/tests/formats/test_fluent.py
+++ b/python/tests/formats/test_fluent.py
@@ -18,6 +18,7 @@ from importlib_resources import files
 from textwrap import dedent
 from unittest import TestCase
 
+from fluent.syntax import ast as ftl
 from moz.l10n.formats import Format
 from moz.l10n.formats.fluent import fluent_parse, fluent_serialize
 from moz.l10n.model import (
@@ -38,6 +39,29 @@ from . import get_linepos
 
 
 class TestFluent(TestCase):
+    def test_fluent_value(self):
+        source = dedent(
+            """\
+            key =
+                pre { $a ->
+                    [1] One
+                   *[2] Two
+                } mid { $b ->
+                   *[bb] BB
+                    [cc] CC
+                } post
+                .attr = foo
+            """
+        )
+        res = fluent_parse(source, as_ftl_patterns=True)
+        assert len(res.sections) == 1
+        assert len(res.sections[0].entries) == 2
+        assert res.sections[0].entries[0].id == ("key",)
+        assert isinstance(res.sections[0].entries[0].value, ftl.Pattern)
+        assert res.sections[0].entries[1].id == ("key", "attr")
+        assert isinstance(res.sections[0].entries[1].value, ftl.Pattern)
+        assert "".join(fluent_serialize(res)) == source
+
     def test_equality_same(self):
         source = 'progress = Progress: { NUMBER($num, style: "percent") }.'
         res1 = fluent_parse(source)
@@ -491,7 +515,7 @@ class TestFluent(TestCase):
 
     def test_junk(self):
         with self.assertRaisesRegex(Exception, 'Expected token: "="'):
-            fluent_parse("msg = value\n# Comment\nLine of junk")
+            fluent_parse("msg = value\n# Comment\nLine of junk", as_ftl_patterns=True)
 
     def test_file(self):
         bytes = files("tests.formats.data").joinpath("demo.ftl").read_bytes()


### PR DESCRIPTION
Reverts #54

I wasn't thinking straight when proposing this earlier: We still need to support resources with string values to be able to use moz.l10n serialisers in Pontoon, at least until the message data model refactor (mozilla/pontoon#3538) is further along.

We should still apply this change, but not yet.