### PR TITLE
Fix type hint for Resource.all_entries(), add/fix tests

### DIFF
--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Iterator
 from dataclasses import dataclass, field
 from typing import Dict, Generic, List, Literal, Tuple, TypeVar, Union
 
@@ -367,7 +367,7 @@ class Resource(Generic[V_co]):
     Metadata attached to the whole resource.
     """
 
-    def all_entries(self) -> Iterable[Entry[V_co]]:
+    def all_entries(self) -> Iterator[Entry[V_co]]:
         """
         All entries in all resource sections.
         """

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -283,8 +283,8 @@ class TestL10nConfigPaths(TestCase):
             "wagtailpages/templates/about/locale/{locale}/LC_MESSAGES/django.po"
         )
         tgt_path, tgt_locales = paths.target(res_source)
-        assert tgt_path == join(paths.base, normpath(res_target))
         assert tgt_path
+        assert tgt_path == join(paths.base, normpath(res_target))
         assert tgt_locales == set(path_locales)
         assert paths.format_target_path(tgt_path, "de") == join(
             paths.base,

--- a/python/tests/test_config.py
+++ b/python/tests/test_config.py
@@ -261,6 +261,7 @@ class TestL10nConfigPaths(TestCase):
             build_file_tree(root, {"l10n.toml": cfg_toml})
             paths = L10nConfigPaths(join(root, "l10n.toml"))
         assert paths.base == join(root, "foundation", "translations", "networkapi")
+        assert paths.locales
         assert paths.locales == ["de", "es", "fr", "fy-NL", "nl", "pl", "pt-BR", "sw"]
         assert paths.all_locales == set(paths.locales)
         path_locales = ["de", "es", "fr", "pt-BR"]
@@ -283,6 +284,7 @@ class TestL10nConfigPaths(TestCase):
         )
         tgt_path, tgt_locales = paths.target(res_source)
         assert tgt_path == join(paths.base, normpath(res_target))
+        assert tgt_path
         assert tgt_locales == set(path_locales)
         assert paths.format_target_path(tgt_path, "de") == join(
             paths.base,

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -1,0 +1,48 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from unittest import TestCase
+
+from moz.l10n.formats import Format
+from moz.l10n.model import Comment, Entry, PatternMessage, Resource, Section
+
+
+class TestResource(TestCase):
+    def test_all_entries_some(self):
+        entries = [
+            Entry(("e0",), PatternMessage(["m0"])),
+            Entry(("e1",), PatternMessage(["m1"])),
+            Entry(("e2",), PatternMessage(["m2"])),
+            Entry(("e3",), PatternMessage(["m3"])),
+        ]
+        res = Resource(
+            Format.inc,
+            [
+                Section((), [Comment("c1"), entries[0], Comment("c2"), entries[1]]),
+                Section(("a",), [entries[2], Comment("c3"), entries[3], Comment("c4")]),
+            ],
+        )
+        assert list(res.all_entries()) == entries
+
+    def test_all_entries_none(self):
+        res = Resource(
+            Format.inc,
+            [
+                Section((), [Comment("c1"), Comment("c2")]),
+                Section(("a",), [Comment("c3"), Comment("c4")]),
+            ],
+        )
+        assert next(res.all_entries(), None) is None


### PR DESCRIPTION
The function was untested previously, and I wanted to validate that it can be used to check if a resource is empty of entries.

The `python/tests/test_config.py` change is unrelated, but makes pylance a little happier.