### PR TITLE
Add single-message serializers

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -109,8 +109,9 @@ Returns a `Format` enum value, or `None` if the input is not recognized.
 ```python
 from moz.l10n.message import from_json, to_json
 
-def message_from_json(json: list[Any] | dict[str, Any]) -> Message: ...
-def message_to_json(msg: Message) -> list[Any] | dict[str, Any]: ...
+def message_from_json(json: list[Any] | dict[str, Any]) -> Message
+
+def message_to_json(msg: Message) -> list[Any] | dict[str, Any]
 ```
 
 Converters to and from a JSON-serializable representation of a `Message`.
@@ -120,6 +121,7 @@ The format of the output is defined by the [`schema.json`](./moz/l10n/message/sc
 
 ```python
 from moz.l10n.message import parse_message
+
 def parse_message(
     format: Format,
     source: str,
@@ -127,8 +129,7 @@ def parse_message(
     printf_placeholders: bool = False,
     webext_placeholders: dict[str, dict[str, str]] | None = None,
     xliff_is_xcode: bool = False,
-) -> Message:
-    ...
+) -> Message
 ```
 
 Parse a `Message` from its string representation.
@@ -141,8 +142,25 @@ providing the message's `webext_placeholders` dict.
 
 To parse an `xliff` message with XCode customizations, enable `xliff_is_xcode`.
 
-Formatting `fluent` messages is not supported,
+Parsing `fluent` messages is not supported,
 as their parsing may result in multiple `Entry` values.
+
+### moz.l10n.message.serialize_message
+
+```python
+from moz.l10n.message import serialize_message
+
+def serialize_message(format: Format, msg: Message) -> str
+```
+
+Serialize a `Message` to its string representation.
+
+Custom serialisers are used for `android`, `mf2`, `webext`, and `xliff` formats.
+Many formats rely on non-string message parts including an appropriate `source` attribute.
+
+SelectMessage serialization is only supported for `mf2`.
+
+Serializing `fluent` messages is not supported.
 
 ### moz.l10n.model
 

--- a/python/moz/l10n/formats/android/__init__.py
+++ b/python/moz/l10n/formats/android/__init__.py
@@ -1,4 +1,9 @@
 from .parse import android_parse, android_parse_message
-from .serialize import android_serialize
+from .serialize import android_serialize, android_serialize_message
 
-__all__ = ["android_parse", "android_parse_message", "android_serialize"]
+__all__ = [
+    "android_parse",
+    "android_parse_message",
+    "android_serialize",
+    "android_serialize_message",
+]

--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -163,6 +163,20 @@ def android_serialize(
     yield "\n"
 
 
+def android_serialize_message(msg: Message) -> str:
+    if not isinstance(msg, PatternMessage) or msg.declarations:
+        raise ValueError(f"Unsupported message: {msg}")
+    target = etree.Element("string")
+    set_pattern(target, msg.pattern)
+    str = etree.tostring(target, encoding="unicode", pretty_print=True).strip()
+    if str == "<string/>":
+        return ""
+    if not str.startswith("<string>"):
+        raise ValueError(f"Invalid serialization: {str}")
+    # trim <string>...</string> wrapper
+    return str[8:-9]
+
+
 def get_attrib(name: str, meta: list[Metadata]) -> dict[str, str]:
     res = {"name": name}
     for m in meta:

--- a/python/moz/l10n/formats/webext/__init__.py
+++ b/python/moz/l10n/formats/webext/__init__.py
@@ -1,4 +1,9 @@
 from .parse import webext_parse, webext_parse_message
-from .serialize import webext_serialize
+from .serialize import webext_serialize, webext_serialize_message
 
-__all__ = ["webext_parse", "webext_parse_message", "webext_serialize"]
+__all__ = [
+    "webext_parse",
+    "webext_parse_message",
+    "webext_serialize",
+    "webext_serialize_message",
+]

--- a/python/moz/l10n/formats/xliff/__init__.py
+++ b/python/moz/l10n/formats/xliff/__init__.py
@@ -1,4 +1,9 @@
 from .parse import xliff_parse, xliff_parse_message
-from .serialize import xliff_serialize
+from .serialize import xliff_serialize, xliff_serialize_message
 
-__all__ = ["xliff_parse", "xliff_parse_message", "xliff_serialize"]
+__all__ = [
+    "xliff_parse",
+    "xliff_parse_message",
+    "xliff_serialize",
+    "xliff_serialize_message",
+]

--- a/python/moz/l10n/formats/xliff/serialize.py
+++ b/python/moz/l10n/formats/xliff/serialize.py
@@ -178,6 +178,20 @@ def xliff_serialize(
     yield etree.tostring(root, encoding="unicode", pretty_print=True)
 
 
+def xliff_serialize_message(msg: Message) -> str:
+    if not isinstance(msg, PatternMessage) or msg.declarations:
+        raise ValueError(f"Unsupported message: {msg}")
+    target = etree.Element("target")
+    set_pattern(target, msg.pattern)
+    str = etree.tostring(target, encoding="unicode", pretty_print=True).strip()
+    if str == "<target/>":
+        return ""
+    if not str.startswith("<target>"):
+        raise ValueError(f"Invalid serialization: {str}")
+    # trim <target>...</target> wrapper
+    return str[8:-9]
+
+
 def add_xliff_stringsdict_plural(
     parent: etree._Element, entry: Entry[SelectMessage], trim_comments: bool
 ) -> None:

--- a/python/moz/l10n/message/__init__.py
+++ b/python/moz/l10n/message/__init__.py
@@ -1,5 +1,6 @@
 from .from_json import message_from_json
 from .parse import parse_message
+from .serialize import serialize_message
 from .to_json import message_to_json
 
-__all__ = ["message_from_json", "message_to_json", "parse_message"]
+__all__ = ["message_from_json", "message_to_json", "parse_message", "serialize_message"]

--- a/python/moz/l10n/message/serialize.py
+++ b/python/moz/l10n/message/serialize.py
@@ -30,7 +30,7 @@ except ImportError:
     pass
 
 
-def serialize_message(format: Format, msg: Message) -> str:
+def serialize_message(format: Format | None, msg: Message) -> str:
     """
     Serialize a `Message` to its string representation.
 

--- a/python/moz/l10n/message/serialize.py
+++ b/python/moz/l10n/message/serialize.py
@@ -1,0 +1,73 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import Callable
+
+from ..formats import Format, UnsupportedFormat
+from ..formats.mf2.serialize import mf2_serialize_message
+from ..formats.webext.serialize import webext_serialize_message
+from ..model import Message, PatternMessage
+
+android_serialize_message: Callable[[Message], str] | None = None
+xliff_serialize_message: Callable[[Message], str] | None = None
+try:
+    from ..formats.android.serialize import android_serialize_message
+    from ..formats.xliff.serialize import xliff_serialize_message
+except ImportError:
+    pass
+
+
+def serialize_message(format: Format, msg: Message) -> str:
+    """
+    Serialize a `Message` to its string representation.
+
+    Custom serialisers are used for `android`, `mf2`, `webext`, and `xliff` formats.
+    Many formats rely on non-string message parts including an appropriate `source` attribute.
+
+    SelectMessage serialization is only supported for `mf2`.
+
+    Serializing `fluent` messages is not supported.
+    """
+    # TODO post-py38: should be a match
+    if format == Format.webext:
+        # Placeholders are discarded
+        return webext_serialize_message(msg)[0]
+    elif format == Format.android:
+        if android_serialize_message is None:
+            raise UnsupportedFormat("Serializing Android messages requires [xml] extra")
+        return android_serialize_message(msg)
+    elif format == Format.xliff:
+        if xliff_serialize_message is None:
+            raise UnsupportedFormat("Serializing XLIFF messages requires [xml] extra")
+        return xliff_serialize_message(msg)
+    elif format == Format.mf2:
+        return "".join(mf2_serialize_message(msg))
+    elif format == Format.fluent:
+        raise UnsupportedFormat("Serializing Fluent message patterns is not supported")
+    elif not isinstance(msg, PatternMessage) or msg.declarations:
+        raise ValueError(f"Unsupported message: {msg}")
+    else:
+        res = ""
+        for part in msg.pattern:
+            if isinstance(part, str):
+                res += part
+            else:
+                part_source = part.attributes.get("source", None)
+                if isinstance(part_source, str):
+                    res += part_source
+                else:
+                    raise ValueError(f"Unsupported placeholder: {part}")
+        return res

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -38,6 +38,7 @@ try:
         android_parse,
         android_parse_message,
         android_serialize,
+        android_serialize_message,
     )
 except ImportError:
     raise SkipTest("Requires [xml] extra")
@@ -386,9 +387,10 @@ class TestAndroid(TestCase):
             ],
         )
 
-    def test_parse_message(self):
-        message = android_parse_message("Hello, %1$s! You have %2$d new messages.")
-        assert message == PatternMessage(
+    def test_message_expressions(self):
+        src = "Hello, %1$s! You have %2$d new messages."
+        msg = android_parse_message(src)
+        assert msg == PatternMessage(
             [
                 "Hello, ",
                 Expression(
@@ -401,9 +403,13 @@ class TestAndroid(TestCase):
                 " new messages.",
             ]
         )
+        res = android_serialize_message(msg)
+        assert res == src
 
-        message = android_parse_message("Welcome to <b>&foo;</b>&bar;!")
-        assert message == PatternMessage(
+    def test_message_markup(self):
+        src = "Welcome to <b>&foo;</b>&bar;!"
+        msg = android_parse_message(src)
+        assert msg == PatternMessage(
             [
                 "Welcome to ",
                 Markup("open", "b"),
@@ -413,6 +419,8 @@ class TestAndroid(TestCase):
                 "!",
             ]
         )
+        res = android_serialize_message(msg)
+        assert res == src
 
     def test_serialize(self):
         res = android_parse(source)

--- a/python/tests/formats/test_xliff1.py
+++ b/python/tests/formats/test_xliff1.py
@@ -34,7 +34,12 @@ from moz.l10n.model import (
 )
 
 try:
-    from moz.l10n.formats.xliff import xliff_parse, xliff_parse_message, xliff_serialize
+    from moz.l10n.formats.xliff import (
+        xliff_parse,
+        xliff_parse_message,
+        xliff_serialize,
+        xliff_serialize_message,
+    )
 except ImportError:
     raise SkipTest("Requires [xml] extra")
 
@@ -77,8 +82,9 @@ class TestXliff1(TestCase):
             ],
         )
 
-    def test_parse_message(self):
-        msg = xliff_parse_message("Hello, <b>%s</b>")
+    def test_message_simple(self):
+        src = "Hello, <b>%s</b>"
+        msg = xliff_parse_message(src)
         assert msg == PatternMessage(
             [
                 "Hello, ",
@@ -87,8 +93,18 @@ class TestXliff1(TestCase):
                 Markup(kind="close", name="b"),
             ]
         )
+        res = xliff_serialize_message(msg)
+        assert res == src
 
-        msg = xliff_parse_message("Hello, <b>%s</b>", is_xcode=True)
+    def test_message_empty(self):
+        msg = xliff_parse_message("")
+        assert msg == PatternMessage([])
+        res = xliff_serialize_message(msg)
+        assert res == ""
+
+    def test_message_xcode(self):
+        src = "Hello, <b>%s</b>"
+        msg = xliff_parse_message(src, is_xcode=True)
         assert msg == PatternMessage(
             [
                 "Hello, ",
@@ -97,7 +113,10 @@ class TestXliff1(TestCase):
                 Markup(kind="close", name="b"),
             ]
         )
+        res = xliff_serialize_message(msg)
+        assert res == src
 
+    def test_message_error(self):
         with self.assertRaises(Exception):
             xliff_parse_message("Hello, <b>%s")
 


### PR DESCRIPTION
I'd rather hoped to avoid needing to provide single-message serialisers, but it turns out that they're effectively required for the Pontoon data model migration -- without them, we'd need to parse each resource using both the old & new tools, and to merge their representations rather clumsily.

With these serialisers, we can instead replace the current Pontoon parsers with the moz.l10n ones, and produce the current resource representations using moz.l10n, allowing for a smaller next step in Pontoon.

Thankfully, these serialisers were even easier to extract from pre-existing code than the parsers of #59. Fluent is again left out, as it'll need special treatment, using the already provided `fluent_astify_message()`.