### PR TITLE
paths: Add locale argument to target()

### DIFF
--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -218,14 +218,14 @@ class L10nDiscoverPaths:
         return paths
 
     def target(
-        self, ref_path: str, *, ref_required: bool = True
+        self, ref_path: str, *, ref_required: bool = True, locale: str | None = None
     ) -> tuple[str | None, Iterable[str]]:
         """
         If `ref_path` is a valid reference path,
         returns its corresponding target path.
         Otherwise, returns `None` for the path.
 
-        Target path will include a `{locale}` variable.
+        If `locale` is not set, target path will include a `{locale}` variable.
         """
         ref_path = normpath(join(self._ref_root, ref_path))
         if ref_path.endswith(".po"):
@@ -236,7 +236,11 @@ class L10nDiscoverPaths:
         target = ref_path.replace(self._ref_root, locale_root, 1)
         if target.endswith(".pot"):
             target = target[:-1]
-        return target, self.locales or ()
+        if locale is None:
+            return target, self.locales or ()
+        if self.locales is None or locale in self.locales:
+            return self.format_target_path(target, locale), {locale}
+        return None, ()
 
     def format_target_path(self, target: str, locale: str) -> str:
         base = self._base()

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -493,3 +493,81 @@ class TestL10nConfigPaths(TestCase):
             join(root, "foo", "{locale}", "toolkit", config),
             join(root, "foo", "{locale}", "calendar", calendar),
         }
+
+    def test_path_per_locale(self):
+        cfg_toml = dedent(
+            """
+            basepath = "."
+            locales = ["en", "es", "de"]
+
+            [[paths]]
+            reference = "translations/wordpress.pot"
+            l10n = "translations/wordpress/wordpress-es_ES.po"
+            locales = ["es"]
+
+            [[paths]]
+            reference = "translations/wordpress.pot"
+            l10n = "translations/wordpress/wordpress-de_DE.po"
+            locales = ["de"]
+
+            [[paths]]
+            reference = "translations/wordpress-react.pot"
+            l10n = "translations/wordpress-react/wordpress-react-{locale}.po"
+            """
+        )
+        with TemporaryDirectory() as root:
+            build_file_tree(root, {"l10n.toml": cfg_toml})
+            paths = L10nConfigPaths(join(root, "l10n.toml"))
+
+        assert paths.all_locales == {"en", "es", "de"}
+        assert paths.all() == {
+            (
+                join(root, "translations/wordpress.pot"),
+                join(root, "translations/wordpress/wordpress-es_ES.po"),
+            ): ["es"],
+            (
+                join(root, "translations/wordpress.pot"),
+                join(root, "translations/wordpress/wordpress-de_DE.po"),
+            ): ["de"],
+            (
+                join(root, "translations/wordpress-react.pot"),
+                join(root, "translations/wordpress-react/wordpress-react-{locale}.po"),
+            ): ["en", "es", "de"],
+        }
+
+        assert list(paths.ref_paths) == [
+            join(root, "translations/wordpress.pot"),
+            join(root, "translations/wordpress.pot"),
+            join(root, "translations/wordpress-react.pot"),
+        ]
+
+        none_path, none_locales = paths.target("translations/wordpress.pot")
+        assert none_path == join(
+            paths.base, normpath("translations/wordpress/wordpress-es_ES.po")
+        )
+        assert none_locales == {"es"}
+        es_path, es_locales = paths.target("translations/wordpress.pot", locale="es")
+        assert es_path == join(
+            paths.base, normpath("translations/wordpress/wordpress-es_ES.po")
+        )
+        assert es_locales == {"es"}
+        de_path, de_locales = paths.target("translations/wordpress.pot", locale="de")
+        assert de_path == join(
+            paths.base, normpath("translations/wordpress/wordpress-de_DE.po")
+        )
+        assert de_locales == {"de"}
+
+        paths.locales = ["en", "de"]
+        lim_path, lim_locales = paths.target("translations/wordpress.pot")
+        assert lim_path == join(
+            paths.base, normpath("translations/wordpress/wordpress-es_ES.po")
+        )
+        assert lim_locales == ()
+
+        set_path, set_locales = paths.target(
+            "translations/wordpress-react.pot", locale="de"
+        )
+        assert set_path == join(
+            paths.base, normpath("translations/wordpress-react/wordpress-react-de.po")
+        )
+        assert set_locales == {"de"}

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -522,23 +522,28 @@ class TestL10nConfigPaths(TestCase):
         assert paths.all_locales == {"en", "es", "de"}
         assert paths.all() == {
             (
-                join(root, "translations/wordpress.pot"),
-                join(root, "translations/wordpress/wordpress-es_ES.po"),
+                join(root, normpath("translations/wordpress.pot")),
+                join(root, normpath("translations/wordpress/wordpress-es_ES.po")),
             ): ["es"],
             (
-                join(root, "translations/wordpress.pot"),
-                join(root, "translations/wordpress/wordpress-de_DE.po"),
+                join(root, normpath("translations/wordpress.pot")),
+                join(root, normpath("translations/wordpress/wordpress-de_DE.po")),
             ): ["de"],
             (
-                join(root, "translations/wordpress-react.pot"),
-                join(root, "translations/wordpress-react/wordpress-react-{locale}.po"),
+                join(root, normpath("translations/wordpress-react.pot")),
+                join(
+                    root,
+                    normpath(
+                        "translations/wordpress-react/wordpress-react-{locale}.po"
+                    ),
+                ),
             ): ["en", "es", "de"],
         }
 
         assert list(paths.ref_paths) == [
-            join(root, "translations/wordpress.pot"),
-            join(root, "translations/wordpress.pot"),
-            join(root, "translations/wordpress-react.pot"),
+            join(root, normpath("translations/wordpress.pot")),
+            join(root, normpath("translations/wordpress.pot")),
+            join(root, normpath("translations/wordpress-react.pot")),
         ]
 
         none_path, none_locales = paths.target("translations/wordpress.pot")

--- a/python/tests/test_discover.py
+++ b/python/tests/test_discover.py
@@ -159,6 +159,11 @@ class TestL10nDiscover(TestCase):
                 join(paths.base, "{locale}", "c.po"),
                 paths.locales,
             )
+            assert paths.target("c.pot", locale="xx") == (None, ())
+            assert paths.target("c.pot", locale="zz") == (
+                join(paths.base, "zz", "c.po"),
+                {"zz"},
+            )
             assert paths.target(join(root, "source", "en-US", "a.ftl")) == (None, ())
             # This relies on the `yy_Latn` directory being actually present.
             assert paths.format_target_path("{locale}/c.pot", "yy-Latn") == join(


### PR DESCRIPTION
Fixes (but does not close) mozilla/pontoon#3572

Allows for multiple paths configs with the same reference path but different locales.

The lookups in `L10nConfigPaths` `target()` and `find_reference()` now need to iterate through a list, rather than doing a `key in dict` lookup.

A `locale` argument is added to `target()` to allow for the right path to be found, and for formatting to be applied. The idea here is that if you're looking for a specific locale's target path, you'll want the formatted path.

While technically this isn't a breaking change, the calling code in Pontoon will need a review to make sure that isn't making any similar assumptions.