### PR TITLE
Add single-message/pattern parsers

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -116,6 +116,34 @@ def message_to_json(msg: Message) -> list[Any] | dict[str, Any]: ...
 Converters to and from a JSON-serializable representation of a `Message`.
 The format of the output is defined by the [`schema.json`](./moz/l10n/message/schema.json) JSON Schema.
 
+### moz.l10n.message.parse_message
+
+```python
+from moz.l10n.message import parse_message
+def parse_message(
+    format: Format,
+    source: str,
+    *,
+    printf_placeholders: bool = False,
+    webext_placeholders: dict[str, dict[str, str]] | None = None,
+    xliff_is_xcode: bool = False,
+) -> Message:
+    ...
+```
+
+Parse a `Message` from its string representation.
+
+Custom parsers are used for `android`, `mf2`, `webext`, and `xliff` formats.
+Other formats may include printf specifiers if `printf_placeholders` is enabled.
+
+Parsing a `webext` message that contains named placeholders requires
+providing the message's `webext_placeholders` dict.
+
+To parse an `xliff` message with XCode customizations, enable `xliff_is_xcode`.
+
+Formatting `fluent` messages is not supported,
+as their parsing may result in multiple `Entry` values.
+
 ### moz.l10n.model
 
 ```python

--- a/python/moz/l10n/bin/build.py
+++ b/python/moz/l10n/bin/build.py
@@ -22,10 +22,10 @@ from os.path import dirname, exists, join, relpath
 from shutil import copyfile
 from textwrap import dedent
 
-from moz.l10n.formats import Format
+from moz.l10n.formats import Format, UnsupportedFormat
 from moz.l10n.model import Comment, Entry, Message, Resource, Section
 from moz.l10n.paths.config import L10nConfigPaths
-from moz.l10n.resource import UnsupportedResource, parse_resource, serialize_resource
+from moz.l10n.resource import parse_resource, serialize_resource
 
 log = logging.getLogger(__name__)
 
@@ -87,7 +87,7 @@ def cli() -> None:
         log.debug(f"source {source_path}")
         try:
             source = parse_resource(source_path)
-        except UnsupportedResource:
+        except UnsupportedFormat:
             source = None
         for locale in locales.intersection(path_locales) if path_locales else locales:
             l10n_path = l10n_path_template.format(locale=locale)

--- a/python/moz/l10n/bin/build_file.py
+++ b/python/moz/l10n/bin/build_file.py
@@ -22,7 +22,8 @@ from shutil import copyfile
 from textwrap import dedent
 
 from moz.l10n.bin.build import write_target_file
-from moz.l10n.resource import UnsupportedResource, parse_resource, serialize_resource
+from moz.l10n.formats import UnsupportedFormat
+from moz.l10n.resource import parse_resource, serialize_resource
 
 log = logging.getLogger(__name__)
 
@@ -60,7 +61,7 @@ def cli() -> None:
     try:
         try:
             source_res = parse_resource(args.source)
-        except UnsupportedResource:
+        except UnsupportedFormat:
             source_res = None
         makedirs(dirname(args.target), exist_ok=True)
         if source_res is None:
@@ -76,7 +77,7 @@ def cli() -> None:
                     file.write(line)
         else:
             write_target_file(args.source, source_res, args.l10n, args.target)
-    except (OSError, UnsupportedResource) as error:
+    except (OSError, UnsupportedFormat) as error:
         raise SystemExit(error)
 
 

--- a/python/moz/l10n/bin/compare.py
+++ b/python/moz/l10n/bin/compare.py
@@ -21,9 +21,10 @@ from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from os.path import abspath, basename, dirname, isdir, join, normpath, relpath
 from textwrap import dedent
 
+from moz.l10n.formats import UnsupportedFormat
 from moz.l10n.model import Entry
 from moz.l10n.paths import L10nConfigPaths, L10nDiscoverPaths
-from moz.l10n.resource import UnsupportedResource, parse_resource
+from moz.l10n.resource import parse_resource
 
 
 def cli() -> None:
@@ -93,7 +94,7 @@ def cli() -> None:
                 try:
                     path = relpath(tgt_path.format(locale=locale0), path0)
                     source_data[path] = msg_ids(ref_path)
-                except UnsupportedResource:
+                except UnsupportedFormat:
                     continue
     source_total = sum(len(sd) for sd in source_data.values())
     if source_total == 0:

--- a/python/moz/l10n/bin/fix.py
+++ b/python/moz/l10n/bin/fix.py
@@ -26,9 +26,10 @@ from os import getcwd
 from os.path import abspath, isdir, relpath
 from textwrap import dedent
 
+from moz.l10n.formats import UnsupportedFormat
 from moz.l10n.paths.config import L10nConfigPaths
 from moz.l10n.paths.discover import L10nDiscoverPaths
-from moz.l10n.resource import UnsupportedResource, parse_resource, serialize_resource
+from moz.l10n.resource import parse_resource, serialize_resource
 
 log = logging.getLogger(__name__)
 
@@ -164,7 +165,7 @@ def fix_file(root: str, path: str) -> Result:
                 file.truncate()
                 log.warning(f"Fixed: {rel_path}")
                 return Result.FIXED
-    except (UnsupportedResource, UnicodeDecodeError):
+    except (UnsupportedFormat, UnicodeDecodeError):
         log.info(f"Skip: {rel_path}")
         return Result.UNSUPPORTED
     except Exception as error:

--- a/python/moz/l10n/formats/__init__.py
+++ b/python/moz/l10n/formats/__init__.py
@@ -37,6 +37,7 @@ Format = Enum(
         "fluent",
         "inc",
         "ini",
+        "mf2",
         "plain_json",
         "po",
         "properties",

--- a/python/moz/l10n/formats/__init__.py
+++ b/python/moz/l10n/formats/__init__.py
@@ -75,6 +75,10 @@ both the reference and target languages in the same file.
 """
 
 
+class UnsupportedFormat(Exception):
+    pass
+
+
 def detect_format(name: str | None, source: bytes | str) -> Format | None:
     """
     Detect the format of the input based on its file extension

--- a/python/moz/l10n/formats/android/__init__.py
+++ b/python/moz/l10n/formats/android/__init__.py
@@ -1,4 +1,4 @@
-from .parse import android_parse
+from .parse import android_parse, android_parse_message
 from .serialize import android_serialize
 
-__all__ = ["android_parse", "android_serialize"]
+__all__ = ["android_parse", "android_parse_message", "android_serialize"]

--- a/python/moz/l10n/formats/fluent/__init__.py
+++ b/python/moz/l10n/formats/fluent/__init__.py
@@ -1,10 +1,10 @@
-from .parse import fluent_parse, fluent_parse_message
+from .parse import fluent_parse, fluent_parse_messages
 from .serialize import fluent_astify, fluent_astify_message, fluent_serialize
 
 __all__ = [
     "fluent_astify",
     "fluent_astify_message",
     "fluent_parse",
-    "fluent_parse_message",
+    "fluent_parse_messages",
     "fluent_serialize",
 ]

--- a/python/moz/l10n/formats/fluent/serialize.py
+++ b/python/moz/l10n/formats/fluent/serialize.py
@@ -38,7 +38,7 @@ from ...model import (
 
 
 def fluent_serialize(
-    resource: (Resource[str] | Resource[Message] | Resource[ftl.Pattern]),
+    resource: (Resource[str] | Resource[Message]),
     serialize_metadata: Callable[[Metadata], str | None] | None = None,
     trim_comments: bool = False,
 ) -> Iterator[str]:
@@ -49,7 +49,7 @@ def fluent_serialize(
     Single-part message identifiers are treated as message values,
     while two-part message identifiers are considered message attributes.
 
-    Function names are upper-cased, and annotations with the `message` function
+    Function names are upper-cased, and expressions using the `message` function
     are mapped to message and term references.
 
     Yields each entry and comment separately.
@@ -66,7 +66,7 @@ def fluent_serialize(
 
 
 def fluent_astify(
-    resource: (Resource[str] | Resource[Message] | Resource[ftl.Pattern]),
+    resource: (Resource[str] | Resource[Message]),
     serialize_metadata: Callable[[Metadata], str | None] | None = None,
     trim_comments: bool = False,
 ) -> ftl.Resource:
@@ -134,11 +134,7 @@ def fluent_astify(
                     body.append(ftl.Comment(entry.comment))
                 cur = None
             else:
-                value = (
-                    entry.value
-                    if isinstance(entry.value, ftl.Pattern)
-                    else fluent_astify_message(entry.value)
-                )
+                value = fluent_astify_message(entry.value)
                 entry_comment = comment(entry)
                 if len(entry.id) == 1:  # value
                     cur_id = entry.id[0]
@@ -181,7 +177,7 @@ def fluent_astify_message(message: str | Message) -> ftl.Pattern:
     """
     Transform a message into a corresponding Fluent AST pattern.
 
-    Function names are upper-cased, and annotations with the `message` function
+    Function names are upper-cased, and expressions using the `message` function
     are mapped to message and term references.
     """
 

--- a/python/moz/l10n/formats/webext/__init__.py
+++ b/python/moz/l10n/formats/webext/__init__.py
@@ -1,4 +1,4 @@
-from .parse import webext_parse
+from .parse import webext_parse, webext_parse_message
 from .serialize import webext_serialize
 
-__all__ = ["webext_parse", "webext_serialize"]
+__all__ = ["webext_parse", "webext_parse_message", "webext_serialize"]

--- a/python/moz/l10n/formats/xliff/__init__.py
+++ b/python/moz/l10n/formats/xliff/__init__.py
@@ -1,4 +1,4 @@
-from .parse import xliff_parse
+from .parse import xliff_parse, xliff_parse_message
 from .serialize import xliff_serialize
 
-__all__ = ["xliff_parse", "xliff_serialize"]
+__all__ = ["xliff_parse", "xliff_parse_message", "xliff_serialize"]

--- a/python/moz/l10n/formats/xliff/common.py
+++ b/python/moz/l10n/formats/xliff/common.py
@@ -27,6 +27,7 @@ xliff_ns = {
     "urn:oasis:names:tc:xliff:document:1.2",
 }
 xml_ns = "http://www.w3.org/XML/1998/namespace"
+xcode_tool_id = Metadata("header/tool/@tool-id", "com.apple.dt.xcode")
 
 
 def element_as_metadata(

--- a/python/moz/l10n/formats/xliff/parse.py
+++ b/python/moz/l10n/formats/xliff/parse.py
@@ -32,7 +32,13 @@ from ...model import (
     Section,
 )
 from .. import Format
-from .common import attrib_as_metadata, element_as_metadata, pretty_name, xliff_ns
+from .common import (
+    attrib_as_metadata,
+    element_as_metadata,
+    pretty_name,
+    xcode_tool_id,
+    xliff_ns,
+)
 from .parse_trans_unit import parse_trans_unit
 from .parse_xcode import parse_xliff_stringsdict
 
@@ -118,7 +124,8 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
             elif body.text and not body.text.isspace():
                 raise ValueError(f"Unexpected text in <body>: {body.text}")
 
-            if file_name.endswith(".stringsdict"):
+            is_xcode = xcode_tool_id in meta
+            if is_xcode and file_name.endswith(".stringsdict"):
                 plural_entries = parse_xliff_stringsdict(ns, body)
                 if plural_entries is not None:
                     entries += cast(
@@ -130,11 +137,11 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
                 if isinstance(unit, etree._Comment):
                     entries.append(Comment(comment_str(unit.text)))
                 elif unit.tag == f"{ns}trans-unit":
-                    entries.append(parse_trans_unit(unit))
+                    entries.append(parse_trans_unit(unit, is_xcode))
                 elif unit.tag == f"{ns}bin-unit":
                     entries.append(parse_bin_unit(unit))
                 elif unit.tag == f"{ns}group":
-                    res.sections += parse_group(ns, [file_name], unit)
+                    res.sections += parse_group(ns, [file_name], unit, is_xcode)
                 else:
                     raise ValueError(
                         f"Unsupported <{unit.tag}> element in <body>: {body}"
@@ -145,7 +152,7 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
 
 
 def parse_group(
-    ns: str, parent: list[str], group: etree._Element
+    ns: str, parent: list[str], group: etree._Element, is_xcode: bool
 ) -> Iterator[Section[Message]]:
     id = group.attrib.get("id", "")
     path = [*parent, id]
@@ -163,11 +170,11 @@ def parse_group(
         if isinstance(unit, etree._Comment):
             entries.append(Comment(comment_str(unit.text)))
         elif unit.tag == f"{ns}trans-unit":
-            entries.append(parse_trans_unit(unit))
+            entries.append(parse_trans_unit(unit, is_xcode))
         elif unit.tag == f"{ns}bin-unit":
             entries.append(parse_bin_unit(unit))
         elif unit.tag == f"{ns}group":
-            yield from parse_group(ns, path, unit)
+            yield from parse_group(ns, path, unit, is_xcode)
         else:
             name = pretty_name(unit, unit.tag)
             idx = seen[name] + 1

--- a/python/moz/l10n/formats/xliff/parse.py
+++ b/python/moz/l10n/formats/xliff/parse.py
@@ -39,7 +39,7 @@ from .common import (
     xcode_tool_id,
     xliff_ns,
 )
-from .parse_trans_unit import parse_trans_unit
+from .parse_trans_unit import parse_pattern, parse_trans_unit
 from .parse_xcode import parse_xliff_stringsdict
 
 
@@ -149,6 +149,17 @@ def xliff_parse(source: str | bytes) -> Resource[Message]:
                 if unit.tail and not unit.tail.isspace():
                     raise ValueError(f"Unexpected text in <body>: {unit.tail}")
     return res
+
+
+def xliff_parse_message(source: str, *, is_xcode: bool = False) -> PatternMessage:
+    """
+    Parse an XLIFF 1.2 <target> into a message.
+
+    Set `is_xcode=True` to parse XCode-style printf strings as variable references.
+    """
+    parser = etree.XMLParser(resolve_entities=False)
+    el = etree.fromstring(f"<target>{source}</target>", parser)
+    return PatternMessage(list(parse_pattern(el, is_xcode)))
 
 
 def parse_group(

--- a/python/moz/l10n/formats/xliff/parse_xcode.py
+++ b/python/moz/l10n/formats/xliff/parse_xcode.py
@@ -99,7 +99,7 @@ def parse_xliff_stringsdict(
                 meta += attrib_as_metadata(variant.target, f"{key}/target")
                 pattern_src = variant.target.text
             msg.variants[(CatchallKey("other") if key == "other" else key,)] = list(
-                parse_pattern(pattern_src)
+                parse_xcode_pattern(pattern_src)
             )
         entries.append(Entry((msg_id,), msg, meta=meta))
     return entries
@@ -178,7 +178,7 @@ def parse_xliff_stringsdict_unit(
             )
 
 
-def parse_pattern(src: str | None) -> Iterator[str | Expression]:
+def parse_xcode_pattern(src: str | None) -> Iterator[str | Expression]:
     if not src:
         return
     pos = 0

--- a/python/moz/l10n/message/__init__.py
+++ b/python/moz/l10n/message/__init__.py
@@ -1,4 +1,5 @@
 from .from_json import message_from_json
+from .parse import parse_message
 from .to_json import message_to_json
 
-__all__ = ["message_from_json", "message_to_json"]
+__all__ = ["message_from_json", "message_to_json", "parse_message"]

--- a/python/moz/l10n/message/parse.py
+++ b/python/moz/l10n/message/parse.py
@@ -1,0 +1,74 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Callable
+
+from ..formats import Format, UnsupportedFormat
+from ..formats.mf2.message_parser import mf2_parse_message
+from ..formats.webext.parse import webext_parse_message
+from ..model import Message, PatternMessage
+from .printf import parse_printf_pattern
+
+android_parse_message: Callable[[str], PatternMessage] | None = None
+xliff_parse_message: Callable[[str], PatternMessage] | None = None
+try:
+    from ..formats.android.parse import android_parse_message
+    from ..formats.xliff.parse import xliff_parse_message
+except ImportError:
+    pass
+
+
+def parse_message(
+    format: Format,
+    source: str,
+    *,
+    printf_placeholders: bool = False,
+    webext_placeholders: dict[str, dict[str, str]] | None = None,
+    xliff_is_xcode: bool = False,
+) -> Message:
+    """
+    Parse a `Message` from its string representation.
+
+    Custom parsers are used for `android`, `mf2`, `webext`, and `xliff` formats.
+    Other formats may include printf specifiers if `printf_placeholders` is enabled.
+
+    Parsing a `webext` message that contains named placeholders requires
+    providing the message's `webext_placeholders` dict.
+
+    To parse an `xliff` message with XCode customizations, enable `xliff_is_xcode`.
+
+    Formatting `fluent` messages is not supported,
+    as their parsing may result in multiple `Entry` values.
+    """
+    # TODO post-py38: should be a match
+    if format == Format.webext:
+        return webext_parse_message(source, webext_placeholders)
+    elif format == Format.android:
+        if android_parse_message is None:
+            raise UnsupportedFormat("Parsing Android messages requires [xml] extra")
+        return android_parse_message(source)
+    elif format == Format.xliff:
+        if xliff_parse_message is None:
+            raise UnsupportedFormat("Parsing XLIFF messages requires [xml] extra")
+        return xliff_parse_message(source, is_xcode=xliff_is_xcode)  # type:ignore[call-arg]
+    elif format == Format.mf2:
+        return mf2_parse_message(source)
+    elif format == Format.fluent:
+        raise UnsupportedFormat("Parsing Fluent message patterns is not supported")
+    elif printf_placeholders:
+        return PatternMessage(list(parse_printf_pattern(source)))
+    else:
+        return PatternMessage([source])

--- a/python/moz/l10n/message/printf.py
+++ b/python/moz/l10n/message/printf.py
@@ -1,0 +1,62 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from re import compile
+
+from ..model import Expression, VariableRef
+
+printf = compile(
+    #     1:argnum    2:python-name                  3:java-datetime                       4:type
+    r"%(?:([1-9])\$|\(([\w.]+)\))?[-#+ 0,]?[0-9.]*(?:([Tt][A-Za-z]+)|(?:(?:hh?|ll?|[Lzjq])?([@%A-Za-z])))"
+)
+
+
+def parse_printf_pattern(src: str | None) -> Iterator[str | Expression]:
+    if not src:
+        return
+    pos = 0
+    for m in printf.finditer(src):
+        start = m.start()
+        if start > pos:
+            yield src[pos:start]
+        source = m[0]
+        [argnum, argname, datetime, type] = m.groups()
+        pos = m.end()
+
+        if type == "%":
+            yield Expression("%", attributes={"source": source})
+            continue
+
+        func: str | None
+        # TODO post-py38: should be a match
+        if datetime:
+            func = "datetime"
+        elif type in {"c", "C", "s", "S"}:
+            func = "string"
+        elif type in {"d", "D", "o", "O", "p", "u", "U", "x", "X"}:
+            func = "integer"
+        elif type in {"a", "A", "e", "E", "f", "F", "g", "G"}:
+            func = "number"
+        else:
+            func = "printf"
+        yield Expression(
+            VariableRef(argname or ("arg" + (argnum or ""))),
+            func,
+            attributes={"source": source},
+        )
+    if pos < len(src):
+        yield src[pos:]

--- a/python/moz/l10n/resource/__init__.py
+++ b/python/moz/l10n/resource/__init__.py
@@ -1,10 +1,9 @@
 from .add_entries import add_entries
 from .l10n_equal import l10n_equal
-from .parse_resource import UnsupportedResource, parse_resource
+from .parse_resource import parse_resource
 from .serialize_resource import serialize_resource
 
 __all__ = [
-    "UnsupportedResource",
     "add_entries",
     "l10n_equal",
     "parse_resource",

--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from typing import Callable
 
-from ..formats import Format, detect_format
+from ..formats import Format, UnsupportedFormat, detect_format
 from ..formats.dtd.parse import dtd_parse
 from ..formats.fluent.parse import fluent_parse
 from ..formats.inc.parse import inc_parse
@@ -35,10 +35,6 @@ try:
 except ImportError:
     android_parse = None
     xliff_parse = None
-
-
-class UnsupportedResource(Exception):
-    pass
 
 
 def parse_resource(
@@ -84,4 +80,4 @@ def parse_resource(
     elif format == Format.xliff and xliff_parse is not None:
         return xliff_parse(source)
     else:
-        raise UnsupportedResource(f"Unsupported resource format: {input}")
+        raise UnsupportedFormat(f"Unsupported resource format: {input}")

--- a/python/tests/formats/data/xcode.xliff
+++ b/python/tests/formats/data/xcode.xliff
@@ -12,6 +12,15 @@
 Assicurati di avere una copia.</target>
         <note>Message to confirm deletion of a key file.</note>
       </trans-unit>
+      <trans-unit id="FirefoxHomepage.Common.PagesCount.v112" xml:space="preserve">
+        <source>Pages: %d</source>
+        <target>Pagine: %d</target>
+      </trans-unit>
+      <trans-unit id="Downloads.Toast.Progress.DescriptionText" xml:space="preserve">
+        <source>%1$@/%2$@</source>
+        <target>%1$@/%2$@</target>
+        <note>The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).</note>
+      </trans-unit>
     </body>
   </file>
   <file original="xcode1/en.lproj/Localizable.stringsdict" source-language="en" target-language="it" datatype="plaintext">
@@ -38,6 +47,9 @@ Assicurati di avere una copia.</target>
     </body>
   </file>
   <file original="xcode2/en.lproj/Localizable.stringsdict" source-language="en" target-language="en" datatype="plaintext">
+    <header>
+      <tool tool-id="com.apple.dt.xcode" tool-name="Xcode"/>
+    </header>
     <body>
       <trans-unit id="/followed_by_three_and_others:dict/NSStringLocalizedFormatKey:dict/:string">
         <source>%#@OTHERS@</source>

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -34,7 +34,11 @@ from moz.l10n.model import (
 )
 
 try:
-    from moz.l10n.formats.android import android_parse, android_serialize
+    from moz.l10n.formats.android import (
+        android_parse,
+        android_parse_message,
+        android_serialize,
+    )
 except ImportError:
     raise SkipTest("Requires [xml] extra")
 
@@ -380,6 +384,34 @@ class TestAndroid(TestCase):
                     ],
                 ),
             ],
+        )
+
+    def test_parse_message(self):
+        message = android_parse_message("Hello, %1$s! You have %2$d new messages.")
+        assert message == PatternMessage(
+            [
+                "Hello, ",
+                Expression(
+                    VariableRef("arg1"), "string", attributes={"source": "%1$s"}
+                ),
+                "! You have ",
+                Expression(
+                    VariableRef("arg2"), "integer", attributes={"source": "%2$d"}
+                ),
+                " new messages.",
+            ]
+        )
+
+        message = android_parse_message("Welcome to <b>&foo;</b>&bar;!")
+        assert message == PatternMessage(
+            [
+                "Welcome to ",
+                Markup("open", "b"),
+                Expression(VariableRef("foo"), "entity"),
+                Markup("close", "b"),
+                Expression(VariableRef("bar"), "entity"),
+                "!",
+            ]
         )
 
     def test_serialize(self):

--- a/python/tests/formats/test_parse_serialize_resource.py
+++ b/python/tests/formats/test_parse_serialize_resource.py
@@ -18,10 +18,9 @@ from importlib.util import find_spec
 from importlib_resources import files
 from unittest import TestCase, skipIf
 
-from moz.l10n.formats import Format
+from moz.l10n.formats import Format, UnsupportedFormat
 from moz.l10n.model import Resource
 from moz.l10n.resource import (
-    UnsupportedResource,
     parse_resource,
     serialize_resource,
 )
@@ -89,7 +88,7 @@ class TesteParseResource(TestCase):
 
     def test_parse_unknown_format(self):
         source = get_source("accounts.dtd")
-        with self.assertRaises(UnsupportedResource):
+        with self.assertRaises(UnsupportedFormat):
             parse_resource(None, source)
 
     def test_serialize_unsupported_format(self):

--- a/python/tests/formats/test_xliff1.py
+++ b/python/tests/formats/test_xliff1.py
@@ -34,7 +34,7 @@ from moz.l10n.model import (
 )
 
 try:
-    from moz.l10n.formats.xliff import xliff_parse, xliff_serialize
+    from moz.l10n.formats.xliff import xliff_parse, xliff_parse_message, xliff_serialize
 except ImportError:
     raise SkipTest("Requires [xml] extra")
 
@@ -76,6 +76,30 @@ class TestXliff1(TestCase):
                 )
             ],
         )
+
+    def test_parse_message(self):
+        msg = xliff_parse_message("Hello, <b>%s</b>")
+        assert msg == PatternMessage(
+            [
+                "Hello, ",
+                Markup(kind="open", name="b"),
+                "%s",
+                Markup(kind="close", name="b"),
+            ]
+        )
+
+        msg = xliff_parse_message("Hello, <b>%s</b>", is_xcode=True)
+        assert msg == PatternMessage(
+            [
+                "Hello, ",
+                Markup(kind="open", name="b"),
+                Expression(VariableRef("str"), "string", attributes={"source": "%s"}),
+                Markup(kind="close", name="b"),
+            ]
+        )
+
+        with self.assertRaises(Exception):
+            xliff_parse_message("Hello, <b>%s")
 
     def test_serialize_hello(self):
         res = xliff_parse(hello)

--- a/python/tests/formats/test_xliff1.py
+++ b/python/tests/formats/test_xliff1.py
@@ -512,7 +512,48 @@ class TestXliff1(TestCase):
                                 ),
                                 Metadata("target/@state", "translated"),
                             ],
-                        )
+                        ),
+                        Entry(
+                            id=("FirefoxHomepage.Common.PagesCount.v112",),
+                            value=PatternMessage(
+                                [
+                                    "Pagine: ",
+                                    Expression(
+                                        VariableRef("int"),
+                                        "integer",
+                                        attributes={"source": "%d"},
+                                    ),
+                                ]
+                            ),
+                            comment="",
+                            meta=[
+                                Metadata(key="@xml:space", value="preserve"),
+                                Metadata(key="source", value="Pages: %d"),
+                            ],
+                        ),
+                        Entry(
+                            id=("Downloads.Toast.Progress.DescriptionText",),
+                            value=PatternMessage(
+                                [
+                                    Expression(
+                                        VariableRef("arg1"),
+                                        attributes={"source": "%1$@"},
+                                    ),
+                                    "/",
+                                    Expression(
+                                        VariableRef("arg2"),
+                                        attributes={"source": "%2$@"},
+                                    ),
+                                ]
+                            ),
+                            comment="The description text in the Download progress "
+                            "toast for showing the downloaded file size "
+                            "(1$) out of the total expected file size (2$).",
+                            meta=[
+                                Metadata(key="@xml:space", value="preserve"),
+                                Metadata(key="source", value="%1$@/%2$@"),
+                            ],
+                        ),
                     ],
                 ),
                 Section(
@@ -606,6 +647,8 @@ class TestXliff1(TestCase):
                         Metadata("@source-language", "en"),
                         Metadata("@target-language", "en"),
                         Metadata("@datatype", "plaintext"),
+                        Metadata("header/tool/@tool-id", "com.apple.dt.xcode"),
+                        Metadata("header/tool/@tool-name", "Xcode"),
                     ],
                     entries=[
                         Entry(
@@ -707,6 +750,15 @@ class TestXliff1(TestCase):
             Assicurati di avere una copia.</target>
                     <note>Message to confirm deletion of a key file.</note>
                   </trans-unit>
+                  <trans-unit id="FirefoxHomepage.Common.PagesCount.v112" xml:space="preserve">
+                    <source>Pages: %d</source>
+                    <target>Pagine: %d</target>
+                  </trans-unit>
+                  <trans-unit id="Downloads.Toast.Progress.DescriptionText" xml:space="preserve">
+                    <source>%1$@/%2$@</source>
+                    <target>%1$@/%2$@</target>
+                    <note>The description text in the Download progress toast for showing the downloaded file size (1$) out of the total expected file size (2$).</note>
+                  </trans-unit>
                 </body>
               </file>
               <file original="xcode1/en.lproj/Localizable.stringsdict" source-language="en" target-language="it" datatype="plaintext">
@@ -733,6 +785,9 @@ class TestXliff1(TestCase):
                 </body>
               </file>
               <file original="xcode2/en.lproj/Localizable.stringsdict" source-language="en" target-language="en" datatype="plaintext">
+                <header>
+                  <tool tool-id="com.apple.dt.xcode" tool-name="Xcode"/>
+                </header>
                 <body>
                   <trans-unit id="/followed_by_three_and_others:dict/NSStringLocalizedFormatKey:dict/:string">
                     <source>%#@OTHERS@</source>

--- a/python/tests/test_message_parse.py
+++ b/python/tests/test_message_parse.py
@@ -1,0 +1,133 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest import SkipTest, TestCase
+
+from moz.l10n.formats import Format, UnsupportedFormat
+from moz.l10n.message import parse_message
+from moz.l10n.model import Expression, Markup, PatternMessage, VariableRef
+
+
+class TestParseMessage(TestCase):
+    def test_plain(self):
+        msg = parse_message(Format.plain_json, "hello %% world")
+        assert msg == PatternMessage(["hello %% world"])
+
+    def test_printf(self):
+        msg = parse_message(
+            Format.plain_json, "hello %% world", printf_placeholders=True
+        )
+        assert msg == PatternMessage(
+            ["hello ", Expression("%", attributes={"source": "%%"}), " world"]
+        )
+
+    def test_webext_numeric(self):
+        msg = parse_message(Format.webext, "ph $1")
+        assert msg == PatternMessage(
+            ["ph ", Expression(VariableRef("arg1"), attributes={"source": "$1"})]
+        )
+
+    def test_webext_named_no_placeholders(self):
+        with self.assertRaises(ValueError):
+            parse_message(Format.webext, "ph $x$")
+
+    def test_webext_named_with_placeholders(self):
+        msg = parse_message(
+            Format.webext, "ph $x$", webext_placeholders={"x": {"content": "$2"}}
+        )
+        assert msg == PatternMessage(
+            declarations={
+                "x": Expression(VariableRef("arg2"), attributes={"source": "$2"})
+            },
+            pattern=["ph ", Expression(VariableRef("x"), attributes={"source": "$x$"})],
+        )
+
+    def test_fluent(self):
+        with self.assertRaises(UnsupportedFormat):
+            parse_message(Format.fluent, "key = hello\n")
+
+
+class TestParseXliffMessage(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from moz.l10n.formats.xliff import xliff_parse_message  # noqa: F401
+        except ImportError:
+            raise SkipTest("Requires [xml] extra")
+
+    def test_simple(self):
+        msg = parse_message(Format.xliff, "Hello, <b>%s</b>")
+        assert msg == PatternMessage(
+            [
+                "Hello, ",
+                Markup(kind="open", name="b"),
+                "%s",
+                Markup(kind="close", name="b"),
+            ]
+        )
+
+    def test_xcode(self):
+        msg = parse_message(Format.xliff, "Hello, <b>%s</b>", xliff_is_xcode=True)
+        assert msg == PatternMessage(
+            [
+                "Hello, ",
+                Markup(kind="open", name="b"),
+                Expression(VariableRef("str"), "string", attributes={"source": "%s"}),
+                Markup(kind="close", name="b"),
+            ]
+        )
+
+    def test_parse_error(self):
+        with self.assertRaises(Exception):
+            parse_message(Format.xliff, "Hello, <b>%s")
+
+
+class TestParseAndroidMessage(TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            from moz.l10n.formats.android import android_parse_message  # noqa: F401
+        except ImportError:
+            raise SkipTest("Requires [xml] extra")
+
+    def test_placeholders(self):
+        msg = parse_message(Format.android, "Hello, %1$s! You have %2$d new messages.")
+        assert msg == PatternMessage(
+            [
+                "Hello, ",
+                Expression(
+                    VariableRef("arg1"), "string", attributes={"source": "%1$s"}
+                ),
+                "! You have ",
+                Expression(
+                    VariableRef("arg2"), "integer", attributes={"source": "%2$d"}
+                ),
+                " new messages.",
+            ]
+        )
+
+    def test_markup(self):
+        msg = parse_message(Format.android, "Welcome to <b>&foo;</b>&bar;!")
+        assert msg == PatternMessage(
+            [
+                "Welcome to ",
+                Markup("open", "b"),
+                Expression(VariableRef("foo"), "entity"),
+                Markup("close", "b"),
+                Expression(VariableRef("bar"), "entity"),
+                "!",
+            ]
+        )


### PR DESCRIPTION
Single-message Python parsers are required by Pontoon's data model migration. A general-purpose `parse_message()` is added for all formats except for Fluent, for which a seprate `fluent_parse_message()` is needed because of the source representing a set of entries, rather than a single pattern.

While at this, support for Xcode message patterns is improved, with a less hacky detector that does not depend on the file name but the `tool-id` that's set within its contents.

As a simplification, the Fluent parser & serialiser will no longer support mixed resources, i.e. ones where a resource contains FTL AST messages.