### PR TITLE
gettext: Add plurals option for parse & serialize

### DIFF
--- a/python/moz/l10n/formats/po/serialize.py
+++ b/python/moz/l10n/formats/po/serialize.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from re import match
+from typing import Sequence, cast
 
 from polib import POEntry, POFile
 
@@ -24,6 +25,8 @@ from ...model import Entry, Message, PatternMessage, Resource, SelectMessage
 
 def po_serialize(
     resource: Resource[str] | Resource[Message],
+    *,
+    plurals: Sequence[str] | None = None,
     trim_comments: bool = False,
     wrapwidth: int = 200,
 ) -> Iterator[str]:
@@ -34,6 +37,10 @@ def po_serialize(
     Message identifiers may have one or two parts,
     with the second one holding the optional message context.
     Comments and metadata on sections is not supported.
+
+    If `plurals` is set,
+    plural keys are mapped to their `plurals` index position.
+    Otherwise, plural key values must match gettext's plural index values.
 
     Yields each entry and empty line separately.
     """
@@ -79,17 +86,19 @@ def po_serialize(
                         for keys, pattern in msg.variants.items()
                     )
                 ):
+                    variants = tuple(
+                        (
+                            (key if isinstance(key := keys[0], str) else key.value),
+                            "".join(cast(Sequence[str], pattern)),
+                        )
+                        for keys, pattern in msg.variants.items()
+                    )
                     pe.msgstr_plural = {
                         idx: next(
                             (
-                                "".join(pattern)  # type: ignore[arg-type]
-                                for keys, pattern in msg.variants.items()
-                                if (
-                                    key
-                                    if isinstance(key := keys[0], str)
-                                    else key.value
-                                )
-                                == str(idx)
+                                pattern
+                                for key, pattern in variants
+                                if key == (plurals[idx] if plurals else str(idx))
                             ),
                             "",
                         )

--- a/python/moz/l10n/formats/po/serialize.py
+++ b/python/moz/l10n/formats/po/serialize.py
@@ -40,7 +40,8 @@ def po_serialize(
 
     If `plurals` is set,
     plural keys are mapped to their `plurals` index position.
-    Otherwise, plural key values must match gettext's plural index values.
+    Otherwise, plural key values must match gettext's plural index values,
+    or be the catchall key.
 
     Yields each entry and empty line separately.
     """
@@ -86,9 +87,14 @@ def po_serialize(
                         for keys, pattern in msg.variants.items()
                     )
                 ):
