### PR TITLE
Various resource format fixes

### DIFF
--- a/python/.gitignore
+++ b/python/.gitignore
@@ -1,2 +1,3 @@
+/build/
 __pycache__/
 *.egg-info/

--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -252,8 +252,7 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
 
 def set_pattern_message(el: etree._Element, msg: PatternMessage | str) -> None:
     if isinstance(msg, str):
-        el.text = escape_backslash(msg)
-        escape_doublequote(el)
+        el.text = msg.replace("'", "\\'")
     elif isinstance(msg, PatternMessage) and not msg.declarations:
         set_pattern(el, msg.pattern)
     else:

--- a/python/moz/l10n/formats/po/parse.py
+++ b/python/moz/l10n/formats/po/parse.py
@@ -19,6 +19,7 @@ from collections import OrderedDict
 from polib import pofile
 
 from ...model import (
+    CatchallKey,
     Entry,
     Expression,
     Message,
@@ -68,14 +69,15 @@ def po_parse(source: str | bytes) -> Resource[Message]:
             keys = list(pe.msgstr_plural)
             keys.sort()
             sel = Expression(VariableRef("n"), "number")
+            max_idx = keys[-1]
             value: Message = SelectMessage(
                 declarations={"n": sel},
                 selectors=(VariableRef("n"),),
                 variants={
-                    (str(idx),): (
+                    (str(idx) if idx < max_idx else CatchallKey(str(idx)),): (
                         [pe.msgstr_plural[idx]] if idx in pe.msgstr_plural else []
                     )
-                    for idx in range(keys[-1] + 1)
+                    for idx in range(max_idx + 1)
                 },
             )
         else:

--- a/python/moz/l10n/formats/po/serialize.py
+++ b/python/moz/l10n/formats/po/serialize.py
@@ -15,6 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from re import match
 
 from polib import POEntry, POFile
 
@@ -24,7 +25,7 @@ from ...model import Entry, Message, PatternMessage, Resource, SelectMessage
 def po_serialize(
     resource: Resource[str] | Resource[Message],
     trim_comments: bool = False,
-    wrapwidth: int = 78,
+    wrapwidth: int = 200,
 ) -> Iterator[str]:
     """
     Serialize a resource as the contents of a .po file.
@@ -39,10 +40,17 @@ def po_serialize(
     """
 
     pf = POFile(wrapwidth=wrapwidth)
-    if not trim_comments:
+    if not trim_comments and resource.comment and not resource.comment.isspace():
         pf.header = resource.comment.rstrip() + "\n"
-    pf.metadata = {m.key: str(m.value) for m in resource.meta}
+    pf.metadata = {m.key: m.value for m in resource.meta}
     yield str(pf)
+
+    nplurals = 1
+    plural_forms = pf.metadata.get("Plural-Forms", None)
+    if isinstance(plural_forms, str):
+        pm = match(r"\s*nplurals=(\d+);", plural_forms)
+        if pm is not None:
+            nplurals = int(pm[1])
 
     for section in resource.sections:
         if section.comment:
@@ -72,14 +80,22 @@ def po_serialize(
                         for keys, pattern in msg.variants.items()
                     )
                 ):
-                    values = [
-                        "".join(pattern)  # type: ignore[arg-type]
-                        for pattern in msg.variants.values()
-                    ]
-                    if len(values) == 1:
-                        pe.msgstr = values[0]
-                    else:
-                        pe.msgstr_plural = {idx: str for idx, str in enumerate(values)}
+                    pe.msgstr_plural = {
+                        idx: next(
+                            (
+                                "".join(pattern)  # type: ignore[arg-type]
+                                for keys, pattern in msg.variants.items()
+                                if (
+                                    key
+                                    if isinstance(key := keys[0], str)
+                                    else key.value
+                                )
+                                == str(idx)
+                            ),
+                            "",
+                        )
+                        for idx in range(nplurals)
+                    }
                 else:
                     raise ValueError(
                         f"Value for {entry.id} is not supported: {entry.value}"

--- a/python/moz/l10n/formats/po/serialize.py
+++ b/python/moz/l10n/formats/po/serialize.py
@@ -30,13 +30,12 @@ def po_serialize(
     """
     Serialize a resource as the contents of a .po file.
 
-    Multi-part identifiers will be joined with `.` between each part.
-    Section identifiers are serialized as message contexts.
+    Section identifiers are not supported.
+    Message identifiers may have one or two parts,
+    with the second one holding the optional message context.
     Comments and metadata on sections is not supported.
 
     Yields each entry and empty line separately.
-    Re-parsing a serialized .properties file is not guaranteed to result in the same Resource,
-    as the serialization may lose information about message identifiers.
     """
 
     pf = POFile(wrapwidth=wrapwidth)
@@ -54,13 +53,13 @@ def po_serialize(
 
     for section in resource.sections:
         if section.comment:
-            raise ValueError(f"Section comments are not supported: {section.id}")
+            raise ValueError("Section comments are not supported")
         if section.meta:
-            raise ValueError(f"Section metadata is not supported: {section.id}")
-        context = ".".join(section.id) if section.id else None
+            raise ValueError("Section metadata is not supported")
         for entry in section.entries:
             if isinstance(entry, Entry):
-                pe = POEntry(msgctxt=context, msgid=".".join(entry.id))
+                context = entry.id[1] if len(entry.id) == 2 else None
+                pe = POEntry(msgctxt=context, msgid=entry.id[0])
                 msg = entry.value
                 if isinstance(msg, str):
                     pe.msgstr = msg

--- a/python/moz/l10n/formats/properties/serialize.py
+++ b/python/moz/l10n/formats/properties/serialize.py
@@ -97,9 +97,11 @@ def properties_serialize(
                 key = key.translate(special_key_trans)
 
                 value: str
+                is_raw = False
                 msg = entry.value
                 if isinstance(msg, str):
                     value = msg
+                    is_raw = True
                 elif serialize_message:
                     value = serialize_message(msg)
                 elif isinstance(msg, PatternMessage) and all(
@@ -109,11 +111,12 @@ def properties_serialize(
                 else:
                     raise ValueError(f"Unsupported message for {key}: {msg}")
 
-                value = (
-                    control_chars.sub(encode_char, value)
-                    if encoding in {"utf-8", "utf-16"}
-                    else not_ascii_printable_chars.sub(encode_char, value)
-                )
+                if not is_raw:
+                    value = (
+                        control_chars.sub(encode_char, value)
+                        if encoding in {"utf-8", "utf-16"}
+                        else not_ascii_printable_chars.sub(encode_char, value)
+                    )
 
                 if value[0:1].isspace():
                     value = "\\" + value

--- a/python/moz/l10n/formats/webext/serialize.py
+++ b/python/moz/l10n/formats/webext/serialize.py
@@ -64,7 +64,7 @@ def webext_serialize(
                     raise ValueError(f"Unsupported entry identifier: {entry.id}")
                 name = entry.id[0]
                 if isinstance(entry.value, str):
-                    res[name] = {"message": sub(r"\$+", r"$\g<0>", entry.value)}
+                    res[name] = {"message": entry.value}
                     if not trim_comments and entry.comment:
                         res[name]["description"] = entry.comment
                 elif isinstance(entry.value, PatternMessage):

--- a/python/moz/l10n/formats/xliff/serialize.py
+++ b/python/moz/l10n/formats/xliff/serialize.py
@@ -143,7 +143,11 @@ def xliff_serialize(
             msg = entry.value
             target = None
             source = None
-            if tag == "trans-unit" and msg:
+            if (
+                tag == "trans-unit"
+                and msg
+                and (not isinstance(msg, PatternMessage) or msg.pattern)
+            ):
                 target = unit.find("target")
                 if target is None:
                     source = unit.find("source")
@@ -158,7 +162,7 @@ def xliff_serialize(
                 else:
                     raise ValueError(f"Unsupported message: {msg}")
 
-            if entry.comment and not trim_comments:
+            if entry.comment and not entry.comment.isspace() and not trim_comments:
                 note = unit.find("note")
                 if note is None:
                     if target is None:
@@ -258,11 +262,12 @@ def assign_metadata(
     for m in meta:
         key = m.key[key_start:] if key_start else m.key
         if key == "":
-            if len(el) == 0:
-                el.text = (el.text or "") + m.value
-            else:
-                last = el[-1]
-                last.tail = (last.tail or "") + m.value
+            if m.value:
+                if len(el) == 0:
+                    el.text = (el.text or "") + m.value
+                else:
+                    last = el[-1]
+                    last.tail = (last.tail or "") + m.value
         elif key == "comment()":
             el.append(etree.Comment(m.value))
         elif key.startswith("@"):

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -23,6 +23,7 @@ __all__ = [
     "Resource",
     "Section",
     "Entry",
+    "Id",
     "Comment",
     "Metadata",
     "Message",
@@ -196,6 +197,11 @@ V = TypeVar("V")
 The Message value type.
 """
 
+Id = Tuple[str, ...]
+"""
+An entry or section identifier.
+"""
+
 
 @dataclass
 class Entry(Generic[V]):
@@ -206,11 +212,11 @@ class Entry(Generic[V]):
     and the second one defines the metadata value type.
     """
 
-    id: tuple[str, ...]
+    id: Id
     """
     The entry identifier.
 
-    This MUST be a non-empty array of non-empty `string` values.
+    This MUST be a non-empty tuple of non-empty `string` values.
 
     The entry identifiers are not normalized,
     i.e. they do not include this identifier.
@@ -258,7 +264,7 @@ class Section(Generic[V]):
     and the second one defines the metadata value type.
     """
 
-    id: tuple[str, ...]
+    id: Id
     """
     The section identifier.
 

--- a/python/tests/formats/data/angular.xliff
+++ b/python/tests/formats/data/angular.xliff
@@ -19,7 +19,7 @@
       <trans-unit id="icu_plural" datatype="html">
         <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minutes ago} }</source>
         <target>{VAR_PLURAL, plural, =0 {juuri nyt} =1 {minuutti sitten} other {<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minuuttia sitten} }</target>
-        <note></note>
+        <note/>
       </trans-unit>
     </body>
   </file>

--- a/python/tests/formats/test_po.py
+++ b/python/tests/formats/test_po.py
@@ -20,6 +20,7 @@ from unittest import TestCase
 from moz.l10n.formats import Format
 from moz.l10n.formats.po import po_parse, po_serialize
 from moz.l10n.model import (
+    CatchallKey,
     Entry,
     Expression,
     Metadata,
@@ -80,7 +81,7 @@ class TestPo(TestCase):
                                     ("0",): ["%d prevedenih sporočil"],
                                     ("1",): ["%d prevedeno sporočilo"],
                                     ("2",): ["%d prevedeni sporočili"],
-                                    ("3",): ["%d prevedena sporočila"],
+                                    (CatchallKey("3"),): ["%d prevedena sporočila"],
                                 },
                             ),
                         ),

--- a/python/tests/formats/test_po.py
+++ b/python/tests/formats/test_po.py
@@ -86,20 +86,15 @@ class TestPo(TestCase):
                             ),
                         ),
                         Entry(
+                            ("original string", "context"),
+                            PatternMessage(["translated string"]),
+                        ),
+                        Entry(
                             ("obsolete string",),
                             meta=[Metadata("obsolete", "true")],
                             value=PatternMessage(["translated string"]),
                         ),
                         Entry(("other string",), PatternMessage(["translated string"])),
-                    ],
-                ),
-                Section(
-                    id=("context",),
-                    entries=[
-                        Entry(
-                            ("original string",),
-                            PatternMessage(["translated string"]),
-                        )
                     ],
                 ),
             ],
@@ -138,14 +133,14 @@ msgstr[1] "%d prevedeno sporočilo"
 msgstr[2] "%d prevedeni sporočili"
 msgstr[3] "%d prevedena sporočila"
 
+msgctxt "context"
+msgid "original string"
+msgstr "translated string"
+
 #~ msgid "obsolete string"
 #~ msgstr "translated string"
 
 msgid "other string"
-msgstr "translated string"
-
-msgctxt "context"
-msgid "original string"
 msgstr "translated string"
 """
         )
@@ -178,11 +173,11 @@ msgstr[1] "%d prevedeno sporočilo"
 msgstr[2] "%d prevedeni sporočili"
 msgstr[3] "%d prevedena sporočila"
 
-msgid "other string"
-msgstr "translated string"
-
 msgctxt "context"
 msgid "original string"
+msgstr "translated string"
+
+msgid "other string"
 msgstr "translated string"
 """
         )
@@ -190,7 +185,7 @@ msgstr "translated string"
     def test_obsolete(self):
         res = po_parse(source)
         res.sections[0].entries[0].meta.append(Metadata("obsolete", True))
-        res.sections[0].entries[2].meta = []
+        res.sections[0].entries[3].meta = []
         assert (
             "".join(po_serialize(res))
             == r"""# Test translation file.
@@ -222,14 +217,14 @@ msgstr[1] "%d prevedeno sporočilo"
 msgstr[2] "%d prevedeni sporočili"
 msgstr[3] "%d prevedena sporočila"
 
+msgctxt "context"
+msgid "original string"
+msgstr "translated string"
+
 msgid "obsolete string"
 msgstr "translated string"
 
 msgid "other string"
-msgstr "translated string"
-
-msgctxt "context"
-msgid "original string"
 msgstr "translated string"
 """
         )

--- a/python/tests/formats/test_xliff1.py
+++ b/python/tests/formats/test_xliff1.py
@@ -203,7 +203,7 @@ class TestXliff1(TestCase):
                   <trans-unit id="icu_plural" datatype="html">
                     <source>{VAR_PLURAL, plural, =0 {just now} =1 {one minute ago} other {<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minutes ago} }</source>
                     <target>{VAR_PLURAL, plural, =0 {juuri nyt} =1 {minuutti sitten} other {<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minuuttia sitten} }</target>
-                    <note></note>
+                    <note/>
                   </trans-unit>
                 </body>
               </file>
@@ -375,11 +375,9 @@ class TestXliff1(TestCase):
                     <!-- The resources for a fictitious Hello World application. The application displays a single window with a logo and the hello message. -->
                     <trans-unit id="authors" resname="authors" restype="x-icu-alias">
                       <source>root/authors</source>
-                      <target/>
                     </trans-unit>
                     <trans-unit id="hello" resname="hello">
                       <source>Hello, world!</source>
-                      <target/>
                       <note>This is the message that the application displays to the user.</note>
                     </trans-unit>
                     <bin-unit id="logo" resname="logo" mime-type="image" restype="x-icu-binary" translate="no">
@@ -399,16 +397,13 @@ class TestXliff1(TestCase):
                       <group id="menus_help_menu" resname="help_menu" restype="x-icu-table">
                         <trans-unit id="menus_help_menu_name" resname="name">
                           <source>Help</source>
-                          <target/>
                         </trans-unit>
                         <group id="menus_help_menu_items" resname="items" restype="x-icu-array">
                           <trans-unit id="menus_help_menu_items_0">
                             <source>Help Topics</source>
-                            <target/>
                           </trans-unit>
                           <trans-unit id="menus_help_menu_items_1">
                             <source>About Hello World</source>
-                            <target/>
                           </trans-unit>
                         </group>
                       </group>
@@ -435,11 +430,9 @@ class TestXliff1(TestCase):
                   <group id="en" restype="x-icu-table">
                     <trans-unit id="authors" resname="authors" restype="x-icu-alias">
                       <source>root/authors</source>
-                      <target/>
                     </trans-unit>
                     <trans-unit id="hello" resname="hello">
                       <source>Hello, world!</source>
-                      <target/>
                     </trans-unit>
                     <bin-unit id="logo" resname="logo" mime-type="image" restype="x-icu-binary" translate="no">
                       <!--The logo to be displayed in the application window.-->
@@ -457,16 +450,13 @@ class TestXliff1(TestCase):
                       <group id="menus_help_menu" resname="help_menu" restype="x-icu-table">
                         <trans-unit id="menus_help_menu_name" resname="name">
                           <source>Help</source>
-                          <target/>
                         </trans-unit>
                         <group id="menus_help_menu_items" resname="items" restype="x-icu-array">
                           <trans-unit id="menus_help_menu_items_0">
                             <source>Help Topics</source>
-                            <target/>
                           </trans-unit>
                           <trans-unit id="menus_help_menu_items_1">
                             <source>About Hello World</source>
-                            <target/>
                           </trans-unit>
                         </group>
                       </group>


### PR DESCRIPTION
Identified during Pontoon dev work:
- Gettext plural messages are now consistently parsed & serialised with the same numerical identifiers.
- A gettext `msgctx` is considered secondary to the `msgid`, rather than a section header.
- When serialising, consider entries with `str` values to have already been appropriately escaped.
- Extraneous string contents in Android strings.xml files should not cause an error.
- In XLIFF, be consistent regarding empty `<node>` and `<target>` elements.