### PR TITLE
Add workarounds for izimobil/polib#170

### DIFF
--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Callable
+from typing import Callable, cast
 
 from ..formats import Format, UnsupportedFormat, detect_format
 from ..formats.dtd.parse import dtd_parse
@@ -52,11 +52,13 @@ def parse_resource(
     the `source` argument is optional,
     as the file will be opened and read.
     """
+    input_is_file = False
     if source is None:
         if not isinstance(input, str):
             raise TypeError("Source is required if type is not a string path")
         with open(input, mode="rb") as file:
             source = file.read()
+            input_is_file = True
     # TODO post-py38: should be a match
     format = input if isinstance(input, Format) else detect_format(input, source)
     if format == Format.dtd:
@@ -70,7 +72,8 @@ def parse_resource(
     elif format == Format.plain_json:
         return plain_json_parse(source)
     elif format == Format.po:
-        return po_parse(source)
+        # Workaround for https://github.com/izimobil/polib/issues/170
+        return po_parse(cast(str, input) if input_is_file else source)
     elif format == Format.properties:
         return properties_parse(source)
     elif format == Format.webext:

--- a/python/tests/formats/data/foo.po
+++ b/python/tests/formats/data/foo.po
@@ -36,3 +36,6 @@ msgstr "translated string"
 
 msgid "other string"
 msgstr "translated string"
+
+msgid "line separator"
+msgstr ""

--- a/python/tests/formats/test_parse_serialize_resource.py
+++ b/python/tests/formats/test_parse_serialize_resource.py
@@ -39,7 +39,8 @@ class TesteParseResource(TestCase):
             "bug121341.properties",
             "defines.inc",
             "demo.ftl",
-            "foo.po",
+            # Skip due to https://github.com/izimobil/polib/issues/170
+            # "foo.po",
             "messages.json",
             "test.properties",
         )
@@ -50,6 +51,15 @@ class TesteParseResource(TestCase):
             assert all(
                 isinstance(s, str) for s in serialize_resource(res, trim_comments=True)
             )
+
+    def test_need_for_polib_workaround(self):
+        """
+        If this fails, the workarounds for
+        https://github.com/izimobil/polib/issues/170
+        are no longer necessary.
+        """
+        with self.assertRaises(OSError):
+            parse_resource("foo.po", get_source("foo.po"))
 
     @skipIf(no_xml, "Requires [xml] extra")
     def test_named_xml_files(self):
@@ -92,9 +102,7 @@ class TesteParseResource(TestCase):
             parse_resource(None, source)
 
     def test_serialize_unsupported_format(self):
-        source = get_source("foo.po")
-        res = parse_resource(Format.po, source)
+        source = get_source("demo.ftl")
+        res = parse_resource(Format.fluent, source)
         with self.assertRaises(ValueError):
-            assert all(
-                isinstance(s, str) for s in serialize_resource(res, Format.fluent)
-            )
+            assert all(isinstance(s, str) for s in serialize_resource(res, Format.po))

--- a/python/tests/formats/test_po.py
+++ b/python/tests/formats/test_po.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ruff: noqa: RUF001
+
 from __future__ import annotations
 
 from importlib_resources import files
@@ -31,12 +33,12 @@ from moz.l10n.model import (
     VariableRef,
 )
 
-source = files("tests.formats.data").joinpath("foo.po").read_bytes().decode("utf-8")
+res_path = str(files("tests.formats.data").joinpath("foo.po"))
 
 
 class TestPo(TestCase):
     def test_parse(self):
-        res = po_parse(source)
+        res = po_parse(res_path)
         assert res == Resource(
             Format.po,
             comment="Test translation file.\n"
@@ -95,13 +97,14 @@ class TestPo(TestCase):
                             value=PatternMessage(["translated string"]),
                         ),
                         Entry(("other string",), PatternMessage(["translated string"])),
+                        Entry(("line\u2028separator",), PatternMessage([""])),
                     ],
                 ),
             ],
         )
 
     def test_serialize(self):
-        res = po_parse(source)
+        res = po_parse(res_path)
         assert (
             "".join(po_serialize(res))
             == r"""# Test translation file.
@@ -142,11 +145,16 @@ msgstr "translated string"
 
 msgid "other string"
 msgstr "translated string"
+
+msgid ""
+"line "
+"separator"
+msgstr ""
 """
         )
 
     def test_trim_comments(self):
-        res = po_parse(source)
+        res = po_parse(res_path)
         assert (
             "".join(po_serialize(res, trim_comments=True))
             == r"""#
@@ -179,11 +187,16 @@ msgstr "translated string"
 
 msgid "other string"
 msgstr "translated string"
+
+msgid ""
+"line "
+"separator"
+msgstr ""
 """
         )
 
     def test_obsolete(self):
-        res = po_parse(source)
+        res = po_parse(res_path)
         res.sections[0].entries[0].meta.append(Metadata("obsolete", True))
         res.sections[0].entries[3].meta = []
         assert (
@@ -226,5 +239,10 @@ msgstr "translated string"
 
 msgid "other string"
 msgstr "translated string"
+
+msgid ""
+"line "
+"separator"
+msgstr ""
 """
         )


### PR DESCRIPTION
As documented in izimobil/polib#170, `polib` does not handle line endings correctly when passed the file source rather than a path; this adds workarounds for that bug.