+                    catchall_name = plurals[-1] if plurals else str(nplurals - 1)
                     variants = tuple(
                         (
-                            (key if isinstance(key := keys[0], str) else key.value),
+                            (
+                                key
+                                if isinstance(key := keys[0], str)
+                                else key.value or catchall_name
+                            ),
                             "".join(cast(Sequence[str], pattern)),
                         )
                         for keys, pattern in msg.variants.items()

--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from typing import Callable, cast
+from typing import Callable, Sequence, cast
 
 from ..formats import Format, UnsupportedFormat, detect_format
 from ..formats.dtd.parse import dtd_parse
@@ -43,6 +43,7 @@ def parse_resource(
     *,
     android_ascii_spaces: bool = False,
     android_literal_quotes: bool = False,
+    gettext_plurals: Sequence[str] | None = None,
 ) -> Resource[Message]:
     """
     Parse a Resource from its string representation.
@@ -77,7 +78,8 @@ def parse_resource(
         return plain_json_parse(source)
     elif format == Format.po:
         # Workaround for https://github.com/izimobil/polib/issues/170
-        return po_parse(cast(str, input) if input_is_file else source)
+        source_ = cast(str, input) if input_is_file else source
+        return po_parse(source_, plurals=gettext_plurals)
     elif format == Format.properties:
         return properties_parse(source)
     elif format == Format.webext:

--- a/python/moz/l10n/resource/serialize_resource.py
+++ b/python/moz/l10n/resource/serialize_resource.py
@@ -15,7 +15,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import Callable
+from typing import Callable, Sequence
 
 from ..formats import Format
 from ..formats.dtd.serialize import dtd_serialize
@@ -45,6 +45,7 @@ except ImportError:
 def serialize_resource(
     resource: Resource[str] | Resource[Message],
     format: Format | None = None,
+    gettext_plurals: Sequence[str] | None = None,
     trim_comments: bool = False,
 ) -> Iterator[str]:
     """
@@ -69,7 +70,9 @@ def serialize_resource(
     elif format == Format.plain_json:
         return plain_json_serialize(resource, trim_comments=trim_comments)
     elif format == Format.po:
-        return po_serialize(resource, trim_comments=trim_comments)
+        return po_serialize(
+            resource, plurals=gettext_plurals, trim_comments=trim_comments
+        )
     elif format == Format.properties:
         return properties_serialize(resource, trim_comments=trim_comments)
     elif format == Format.webext:

--- a/python/tests/formats/test_po.py
+++ b/python/tests/formats/test_po.py
@@ -105,9 +105,7 @@ class TestPo(TestCase):
 
     def test_serialize(self):
         res = po_parse(res_path)
-        assert (
-            "".join(po_serialize(res))
-            == r"""# Test translation file.
+        exp = r"""# Test translation file.
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
 #
@@ -151,7 +149,16 @@ msgid ""
 "separator"
 msgstr ""
 """
-        )
+        assert "".join(po_serialize(res)) == exp
+
+        # Remove catchall key label
+        res.sections[0].entries[1].value.variants = {
+            ("0",): ["%d prevedenih sporočil"],
+            ("1",): ["%d prevedeno sporočilo"],
+            ("2",): ["%d prevedeni sporočili"],
+            (CatchallKey(),): ["%d prevedena sporočila"],
+        }
+        assert "".join(po_serialize(res)) == exp
 
     def test_trim_comments(self):
         res = po_parse(res_path)
@@ -282,4 +289,12 @@ msgstr[2] "pl-many"
                 ],
             ),
         ]
+        assert "".join(po_serialize(res, plurals=plurals)) == src
+
+        # Remove catchall key label
+        res.sections[0].entries[0].value.variants = {
+            ("one",): ["pl-one"],
+            ("few",): ["pl-few"],
+            (CatchallKey(),): ["pl-many"],
+        }
         assert "".join(po_serialize(res, plurals=plurals)) == src

--- a/python/tests/formats/test_po.py
+++ b/python/tests/formats/test_po.py
@@ -197,7 +197,7 @@ msgstr ""
 
     def test_obsolete(self):
         res = po_parse(res_path)
-        res.sections[0].entries[0].meta.append(Metadata("obsolete", True))
+        res.sections[0].entries[0].meta.append(Metadata("obsolete", "true"))
         res.sections[0].entries[3].meta = []
         assert (
             "".join(po_serialize(res))
@@ -246,3 +246,40 @@ msgid ""
 msgstr ""
 """
         )
+
+    def test_named_plurals(self):
+        src = r"""#
+msgid ""
+msgstr ""
+"Language: pl\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+
+msgid "src-one"
+msgid_plural "src-other"
+msgstr[0] "pl-one"
+msgstr[1] "pl-few"
+msgstr[2] "pl-many"
+"""
+        plurals = ["one", "few", "many"]
+        res = po_parse(src, plurals=plurals)
+        assert res.sections == [
+            Section(
+                id=(),
+                entries=[
+                    Entry(
+                        ("src-one",),
+                        meta=[Metadata("plural", "src-other")],
+                        value=SelectMessage(
+                            declarations={"n": Expression(VariableRef("n"), "number")},
+                            selectors=(VariableRef("n"),),
+                            variants={
+                                ("one",): ["pl-one"],
+                                ("few",): ["pl-few"],
+                                (CatchallKey("many"),): ["pl-many"],
+                            },
+                        ),
+                    ),
+                ],
+            ),
+        ]
+        assert "".join(po_serialize(res, plurals=plurals)) == src


### PR DESCRIPTION
For Pontoon, we want gettext plurals to have named rather than numbered keys.