### PR TITLE
Rename "po" format as "gettext"

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -16,10 +16,10 @@ The library currently supports the following resource formats:
 - `android`†: Android string resources (strings.xml)
 - `dtd`: .dtd
 - `fluent`: Fluent (.ftl)
+- `gettext`: Gettext (.po, .pot)
 - `inc`: .inc
 - `ini`: .ini
 - `plain_json`: Plain JSON (.json)
-- `po`: Gettext (.po, .pot)
 - `properties`: .properties
 - `webext`: WebExtensions (messages.json)
 - `xliff`†: XLIFF 1.2, including XCode customizations (.xlf, .xliff)

--- a/python/moz/l10n/formats/__init__.py
+++ b/python/moz/l10n/formats/__init__.py
@@ -35,11 +35,11 @@ Format = Enum(
         "android",
         "dtd",
         "fluent",
+        "gettext",
         "inc",
         "ini",
         "mf2",
         "plain_json",
-        "po",
         "properties",
         "webext",
         "xliff",
@@ -97,14 +97,14 @@ def detect_format(name: str | None, source: bytes | str | None = None) -> Format
             return Format.dtd
         elif ext == ".ftl":
             return Format.fluent
+        elif ext in {".po", ".pot"}:
+            return Format.gettext
         elif ext == ".inc":
             return Format.inc
         elif ext == ".ini":
             return Format.ini
         elif ext == ".properties":
             return Format.properties
-        elif ext in {".po", ".pot"}:
-            return Format.po
         elif ext in {".xlf", ".xliff"}:
             return Format.xliff
 

--- a/python/moz/l10n/formats/gettext/__init__.py
+++ b/python/moz/l10n/formats/gettext/__init__.py
@@ -1,0 +1,4 @@
+from .parse import gettext_parse
+from .serialize import gettext_serialize
+
+__all__ = ["gettext_parse", "gettext_serialize"]

--- a/python/moz/l10n/formats/gettext/parse.py
+++ b/python/moz/l10n/formats/gettext/parse.py
@@ -34,7 +34,7 @@ from ...model import (
 from .. import Format
 
 
-def po_parse(
+def gettext_parse(
     source: str | bytes, *, plurals: Sequence[str] | None = None
 ) -> Resource[Message]:
     """
@@ -94,7 +94,7 @@ def po_parse(
             value = PatternMessage([pe.msgstr])
         id = (pe.msgid, pe.msgctxt) if pe.msgctxt else (pe.msgid,)
         entries.append(Entry(id, value, meta=meta))
-    return Resource(Format.po, [Section((), entries)], res_comment, res_meta)
+    return Resource(Format.gettext, [Section((), entries)], res_comment, res_meta)
 
 
 def plural_key(

--- a/python/moz/l10n/formats/gettext/serialize.py
+++ b/python/moz/l10n/formats/gettext/serialize.py
@@ -23,7 +23,7 @@ from polib import POEntry, POFile
 from ...model import Entry, Message, PatternMessage, Resource, SelectMessage
 
 
-def po_serialize(
+def gettext_serialize(
     resource: Resource[str] | Resource[Message],
     *,
     plurals: Sequence[str] | None = None,

--- a/python/moz/l10n/formats/po/__init__.py
+++ b/python/moz/l10n/formats/po/__init__.py
@@ -1,4 +1,0 @@
-from .parse import po_parse
-from .serialize import po_serialize
-
-__all__ = ["po_parse", "po_serialize"]

--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -19,10 +19,10 @@ from typing import Callable, Sequence, cast
 from ..formats import Format, UnsupportedFormat, detect_format
 from ..formats.dtd.parse import dtd_parse
 from ..formats.fluent.parse import fluent_parse
+from ..formats.gettext.parse import gettext_parse
 from ..formats.inc.parse import inc_parse
 from ..formats.ini.parse import ini_parse
 from ..formats.plain_json.parse import plain_json_parse
-from ..formats.po.parse import po_parse
 from ..formats.properties.parse import properties_parse
 from ..formats.webext.parse import webext_parse
 from ..model import Message, Resource
@@ -70,16 +70,16 @@ def parse_resource(
         return dtd_parse(source)
     elif format == Format.fluent:
         return fluent_parse(source)
+    elif format == Format.gettext:
+        # Workaround for https://github.com/izimobil/polib/issues/170
+        source_ = cast(str, input) if input_is_file else source
+        return gettext_parse(source_, plurals=gettext_plurals)
     elif format == Format.inc:
         return inc_parse(source)
     elif format == Format.ini:
         return ini_parse(source)
     elif format == Format.plain_json:
         return plain_json_parse(source)
-    elif format == Format.po:
-        # Workaround for https://github.com/izimobil/polib/issues/170
-        source_ = cast(str, input) if input_is_file else source
-        return po_parse(source_, plurals=gettext_plurals)
     elif format == Format.properties:
         return properties_parse(source)
     elif format == Format.webext:

--- a/python/moz/l10n/resource/serialize_resource.py
+++ b/python/moz/l10n/resource/serialize_resource.py
@@ -20,10 +20,10 @@ from typing import Callable, Sequence
 from ..formats import Format
 from ..formats.dtd.serialize import dtd_serialize
 from ..formats.fluent.serialize import fluent_serialize
+from ..formats.gettext.serialize import gettext_serialize
 from ..formats.inc.serialize import inc_serialize
 from ..formats.ini.serialize import ini_serialize
 from ..formats.plain_json.serialize import plain_json_serialize
-from ..formats.po.serialize import po_serialize
 from ..formats.properties.serialize import properties_serialize
 from ..formats.webext.serialize import webext_serialize
 from ..model import Message, Resource
@@ -63,16 +63,16 @@ def serialize_resource(
         return dtd_serialize(resource, trim_comments=trim_comments)
     elif format == Format.fluent:
         return fluent_serialize(resource, trim_comments=trim_comments)
+    elif format == Format.gettext:
+        return gettext_serialize(
+            resource, plurals=gettext_plurals, trim_comments=trim_comments
+        )
     elif format == Format.inc:
         return inc_serialize(resource, trim_comments=trim_comments)
     elif format == Format.ini:
         return ini_serialize(resource, trim_comments=trim_comments)
     elif format == Format.plain_json:
         return plain_json_serialize(resource, trim_comments=trim_comments)
-    elif format == Format.po:
-        return po_serialize(
-            resource, plurals=gettext_plurals, trim_comments=trim_comments
-        )
     elif format == Format.properties:
         return properties_serialize(resource, trim_comments=trim_comments)
     elif format == Format.webext:

--- a/python/tests/formats/test_detect_format.py
+++ b/python/tests/formats/test_detect_format.py
@@ -30,7 +30,7 @@ class TestDetectFormat(TestCase):
             "bug121341.properties": Format.properties,
             "defines.inc": Format.inc,
             "demo.ftl": Format.fluent,
-            "foo.po": Format.po,
+            "foo.po": Format.gettext,
             "messages.json": Format.webext,
             "test.properties": Format.properties,
         }

--- a/python/tests/formats/test_gettext.py
+++ b/python/tests/formats/test_gettext.py
@@ -20,7 +20,7 @@ from importlib_resources import files
 from unittest import TestCase
 
 from moz.l10n.formats import Format
-from moz.l10n.formats.po import po_parse, po_serialize
+from moz.l10n.formats.gettext import gettext_parse, gettext_serialize
 from moz.l10n.model import (
     CatchallKey,
     Entry,
@@ -36,11 +36,11 @@ from moz.l10n.model import (
 res_path = str(files("tests.formats.data").joinpath("foo.po"))
 
 
-class TestPo(TestCase):
+class TestGettext(TestCase):
     def test_parse(self):
-        res = po_parse(res_path)
+        res = gettext_parse(res_path)
         assert res == Resource(
-            Format.po,
+            Format.gettext,
             comment="Test translation file.\n"
             "Any copyright is dedicated to the Public Domain.\n"
             "http://creativecommons.org/publicdomain/zero/1.0/",
@@ -104,7 +104,7 @@ class TestPo(TestCase):
         )
 
     def test_serialize(self):
-        res = po_parse(res_path)
+        res = gettext_parse(res_path)
         exp = r"""# Test translation file.
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
@@ -149,7 +149,7 @@ msgid ""
 "separator"
 msgstr ""
 """
-        assert "".join(po_serialize(res)) == exp
+        assert "".join(gettext_serialize(res)) == exp
 
         # Remove catchall key label
         res.sections[0].entries[1].value.variants = {
@@ -158,12 +158,12 @@ msgstr ""
             ("2",): ["%d prevedeni sporočili"],
             (CatchallKey(),): ["%d prevedena sporočila"],
         }
-        assert "".join(po_serialize(res)) == exp
+        assert "".join(gettext_serialize(res)) == exp
 
     def test_trim_comments(self):
-        res = po_parse(res_path)
+        res = gettext_parse(res_path)
         assert (
-            "".join(po_serialize(res, trim_comments=True))
+            "".join(gettext_serialize(res, trim_comments=True))
             == r"""#
 msgid ""
 msgstr ""
@@ -203,11 +203,11 @@ msgstr ""
         )
 
     def test_obsolete(self):
-        res = po_parse(res_path)
+        res = gettext_parse(res_path)
         res.sections[0].entries[0].meta.append(Metadata("obsolete", "true"))
         res.sections[0].entries[3].meta = []
         assert (
-            "".join(po_serialize(res))
+            "".join(gettext_serialize(res))
             == r"""# Test translation file.
 # Any copyright is dedicated to the Public Domain.
 # http://creativecommons.org/publicdomain/zero/1.0/
@@ -268,7 +268,7 @@ msgstr[1] "pl-few"
 msgstr[2] "pl-many"
 """
         plurals = ["one", "few", "many"]
-        res = po_parse(src, plurals=plurals)
+        res = gettext_parse(src, plurals=plurals)
         assert res.sections == [
             Section(
                 id=(),
@@ -289,7 +289,7 @@ msgstr[2] "pl-many"
                 ],
             ),
         ]
-        assert "".join(po_serialize(res, plurals=plurals)) == src
+        assert "".join(gettext_serialize(res, plurals=plurals)) == src
 
         # Remove catchall key label
         res.sections[0].entries[0].value.variants = {
@@ -297,4 +297,4 @@ msgstr[2] "pl-many"
             ("few",): ["pl-few"],
             (CatchallKey(),): ["pl-many"],
         }
-        assert "".join(po_serialize(res, plurals=plurals)) == src
+        assert "".join(gettext_serialize(res, plurals=plurals)) == src

--- a/python/tests/formats/test_parse_serialize_resource.py
+++ b/python/tests/formats/test_parse_serialize_resource.py
@@ -105,4 +105,6 @@ class TesteParseResource(TestCase):
         source = get_source("demo.ftl")
         res = parse_resource(Format.fluent, source)
         with self.assertRaises(ValueError):
-            assert all(isinstance(s, str) for s in serialize_resource(res, Format.po))
+            assert all(
+                isinstance(s, str) for s in serialize_resource(res, Format.gettext)
+            )


### PR DESCRIPTION
The format is more commonly known as "gettext", rather than by its .po extension.

This also opens up the possibility of later supporting Gettext MO files, a bit like we might support XLIFF 2 eventually.