### PR TITLE
Make `l10n-build-file --l10n` option optional

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -43,7 +43,7 @@ Adds empty files for any missing from the target locale.
 
 Build one localization file for release.
 
-Uses the `--source` file as a baseline, applying `--l10n` localizations to build `--target`.
+Uses the `--source` file as a baseline, applying `--l10n` localizations (if set) to build `--target`.
 Trims out all comments and messages not in the source file.
 
 ### `l10n-compare`

--- a/python/moz/l10n/bin/build_file.py
+++ b/python/moz/l10n/bin/build_file.py
@@ -60,19 +60,20 @@ def cli() -> None:
     try:
         try:
             source_res = parse_resource(args.source)
-        except UnsupportedResource as error:
-            if args.l10n is None:
-                raise error
-            else:
-                source_res = None
+        except UnsupportedResource:
+            source_res = None
         makedirs(dirname(args.target), exist_ok=True)
-        if args.l10n is None:
+        if source_res is None:
+            from_path = (
+                args.l10n
+                if args.l10n is not None and exists(args.l10n)
+                else args.source
+            )
+            copyfile(from_path, args.target)
+        elif args.l10n is None:
             with open(args.target, "w", encoding="utf-8") as file:
                 for line in serialize_resource(source_res, trim_comments=True):
                     file.write(line)
-        elif source_res is None:
-            from_path = args.l10n if exists(args.l10n) else args.source
-            copyfile(from_path, args.target)
         else:
             write_target_file(args.source, source_res, args.l10n, args.target)
     except (OSError, UnsupportedResource) as error:


### PR DESCRIPTION
For context, see [bug 1956660](https://bugzilla.mozilla.org/show_bug.cgi?id=1956660).

This allows using the `l10n-build-file` CLI command to minify a source file.