### PR TITLE
Add affordances for bad Android XML serialisers & fix related bugs

### DIFF
--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -438,8 +438,8 @@ def parse_quotes(
 
 
 inline_re = compile(
-    r"""\\([@?nt'"\\])|"""
     r"\\u([0-9]{4})|"
+    r"\\(.)|"
     r"(<[^%>]+>)|"
     r"(%(?:[1-9]\$)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%]|[tT][a-zA-Z]))"
 )
@@ -462,12 +462,12 @@ def parse_inline(
                 if start > pos:
                     acc += part[pos:start]
                 if m[1]:
-                    # Special character
-                    c = m[1]
-                    acc += "\n" if c == "n" else "\t" if c == "t" else c
-                elif m[2]:
                     # Unicode escape
-                    acc += chr(int(m[2]))
+                    acc += chr(int(m[1]))
+                elif m[2]:
+                    # Escaped character
+                    c = m[2]
+                    acc += "\n" if c == "n" else "\t" if c == "t" else c
                 elif m[3]:
                     # Escaped HTML element, e.g. &lt;b>
                     # HTML elements containing internal % formatting are not wrapped as literals

--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -266,7 +266,8 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
 
 def set_pattern_message(el: etree._Element, msg: PatternMessage | str) -> None:
     if isinstance(msg, str):
-        el.text = msg
+        el.text = escape_part(msg)
+        escape_pattern(el)
     elif isinstance(msg, PatternMessage) and not msg.declarations:
         set_pattern(el, msg.pattern)
     else:
@@ -290,7 +291,7 @@ def set_pattern(el: etree._Element, pattern: Pattern) -> None:
     node = None
     for part in pattern:
         if isinstance(part, str):
-            esc = escape_backslash(part)
+            esc = escape_part(part)
             if node is None:
                 parent.text = parent.text + esc if parent.text else esc
             else:
@@ -310,7 +311,7 @@ def set_pattern(el: etree._Element, pattern: Pattern) -> None:
                         node.text = str(source)
                 else:
                     if isinstance(part.arg, str):
-                        node.text = escape_backslash(part.arg)
+                        node.text = escape_part(part.arg)
                     elif isinstance(part.arg, VariableRef):
                         node.text = part.arg.name
             elif ent_name:
@@ -327,7 +328,7 @@ def set_pattern(el: etree._Element, pattern: Pattern) -> None:
             else:
                 source = None
                 if isinstance(part.arg, str):
-                    source = escape_backslash(part.arg)
+                    source = escape_part(part.arg)
                 elif isinstance(part.arg, VariableRef):
                     source = part.arg.name
                 if source is not None:
@@ -359,7 +360,7 @@ def set_pattern(el: etree._Element, pattern: Pattern) -> None:
                 parent = cast(etree._Element, parent.getparent())
             else:
                 raise ValueError(f"Improper element nesting for {part} in {parent}")
-    escape_doublequote(el)
+    escape_pattern(el)
 
 
 def entity_name(part: Expression) -> str | None:
@@ -377,28 +378,25 @@ android_escape = str.maketrans(
     {"\\": r"\\", "\n": r"\n", "\t": r"\t", "'": r"\'", '"': r"\""}
 )
 
-# Control codes are not valid in XML, and nonstandard whitespace is hard to see.
-control_chars = compile(r"[\x00-\x19\x7F-\x9F]|[^\S ]")
+# Control codes are not valid in XML, and nonstandard whitespace needs escaping
+control_chars = compile(r"[\x00-\x19\x7F-\x9F]|[^\S ]|(?<= ) ")
 
 
-def escape_backslash(src: str) -> str:
+def escape_char(ch: str) -> str:
+    return f"\\u{ord(ch):04d}"
+
+
+def escape_part(src: str) -> str:
     res = src.translate(android_escape)
-    return control_chars.sub(lambda m: f"\\u{ord(m.group()):04d}", res)
+    return control_chars.sub(lambda m: escape_char(m.group()), res)
 
 
-def escape_doublequote(el: etree._Element, root: bool = True) -> None:
-    if el.text and ("  " in el.text):
-        el.text = f'"{el.text}"'
-    for child in el:
-        escape_doublequote(child, False)
-        if child.tail and "  " in child.tail:
-            child.tail = f'"{child.tail}"'
-    if root:
-        if el.text and el.text.startswith((" ", "@", "?")):
-            el.text = f'"{el.text}"'
-        if len(el) > 0:
-            last = el[-1]
-            if last.tail and last.tail.endswith(" "):
-                last.tail = f'"{last.tail}"'
-        elif el.text and el.text.endswith(" "):
-            el.text = f'"{el.text}"'
+def escape_pattern(el: etree._Element) -> None:
+    if el.text and el.text.startswith((" ", "@", "?")):
+        el.text = escape_char(el.text[0]) + el.text[1:]
+    if len(el) > 0:
+        last = el[-1]
+        if last.tail and last.tail.endswith(" "):
+            last.tail = last.tail[:-1] + escape_char(" ")
+    elif el.text and el.text.endswith(" "):
+        el.text = el.text[:-1] + escape_char(" ")

--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -266,7 +266,7 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
 
 def set_pattern_message(el: etree._Element, msg: PatternMessage | str) -> None:
     if isinstance(msg, str):
-        el.text = msg.replace("'", "\\'")
+        el.text = msg
     elif isinstance(msg, PatternMessage) and not msg.declarations:
         set_pattern(el, msg.pattern)
     else:

--- a/python/moz/l10n/message/parse.py
+++ b/python/moz/l10n/message/parse.py
@@ -22,8 +22,8 @@ from ..formats.webext.parse import webext_parse_message
 from ..model import Message, PatternMessage
 from .printf import parse_printf_pattern
 
-android_parse_message: Callable[[str], PatternMessage] | None = None
-xliff_parse_message: Callable[[str], PatternMessage] | None = None
+android_parse_message: Callable[..., PatternMessage] | None = None
+xliff_parse_message: Callable[..., PatternMessage] | None = None
 try:
     from ..formats.android.parse import android_parse_message
     from ..formats.xliff.parse import xliff_parse_message
@@ -35,6 +35,7 @@ def parse_message(
     format: Format,
     source: str,
     *,
+    android_ascii_spaces: bool = False,
     printf_placeholders: bool = False,
     webext_placeholders: dict[str, dict[str, str]] | None = None,
     xliff_is_xcode: bool = False,
@@ -59,11 +60,11 @@ def parse_message(
     elif format == Format.android:
         if android_parse_message is None:
             raise UnsupportedFormat("Parsing Android messages requires [xml] extra")
-        return android_parse_message(source)
+        return android_parse_message(source, ascii_spaces=android_ascii_spaces)
     elif format == Format.xliff:
         if xliff_parse_message is None:
             raise UnsupportedFormat("Parsing XLIFF messages requires [xml] extra")
-        return xliff_parse_message(source, is_xcode=xliff_is_xcode)  # type:ignore[call-arg]
+        return xliff_parse_message(source, is_xcode=xliff_is_xcode)
     elif format == Format.mf2:
         return mf2_parse_message(source)
     elif format == Format.fluent:

--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -27,7 +27,7 @@ from ..formats.properties.parse import properties_parse
 from ..formats.webext.parse import webext_parse
 from ..model import Message, Resource
 
-android_parse: Callable[[str | bytes], Resource[Message]] | None
+android_parse: Callable[..., Resource[Message]] | None
 xliff_parse: Callable[[str | bytes], Resource[Message]] | None
 try:
     from ..formats.android.parse import android_parse
@@ -38,7 +38,11 @@ except ImportError:
 
 
 def parse_resource(
-    input: Format | str | None, source: str | bytes | None = None
+    input: Format | str | None,
+    source: str | bytes | None = None,
+    *,
+    android_ascii_spaces: bool = False,
+    android_literal_quotes: bool = False,
 ) -> Resource[Message]:
     """
     Parse a Resource from its string representation.
@@ -79,7 +83,11 @@ def parse_resource(
     elif format == Format.webext:
         return webext_parse(source)
     elif format == Format.android and android_parse is not None:
-        return android_parse(source)
+        return android_parse(
+            source,
+            ascii_spaces=android_ascii_spaces,
+            literal_quotes=android_literal_quotes,
+        )
     elif format == Format.xliff and xliff_parse is not None:
         return xliff_parse(source)
     else:

--- a/python/tests/formats/data/strings.xml
+++ b/python/tests/formats/data/strings.xml
@@ -22,8 +22,10 @@
   <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
   <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
 
-  <string name="ws_trimmed"> &#32; &#8200; &#8195;</string>
-  <string name="ws_quoted">" &#32; &#8200; &#8195;&quot;</string>
+  <string name="ws_trimmed"> &#32;  &#8200;
+    &#8195;</string>
+  <string name="ws_quoted">" &#32; &#8200;
+    &#8195;&quot;</string>
   <string name="ws_escaped"> \u0032 \u8200 \u8195</string>
   <string name="ws_with_entities"> one <xliff:g>&foo; two &bar;</xliff:g> three </string>
   <string name="ws_with_html"> one<b> two </b>three </string>

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -218,7 +218,8 @@ class TestAndroid(TestCase):
                         ),
                         Entry(("ws_trimmed",), PatternMessage([" "])),
                         Entry(
-                            ("ws_quoted",), PatternMessage([" \u0020 \u2008 \u2003"])
+                            ("ws_quoted",),
+                            PatternMessage([" \u0020 \u2008\n    \u2003"]),
                         ),
                         Entry(
                             ("ws_escaped",),
@@ -460,7 +461,7 @@ class TestAndroid(TestCase):
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
               <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
               <string name="ws_trimmed">" "</string>
-              <string name="ws_quoted">"   \\u8200 \\u8195"</string>
+              <string name="ws_quoted">"   \\u8200\\n    \\u8195"</string>
               <string name="ws_escaped">"   \\u8200 \\u8195"</string>
               <string name="ws_with_entities">" one "<xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g>" three "</string>
               <string name="ws_with_html">" one"<b> two </b>"three "</string>
@@ -520,7 +521,7 @@ class TestAndroid(TestCase):
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
               <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
               <string name="ws_trimmed">" "</string>
-              <string name="ws_quoted">"   \\u8200 \\u8195"</string>
+              <string name="ws_quoted">"   \\u8200\\n    \\u8195"</string>
               <string name="ws_escaped">"   \\u8200 \\u8195"</string>
               <string name="ws_with_entities">" one "<xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g>" three "</string>
               <string name="ws_with_html">" one"<b> two </b>"three "</string>

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -583,6 +583,21 @@ class TestAndroid(TestCase):
             """
         )
 
+    def test_string_value(self):
+        res = Resource(
+            Format.android, [Section((), [Entry(("x",), "This & <b>that</b>")])]
+        )
+
+        ser = "".join(android_serialize(res))
+        assert ser == dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">This &amp; &lt;b&gt;that&lt;/b&gt;</string>
+            </resources>
+            """
+        )
+
     def test_translate_no(self):
         msg = PatternMessage(
             [

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -599,6 +599,52 @@ class TestAndroid(TestCase):
             """
         )
 
+    def test_cdata_value(self):
+        src = dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x"><![CDATA[Click <a href="%1$s">here</a>]]></string>
+            </resources>
+            """
+        )
+        res = android_parse(src)
+        assert res == Resource(
+            Format.android,
+            [
+                Section(
+                    (),
+                    [
+                        Entry(
+                            ("x",),
+                            PatternMessage(
+                                [
+                                    'Click <a href="',
+                                    Expression(
+                                        arg=VariableRef(name="arg1"),
+                                        function="string",
+                                        attributes={"source": "%1$s"},
+                                    ),
+                                    '">here',
+                                    Expression(arg="</a>", function="html"),
+                                ],
+                            ),
+                        )
+                    ],
+                )
+            ],
+        )
+
+        ser = "".join(android_serialize(res))
+        assert ser == dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">Click &lt;a href=\\"%1$s\\"&gt;here&lt;/a&gt;</string>
+            </resources>
+            """
+        )
+
     def test_translate_no(self):
         msg = PatternMessage(
             [

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -664,3 +664,65 @@ class TestAndroid(TestCase):
             </resources>
             """
         )
+
+    def test_spaces(self):
+        src = dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">One\ttwo\xa0three</string>
+            </resources>
+            """
+        )
+
+        res = android_parse(src)
+        assert res == Resource(
+            Format.android,
+            [Section((), [Entry(("x",), PatternMessage(["One two three"]))])],
+        )
+        ser = "".join(android_serialize(res))
+        assert ser == dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">One two three</string>
+            </resources>
+            """
+        )
+
+        res = android_parse(src, ascii_spaces=True)
+        assert res == Resource(
+            Format.android,
+            [Section((), [Entry(("x",), PatternMessage(["One two\xa0three"]))])],
+        )
+        ser = "".join(android_serialize(res))
+        assert ser == dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">One two\\u0160three</string>
+            </resources>
+            """
+        )
+
+    def test_quotes(self):
+        src = dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">"hello"</string>
+            </resources>
+            """
+        )
+
+        res = android_parse(src)
+        assert res == Resource(
+            Format.android,
+            [Section((), [Entry(("x",), PatternMessage(["hello"]))])],
+        )
+
+        res = android_parse(src, literal_quotes=True)
+        assert res == Resource(
+            Format.android,
+            [Section((), [Entry(("x",), PatternMessage(['"hello"']))])],
+        )

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -726,3 +726,28 @@ class TestAndroid(TestCase):
             Format.android,
             [Section((), [Entry(("x",), PatternMessage(['"hello"']))])],
         )
+
+    def test_escapes(self):
+        src = dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">1\\t2\\,3\\'</string>
+            </resources>
+            """
+        )
+
+        res = android_parse(src)
+        assert res == Resource(
+            Format.android,
+            [Section((), [Entry(("x",), PatternMessage(["1\t2,3'"]))])],
+        )
+        ser = "".join(android_serialize(res))
+        assert ser == dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">1\\t2,3\\'</string>
+            </resources>
+            """
+        )

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -460,11 +460,11 @@ class TestAndroid(TestCase):
               <string name="escaped_html">Hello, %1$s! You have &lt;b&gt;%2$d new messages&lt;/b&gt;.</string>
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
               <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
-              <string name="ws_trimmed">" "</string>
-              <string name="ws_quoted">"   \\u8200\\n    \\u8195"</string>
-              <string name="ws_escaped">"   \\u8200 \\u8195"</string>
-              <string name="ws_with_entities">" one "<xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g>" three "</string>
-              <string name="ws_with_html">" one"<b> two </b>"three "</string>
+              <string name="ws_trimmed">\\u0032</string>
+              <string name="ws_quoted">\\u0032\\u0032\\u0032\\u8200\\n \\u0032\\u0032\\u0032\\u8195</string>
+              <string name="ws_escaped">\\u0032\\u0032\\u0032\\u8200 \\u8195</string>
+              <string name="ws_with_entities">\\u0032one <xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g> three\\u0032</string>
+              <string name="ws_with_html">\\u0032one<b> two </b>three\\u0032</string>
               <string name="control_chars">\\u0000 \\u0001</string>
               <string name="percent">%%</string>
               <string name="single_quote">They\\'re great</string>
@@ -520,11 +520,11 @@ class TestAndroid(TestCase):
               <string name="escaped_html">Hello, %1$s! You have &lt;b&gt;%2$d new messages&lt;/b&gt;.</string>
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
               <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
-              <string name="ws_trimmed">" "</string>
-              <string name="ws_quoted">"   \\u8200\\n    \\u8195"</string>
-              <string name="ws_escaped">"   \\u8200 \\u8195"</string>
-              <string name="ws_with_entities">" one "<xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g>" three "</string>
-              <string name="ws_with_html">" one"<b> two </b>"three "</string>
+              <string name="ws_trimmed">\\u0032</string>
+              <string name="ws_quoted">\\u0032\\u0032\\u0032\\u8200\\n \\u0032\\u0032\\u0032\\u8195</string>
+              <string name="ws_escaped">\\u0032\\u0032\\u0032\\u8200 \\u8195</string>
+              <string name="ws_with_entities">\\u0032one <xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g> three\\u0032</string>
+              <string name="ws_with_html">\\u0032one<b> two </b>three\\u0032</string>
               <string name="control_chars">\\u0000 \\u0001</string>
               <string name="percent">%%</string>
               <string name="single_quote">They\\'re great</string>
@@ -568,7 +568,7 @@ class TestAndroid(TestCase):
             """\
             <?xml version="1.0" encoding="utf-8"?>
             <resources>
