### PR TITLE
Add a minimal l10n-lint CLI command

### DIFF
--- a/python/moz/l10n/bin/lint.py
+++ b/python/moz/l10n/bin/lint.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import logging
+import sys
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from collections.abc import Iterable
+from enum import Enum
+from glob import glob
+from os import getcwd
+from os.path import abspath, isdir, relpath
+from textwrap import dedent
+
+from moz.l10n.formats import UnsupportedFormat
+from moz.l10n.paths.config import L10nConfigPaths
+from moz.l10n.paths.discover import L10nDiscoverPaths
+from moz.l10n.resource import parse_resource
+
+log = logging.getLogger(__name__)
+
+Result = Enum("Result", ("OK", "UNSUPPORTED", "FAIL"))
+
+
+def cli() -> None:
+    parser = ArgumentParser(
+        description=dedent(
+            """
+            Lint/validate localization resources.
+
+            If `paths` is a single directory, it is iterated with L10nConfigPaths if --config is set, or L10nDiscoverPaths otherwise.
+
+            If `paths` is not a single directory, its values are treated as glob expressions, with ** support.
+
+            FIXME: Currently only checks that files can be parsed, and does not check their contents more deeply.
+            """
+        ),
+        formatter_class=RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-q", "--quiet", action="store_true", help="only log input argument errors"
+    )
+    parser.add_argument(
+        "-v", "--verbose", action="count", default=0, help="increase logging verbosity"
+    )
+    parser.add_argument(
+        "--config", metavar="PATH", type=str, help="path to l10n.toml config file"
+    )
+    parser.add_argument("paths", nargs="*", type=str, help="directory or files to fix")
+    args = parser.parse_args()
+
+    log_level = (
+        logging.ERROR
+        if args.quiet
+        else (
+            logging.WARNING
+            if args.verbose == 0
+            else logging.INFO
+            if args.verbose == 1
+            else logging.DEBUG
+        )
+    )
+    logging.basicConfig(format="%(message)s", level=log_level)
+
+    res = lint(args.paths, args.config)
+    sys.exit(res)
+
+
+def lint(file_paths: list[str], config_path: str | None = None) -> int:
+    """
+    Lint/validate `file_paths` localization resources.
+
+    If a single directory is given,
+    it is iterated with `L10nConfigPaths` if `config_path` is set,
+    or `L10nDiscoverPaths` otherwise.
+
+    If `file_paths` is not a single directory,
+    the paths are treated as glob expressions.
+
+    Returns 0 on success, 1 on parse error, or 2 on argument error.
+    """
+    if config_path:
+        if file_paths:
+            log.error("With --config, paths must not be set.")
+            return 2
+        cfg_paths = L10nConfigPaths(config_path)
+        root_dir = abspath(cfg_paths.base)
+        path_iter: Iterable[str] = cfg_paths.ref_paths
+    elif len(file_paths) == 1 and isdir(file_paths[0]):
+        root_dir = abspath(file_paths[0])
+        path_iter = L10nDiscoverPaths(root_dir, ref_root=".").ref_paths
+    elif file_paths:
+        root_dir = getcwd()
+        path_iter = (path for fp in file_paths for path in glob(fp, recursive=True))
+    else:
+        log.error("Either paths of --config is required")
+        return 2
+
+    ok = 0
+    unsupported = 0
+    failed = 0
+    for path in path_iter:
+        res = lint_file(root_dir, path)
+        if res == Result.UNSUPPORTED:
+            unsupported += 1
+        elif res == Result.FAIL:
+            failed += 1
+        else:
+            ok += 1
+    if not ok and not failed:
+        log.warning("Found no localization resources")
+    return 1 if failed or unsupported else 0
+
+
+def lint_file(root: str, path: str) -> Result:
+    log_path = relpath(path, root)
+    if log_path.startswith(".."):
+        log_path = path
+    try:
+        parse_resource(path)
+        log.info(f"ok {log_path}")
+        return Result.OK
+    except (UnsupportedFormat, UnicodeDecodeError):
+        log.warning(f"unsupported {log_path}")
+        return Result.UNSUPPORTED
+    except Exception as error:
+        log.warning(f"FAIL {log_path} - {error}")
+        return Result.FAIL
+
+
+if __name__ == "__main__":
+    cli()

--- a/python/moz/l10n/bin/lint.py
+++ b/python/moz/l10n/bin/lint.py
@@ -121,7 +121,7 @@ def lint(file_paths: list[str], config_path: str | None = None) -> int:
             failed += 1
         else:
             ok += 1
-    if not ok and not failed:
+    if not ok and not unsupported and not failed:
         log.warning("Found no localization resources")
     return 1 if failed or unsupported else 0
 

--- a/python/moz/l10n/bin/lint.py
+++ b/python/moz/l10n/bin/lint.py
@@ -127,8 +127,11 @@ def lint(file_paths: list[str], config_path: str | None = None) -> int:
 
 
 def lint_file(root: str, path: str) -> Result:
