### PR TITLE
android: Use CDATA escaping also for string message values

### DIFF
--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -276,17 +276,21 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
         item.tail = "\n  "
 
 
+tag_like = compile(r"<.+>")
+
+
 def set_pattern_message(el: etree._Element, msg: PatternMessage | str) -> None:
     if isinstance(msg, str):
         el.text = escape_part(msg)
         escape_pattern(el)
+        if tag_like.search(el.text) is not None:
+            # The manual wrapper is a workaround for
+            # https://bugs.launchpad.net/lxml/+bug/2111509
+            el.text = etree.CDATA(f"<![CDATA[{el.text}]]>")  # type: ignore[assignment]
     elif isinstance(msg, PatternMessage) and not msg.declarations:
         set_pattern(el, msg.pattern)
     else:
         raise ValueError(f"Unsupported message: {msg}")
-
-
-tag_like = compile(r"<.+>")
 
 
 def set_pattern(

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -536,7 +536,7 @@ class TestAndroid(TestCase):
             """
         )
 
-    def test_string_value(self):
+    def test_string_cdata_value(self):
         res = Resource(
             Format.android, [Section((), [Entry(("x",), "This & <b>that</b>")])]
         )
@@ -546,7 +546,7 @@ class TestAndroid(TestCase):
             """\
             <?xml version="1.0" encoding="utf-8"?>
             <resources>
-              <string name="x">This &amp; &lt;b&gt;that&lt;/b&gt;</string>
+              <string name="x"><![CDATA[This & <b>that</b>]]></string>
             </resources>
             """
         )


### PR DESCRIPTION
I missed this in #79.