### PR TITLE
Use hexadecimal rather than decimal `\u` values in Android string resources

### DIFF
--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -438,7 +438,7 @@ def parse_quotes(
 
 
 inline_re = compile(
-    r"\\u([0-9]{4})|"
+    r"\\u([0-9a-fA-F]{4})|"
     r"\\(.)|"
     r"(<[^%>]+>)|"
     r"(%(?:[1-9]\$)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%]|[tT][a-zA-Z]))"
@@ -463,7 +463,7 @@ def parse_inline(
                     acc += part[pos:start]
                 if m[1]:
                     # Unicode escape
-                    acc += chr(int(m[1]))
+                    acc += chr(int(m[1], base=16))
                 elif m[2]:
                     # Escaped character
                     c = m[2]

--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -252,6 +252,7 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
     sel = msg.selector_expressions()[0] if len(msg.selectors) == 1 else None
     if len(msg.declarations) != 1 or not sel or sel.function != "number":
         raise ValueError(f"Unsupported message: {msg}")
+    item: etree._Element | None = None
     for keys, value in msg.variants.items():
         key = keys[0] if len(keys) == 1 else None
         if isinstance(key, CatchallKey):
@@ -261,7 +262,8 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
         item = etree.SubElement(plurals, "item", attrib={"quantity": key})
         set_pattern(item, value)
         item.tail = "\n    "
-    item.tail = "\n  "
+    if item is not None:
+        item.tail = "\n  "
 
 
 def set_pattern_message(el: etree._Element, msg: PatternMessage | str) -> None:
@@ -383,7 +385,7 @@ control_chars = compile(r"[\x00-\x19\x7F-\x9F]|[^\S ]|(?<= ) ")
 
 
 def escape_char(ch: str) -> str:
-    return f"\\u{ord(ch):04d}"
+    return f"\\u{ord(ch):04x}"
 
 
 def escape_part(src: str) -> str:

--- a/python/tests/formats/data/strings.xml
+++ b/python/tests/formats/data/strings.xml
@@ -26,7 +26,7 @@
     &#8195;</string>
   <string name="ws_quoted">" &#32; &#8200;
     &#8195;&quot;</string>
-  <string name="ws_escaped"> \u0032 \u8200 \u8195</string>
+  <string name="ws_escaped"> \u0020 \u2008 \u2003</string>
   <string name="ws_with_entities"> one <xliff:g>&foo; two &bar;</xliff:g> three </string>
   <string name="ws_with_html"> one<b> two </b>three </string>
 

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -460,11 +460,11 @@ class TestAndroid(TestCase):
               <string name="escaped_html">Hello, %1$s! You have &lt;b&gt;%2$d new messages&lt;/b&gt;.</string>
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
               <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
-              <string name="ws_trimmed">\\u0032</string>
-              <string name="ws_quoted">\\u0032\\u0032\\u0032\\u8200\\n \\u0032\\u0032\\u0032\\u8195</string>
-              <string name="ws_escaped">\\u0032\\u0032\\u0032\\u8200 \\u8195</string>
-              <string name="ws_with_entities">\\u0032one <xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g> three\\u0032</string>
-              <string name="ws_with_html">\\u0032one<b> two </b>three\\u0032</string>
+              <string name="ws_trimmed">\\u0020</string>
+              <string name="ws_quoted">\\u0020\\u0020\\u0020\\u2008\\n \\u0020\\u0020\\u0020\\u2003</string>
+              <string name="ws_escaped">\\u0020\\u0020\\u0020\\u2008 \\u2003</string>
+              <string name="ws_with_entities">\\u0020one <xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g> three\\u0020</string>
+              <string name="ws_with_html">\\u0020one<b> two </b>three\\u0020</string>
               <string name="control_chars">\\u0000 \\u0001</string>
               <string name="percent">%%</string>
               <string name="single_quote">They\\'re great</string>
@@ -520,11 +520,11 @@ class TestAndroid(TestCase):
               <string name="escaped_html">Hello, %1$s! You have &lt;b&gt;%2$d new messages&lt;/b&gt;.</string>
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
               <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
-              <string name="ws_trimmed">\\u0032</string>
-              <string name="ws_quoted">\\u0032\\u0032\\u0032\\u8200\\n \\u0032\\u0032\\u0032\\u8195</string>
-              <string name="ws_escaped">\\u0032\\u0032\\u0032\\u8200 \\u8195</string>
-              <string name="ws_with_entities">\\u0032one <xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g> three\\u0032</string>
-              <string name="ws_with_html">\\u0032one<b> two </b>three\\u0032</string>
+              <string name="ws_trimmed">\\u0020</string>
+              <string name="ws_quoted">\\u0020\\u0020\\u0020\\u2008\\n \\u0020\\u0020\\u0020\\u2003</string>
+              <string name="ws_escaped">\\u0020\\u0020\\u0020\\u2008 \\u2003</string>
+              <string name="ws_with_entities">\\u0020one <xliff:g>&foo;</xliff:g><xliff:g> two </xliff:g><xliff:g>&bar;</xliff:g> three\\u0020</string>
+              <string name="ws_with_html">\\u0020one<b> two </b>three\\u0020</string>
               <string name="control_chars">\\u0000 \\u0001</string>
               <string name="percent">%%</string>
               <string name="single_quote">They\\'re great</string>
@@ -568,7 +568,7 @@ class TestAndroid(TestCase):
             """\
             <?xml version="1.0" encoding="utf-8"?>
             <resources>
-              <string name="x">\\u0032X\\u0032</string>
+              <string name="x">\\u0020X\\u0020</string>
             </resources>
             """
         )
@@ -700,7 +700,7 @@ class TestAndroid(TestCase):
             """\
             <?xml version="1.0" encoding="utf-8"?>
             <resources>
-              <string name="x">One two\\u0160three</string>
+              <string name="x">One two\\u00a0three</string>
             </resources>
             """
         )

--- a/python/tests/test_message.py
+++ b/python/tests/test_message.py
@@ -166,14 +166,14 @@ class TestAndroidMessage(TestCase):
         assert res == src
 
     def test_spaces(self):
-        src = "One\ttwo\xa0three\\u0160four"
+        src = "One\ttwo\xa0three\\u00a0four"
 
         msg = parse_message(Format.android, src)
         assert msg == PatternMessage(["One two three\xa0four"])
         res = serialize_message(Format.android, msg)
-        assert res == "One two three\\u0160four"
+        assert res == "One two three\\u00a0four"
 
         msg = parse_message(Format.android, src, android_ascii_spaces=True)
         assert msg == PatternMessage(["One two\xa0three\xa0four"])
         res = serialize_message(Format.android, msg)
-        assert res == "One two\\u0160three\\u0160four"
+        assert res == "One two\\u00a0three\\u00a0four"


### PR DESCRIPTION
I was previously misled by [this section](https://developer.android.com/guide/topics/resources/string-resource#escaping_quotes) of the string resource docs:
> Whitespace collapsing and Android escaping happens after your resource file gets parsed as XML. This means that `<string> &#32; &#8200; &#8195;</string>` (space, punctuation space, Unicode Em space) all collapse to a single space (`" "`), because they are all Unicode spaces after the file is parsed as an XML. To preserve those spaces as they are, you can either quote them (`<string>" &#32; &#8200; &#8195;"</string>`) or use Android escaping (`<string> \u0032 \u8200 \u8195</string>`). 

That last example there should read instead: `<string> \u0020 \u2008 \u2003</string>`.