-    log_path = relpath(path, root)
-    if log_path.startswith(".."):
+    try:
+        log_path = relpath(path, root)
+        if log_path.startswith(".."):
+            log_path = path
+    except ValueError:
         log_path = path
     try:
         parse_resource(path)

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -45,6 +45,7 @@ l10n-build = "moz.l10n.bin.build:cli"
 l10n-build-file = "moz.l10n.bin.build_file:cli"
 l10n-compare = "moz.l10n.bin.compare:cli"
 l10n-fix = "moz.l10n.bin.fix:cli"
+l10n-lint = "moz.l10n.bin.lint:cli"
 
 [project.urls]
 repository = "https://github.com/mozilla/moz-l10n"

--- a/python/tests/test_lint.py
+++ b/python/tests/test_lint.py
@@ -1,0 +1,72 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from os.path import join
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import TestCase
+
+from moz.l10n.bin.lint import lint
+
+from .test_walk_files import test_data_files
+
+# /python/
+root = Path(__file__).parent.parent
+test_data_dir = join(root, "tests", "formats", "data")
+
+
+class TestLintCommand(TestCase):
+    def test_directory(self):
+        with self.assertLogs("moz.l10n.bin.lint", level="INFO") as logs:
+            assert lint([test_data_dir]) == 1
+        logs.output.sort()
+        assert logs.output == [
+            "INFO:moz.l10n.bin.lint:ok accounts.dtd",
+            "INFO:moz.l10n.bin.lint:ok angular.xliff",
+            "INFO:moz.l10n.bin.lint:ok bug121341.properties",
+            "INFO:moz.l10n.bin.lint:ok defines.inc",
+            "INFO:moz.l10n.bin.lint:ok demo.ftl",
+            "INFO:moz.l10n.bin.lint:ok foo.po",
+            "INFO:moz.l10n.bin.lint:ok hello.xliff",
+            "INFO:moz.l10n.bin.lint:ok icu-docs.xliff",
+            "INFO:moz.l10n.bin.lint:ok messages.json",
+            "INFO:moz.l10n.bin.lint:ok plain.json",
+            "INFO:moz.l10n.bin.lint:ok strings.xml",
+            "INFO:moz.l10n.bin.lint:ok test.properties",
+            "INFO:moz.l10n.bin.lint:ok xcode.xliff",
+            "WARNING:moz.l10n.bin.lint:unsupported mf2-message-schema.json",
+        ]
+
+    def test_files(self):
+        for file in test_data_files:
+            path = join(test_data_dir, file)
+            exp = 1 if file == "mf2-message-schema.json" else 0
+            assert lint([path]) == exp
+
+    def test_parse_error(self):
+        with TemporaryDirectory() as root:
+            json_path = join(root, "one.json")
+            with open(json_path, "x") as file:
+                file.write('{"key":{"message":"Missing $VAR$"}}\n')
+            ftl_path = join(root, "two.ftl")
+            with open(ftl_path, "x") as file:
+                file.write("key = broken { value\n")
+            with self.assertLogs("moz.l10n.bin.lint", level="INFO") as logs:
+                assert lint([json_path, ftl_path]) == 1
+                assert logs.output == [
+                    f"WARNING:moz.l10n.bin.lint:FAIL {root}/one.json - Missing placeholders entry for var",
+                    f'WARNING:moz.l10n.bin.lint:FAIL {root}/two.ftl - Expected token: "{"}"}"',
+                ]

--- a/python/tests/test_lint.py
+++ b/python/tests/test_lint.py
@@ -27,28 +27,56 @@ from .test_walk_files import test_data_files
 root = Path(__file__).parent.parent
 test_data_dir = join(root, "tests", "formats", "data")
 
+try:
+    from moz.l10n.formats.xliff import xliff_parse
+
+    assert xliff_parse
+    has_xml = True
+except ImportError:
+    has_xml = False
+
 
 class TestLintCommand(TestCase):
     def test_directory(self):
         with self.assertLogs("moz.l10n.bin.lint", level="INFO") as logs:
             assert lint([test_data_dir]) == 1
         logs.output.sort()