-              <string name="x">" X "</string>
+              <string name="x">\\u0032X\\u0032</string>
             </resources>
             """
         )

--- a/python/tests/formats/test_xliff1.py
+++ b/python/tests/formats/test_xliff1.py
@@ -82,6 +82,28 @@ class TestXliff1(TestCase):
             ],
         )
 
+    def test_serialize_hello(self):
+        res = xliff_parse(hello)
+        ser = "".join(xliff_serialize(res))
+        assert ser == dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
+              <file original="hello.txt" source-language="en" target-language="fr" datatype="plaintext">
+                <body>
+                  <trans-unit id="hi">
+                    <source>Hello world</source>
+                    <target>Bonjour le monde</target>
+                    <alt-trans>
+                      <target xml:lang="es">Hola mundo</target>
+                    </alt-trans>
+                  </trans-unit>
+                </body>
+              </file>
+            </xliff>
+            """
+        )
+
     def test_message_simple(self):
         src = "Hello, <b>%s</b>"
         msg = xliff_parse_message(src)
@@ -120,21 +142,38 @@ class TestXliff1(TestCase):
         with self.assertRaises(Exception):
             xliff_parse_message("Hello, <b>%s")
 
-    def test_serialize_hello(self):
-        res = xliff_parse(hello)
-        ser = "".join(xliff_serialize(res))
+    def test_string_value(self):
+        res = Resource(
+            Format.xliff,
+            meta=[Metadata("@version", "1.2")],
+            sections=[
+                Section(
+                    id=("hello.txt",),
+                    meta=[
+                        Metadata("@source-language", "en"),
+                        Metadata("@target-language", "fr"),
+                    ],
+                    entries=[
+                        Entry(
+                            id=("x",),
+                            meta=[Metadata("source", "This & <b>that</b>")],
+                            value="This & <b>that</b>",
+                        )
+                    ],
+                )
+            ],
+        )
+
+        ser = "".join(xliff_serialize(res, trim_comments=True))
         assert ser == dedent(
             """\
             <?xml version="1.0" encoding="utf-8"?>
-            <xliff xmlns="urn:oasis:names:tc:xliff:document:1.2" version="1.2">
-              <file original="hello.txt" source-language="en" target-language="fr" datatype="plaintext">
+            <xliff version="1.2">
+              <file original="hello.txt" source-language="en" target-language="fr">
                 <body>
-                  <trans-unit id="hi">
-                    <source>Hello world</source>
-                    <target>Bonjour le monde</target>
-                    <alt-trans>
-                      <target xml:lang="es">Hola mundo</target>
-                    </alt-trans>
+                  <trans-unit id="x">
+                    <source>This &amp; &lt;b&gt;that&lt;/b&gt;</source>
+                    <target>This &amp; &lt;b&gt;that&lt;/b&gt;</target>
                   </trans-unit>
                 </body>
               </file>

--- a/python/tests/test_message.py
+++ b/python/tests/test_message.py
@@ -155,3 +155,16 @@ class TestAndroidMessage(TestCase):
         )
         res = serialize_message(Format.android, msg)
         assert res == src
+
+    def test_spaces(self):
+        src = "One\ttwo\xa0three\\u0160four"
+
+        msg = parse_message(Format.android, src)
+        assert msg == PatternMessage(["One two three\xa0four"])
+        res = serialize_message(Format.android, msg)
+        assert res == "One two three\\u0160four"
+
+        msg = parse_message(Format.android, src, android_ascii_spaces=True)
+        assert msg == PatternMessage(["One two\xa0three\xa0four"])
+        res = serialize_message(Format.android, msg)
+        assert res == "One two\\u0160three\\u0160four"


### PR DESCRIPTION
Add `ascii_spaces` and `literal_quotes` affordances for Android parsing to not lose incorrectly serialised characters from messages; allow all characters to be `\` escaped, and never use `"` escaping when serialising.