-        assert logs.output == [
-            "INFO:moz.l10n.bin.lint:ok accounts.dtd",
-            "INFO:moz.l10n.bin.lint:ok angular.xliff",
-            "INFO:moz.l10n.bin.lint:ok bug121341.properties",
-            "INFO:moz.l10n.bin.lint:ok defines.inc",
-            "INFO:moz.l10n.bin.lint:ok demo.ftl",
-            "INFO:moz.l10n.bin.lint:ok foo.po",
-            "INFO:moz.l10n.bin.lint:ok hello.xliff",
-            "INFO:moz.l10n.bin.lint:ok icu-docs.xliff",
-            "INFO:moz.l10n.bin.lint:ok messages.json",
-            "INFO:moz.l10n.bin.lint:ok plain.json",
-            "INFO:moz.l10n.bin.lint:ok strings.xml",
-            "INFO:moz.l10n.bin.lint:ok test.properties",
-            "INFO:moz.l10n.bin.lint:ok xcode.xliff",
-            "WARNING:moz.l10n.bin.lint:unsupported mf2-message-schema.json",
-        ]
+        assert (
+            logs.output
+            == [
+                "INFO:moz.l10n.bin.lint:ok accounts.dtd",
+                "INFO:moz.l10n.bin.lint:ok angular.xliff",
+                "INFO:moz.l10n.bin.lint:ok bug121341.properties",
+                "INFO:moz.l10n.bin.lint:ok defines.inc",
+                "INFO:moz.l10n.bin.lint:ok demo.ftl",
+                "INFO:moz.l10n.bin.lint:ok foo.po",
+                "INFO:moz.l10n.bin.lint:ok hello.xliff",
+                "INFO:moz.l10n.bin.lint:ok icu-docs.xliff",
+                "INFO:moz.l10n.bin.lint:ok messages.json",
+                "INFO:moz.l10n.bin.lint:ok plain.json",
+                "INFO:moz.l10n.bin.lint:ok strings.xml",
+                "INFO:moz.l10n.bin.lint:ok test.properties",
+                "INFO:moz.l10n.bin.lint:ok xcode.xliff",
+                "WARNING:moz.l10n.bin.lint:unsupported mf2-message-schema.json",
+            ]
+            if has_xml
+            else [
+                "INFO:moz.l10n.bin.lint:ok accounts.dtd",
+                "INFO:moz.l10n.bin.lint:ok bug121341.properties",
+                "INFO:moz.l10n.bin.lint:ok defines.inc",
+                "INFO:moz.l10n.bin.lint:ok demo.ftl",
+                "INFO:moz.l10n.bin.lint:ok foo.po",
+                "INFO:moz.l10n.bin.lint:ok messages.json",
+                "INFO:moz.l10n.bin.lint:ok plain.json",
+                "INFO:moz.l10n.bin.lint:ok test.properties",
+                "WARNING:moz.l10n.bin.lint:unsupported angular.xliff",
+                "WARNING:moz.l10n.bin.lint:unsupported hello.xliff",
+                "WARNING:moz.l10n.bin.lint:unsupported icu-docs.xliff",
+                "WARNING:moz.l10n.bin.lint:unsupported mf2-message-schema.json",
+                "WARNING:moz.l10n.bin.lint:unsupported strings.xml",
+                "WARNING:moz.l10n.bin.lint:unsupported xcode.xliff",
+            ]
+        )
 
     def test_files(self):
         for file in test_data_files:

--- a/python/tests/test_lint.py
+++ b/python/tests/test_lint.py
@@ -79,9 +79,21 @@ class TestLintCommand(TestCase):
         )
 
     def test_files(self):
+        unsupported_files = (
+            {"mf2-message-schema.json"}
+            if has_xml
+            else {
+                "angular.xliff",
+                "hello.xliff",
+                "icu-docs.xliff",
+                "mf2-message-schema.json",
+                "strings.xml",
+                "xcode.xliff",
+            }
+        )
         for file in test_data_files:
             path = join(test_data_dir, file)
-            exp = 1 if file == "mf2-message-schema.json" else 0
+            exp = 1 if file in unsupported_files else 0
             assert lint([path]) == exp
 
     def test_parse_error(self):

--- a/python/tests/test_lint.py
+++ b/python/tests/test_lint.py
@@ -107,6 +107,6 @@ class TestLintCommand(TestCase):
             with self.assertLogs("moz.l10n.bin.lint", level="INFO") as logs:
                 assert lint([json_path, ftl_path]) == 1
                 assert logs.output == [
-                    f"WARNING:moz.l10n.bin.lint:FAIL {root}/one.json - Missing placeholders entry for var",
-                    f'WARNING:moz.l10n.bin.lint:FAIL {root}/two.ftl - Expected token: "{"}"}"',
+                    f"WARNING:moz.l10n.bin.lint:FAIL {join(root, 'one.json')} - Missing placeholders entry for var",
+                    f'WARNING:moz.l10n.bin.lint:FAIL {join(root, "two.ftl")} - Expected token: "{"}"}"',
                 ]


### PR DESCRIPTION
Adds an `l10n-lint` CLI command that at this stage only checks that files are correctly parsed. Actual linting functionality will be added later.

The initial use case is for a new `firefox-l10n` repo action that validates changed files. See [bug 1963728](https://bugzilla.mozilla.org/show_bug.cgi?id=1963728) for context; in mozilla-l10n/firefox-l10n#66 the introduction of a broken translation was not caught like it should have been.