### PR TITLE
cli/build: Specialize the merge some more for Fluent

### DIFF
--- a/python/tests/test_bin_build.py
+++ b/python/tests/test_bin_build.py
@@ -29,7 +29,7 @@ class TestBuild(TestCase):
         entries: list[Entry[PatternMessage] | Comment] = [
             Entry(("msg-a",), PatternMessage(["s"])),
             Entry(("msg-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
-            Entry(("msg-c",), PatternMessage(["s"])),
+            Entry(("msg-c",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
             Entry(("-term-a",), PatternMessage(["s"])),
             Entry(("-term-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
             Entry(("-term-c",), PatternMessage(["s"])),
@@ -39,8 +39,9 @@ class TestBuild(TestCase):
             msg-a = tgt
                 .extra = tgt
             msg-b = tgt
+                .attr = tgt
                 .extra = tgt
-            msg-x = tgt
+            msg-c = tgt
                 .extra = tgt
             -term-a = tgt
                 .extra = tgt
@@ -59,9 +60,8 @@ class TestBuild(TestCase):
                 tgt_src = file.read()
             assert tgt_src == dedent("""\
                 msg-a = tgt
-                    .extra = tgt
                 msg-b = tgt
-                    .extra = tgt
+                    .attr = tgt
                 -term-a = tgt
                     .extra = tgt
                 -term-b = tgt
@@ -73,18 +73,20 @@ class TestBuild(TestCase):
         entries: list[Entry[PatternMessage] | Comment] = [
             Entry(("msg-a",), PatternMessage(["s"])),
             Entry(("msg-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
-            Entry(("msg-c",), PatternMessage(["s"])),
+            Entry(("msg-c",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
             Entry(("-term-a",), PatternMessage(["s"])),
             Entry(("-term-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
             Entry(("-term-c",), PatternMessage(["s"])),
         ]
+        # A bit hacky, but works for test purposes
         source_res = Resource(Format.plain_json, [Section((), entries)])
         l10n_src = dedent("""\
             msg-a = tgt
                 .extra = tgt
             msg-b = tgt
+                .attr = tgt
                 .extra = tgt
-            msg-x = tgt
+            msg-c = tgt
                 .extra = tgt
             -term-a = tgt
                 .extra = tgt
@@ -105,12 +107,14 @@ class TestBuild(TestCase):
                 msg-a = tgt
                     .extra = tgt
                 msg-b = tgt
+                    .attr = tgt
                     .extra = tgt
-                msg-c = s
+                msg-c = tgt
+                    .extra = tgt
                 -term-a = tgt
                     .extra = tgt
                 -term-b = tgt
                     .extra = tgt
                 -term-c = s
                 """)
-            assert msg_delta == 2
+            assert msg_delta == 1

--- a/python/tests/test_bin_build.py
+++ b/python/tests/test_bin_build.py
@@ -1,0 +1,116 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from os.path import join
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+from unittest import TestCase
+
+from moz.l10n.bin.build import write_target_file
+from moz.l10n.formats import Format
+from moz.l10n.model import Comment, Entry, PatternMessage, Resource, Section
+
+
+class TestBuild(TestCase):
+    def test_write_target_file_fluent(self):
+        entries: list[Entry[PatternMessage] | Comment] = [
+            Entry(("msg-a",), PatternMessage(["s"])),
+            Entry(("msg-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
+            Entry(("msg-c",), PatternMessage(["s"])),
+            Entry(("-term-a",), PatternMessage(["s"])),
+            Entry(("-term-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
+            Entry(("-term-c",), PatternMessage(["s"])),
+        ]
+        source_res = Resource(Format.fluent, [Section((), entries)])
+        l10n_src = dedent("""\
+            msg-a = tgt
+                .extra = tgt
+            msg-b = tgt
+                .extra = tgt
+            msg-x = tgt
+                .extra = tgt
+            -term-a = tgt
+                .extra = tgt
+            -term-b = tgt
+                .extra = tgt
+            -term-x = tgt
+                .extra = tgt
+            """)
+        with TemporaryDirectory() as tmpdir:
+            l10n_path = join(tmpdir, "l10n.ftl")
+            tgt_path = join(tmpdir, "tgt.ftl")
+            with open(l10n_path, mode="w") as file:
+                file.write(l10n_src)
+            msg_delta = write_target_file("", source_res, l10n_path, tgt_path)
+            with open(tgt_path, mode="r") as file:
+                tgt_src = file.read()
+            assert tgt_src == dedent("""\
+                msg-a = tgt
+                    .extra = tgt
+                msg-b = tgt
+                    .extra = tgt
+                -term-a = tgt
+                    .extra = tgt
+                -term-b = tgt
+                    .extra = tgt
+                """)
+            assert msg_delta == -2
+
+    def test_write_target_file_nonfluent(self):
+        entries: list[Entry[PatternMessage] | Comment] = [
+            Entry(("msg-a",), PatternMessage(["s"])),
+            Entry(("msg-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
+            Entry(("msg-c",), PatternMessage(["s"])),
+            Entry(("-term-a",), PatternMessage(["s"])),
+            Entry(("-term-b",), PatternMessage(["s"]), {"attr": PatternMessage(["s"])}),
+            Entry(("-term-c",), PatternMessage(["s"])),
+        ]
+        source_res = Resource(Format.plain_json, [Section((), entries)])
+        l10n_src = dedent("""\
+            msg-a = tgt
+                .extra = tgt
+            msg-b = tgt
+                .extra = tgt
+            msg-x = tgt
+                .extra = tgt
+            -term-a = tgt
+                .extra = tgt
+            -term-b = tgt
+                .extra = tgt
+            -term-x = tgt
+                .extra = tgt
+            """)
+        with TemporaryDirectory() as tmpdir:
+            l10n_path = join(tmpdir, "l10n.ftl")
+            tgt_path = join(tmpdir, "tgt.ftl")
+            with open(l10n_path, mode="w") as file:
+                file.write(l10n_src)
+            msg_delta = write_target_file("", source_res, l10n_path, tgt_path)
+            with open(tgt_path, mode="r") as file:
+                tgt_src = file.read()
+            assert tgt_src == dedent("""\
+                msg-a = tgt
+                    .extra = tgt
+                msg-b = tgt
+                    .extra = tgt
+                msg-c = s
+                -term-a = tgt
+                    .extra = tgt
+                -term-b = tgt
+                    .extra = tgt
+                -term-c = s
+                """)
+            assert msg_delta == 2


### PR DESCRIPTION
While the changes made in #83 do solve the problem reported in [bug 1977256](https://bugzilla.mozilla.org/show_bug.cgi?id=1977256) (so an update to v0.8.0 in f-m would technically close the bug), we really ought to account for some extra specialization for Fluent merges. Specifically, when building L10n content for runtime use:
- If a Fluent message has attributes that are not localized, the partially-localized message should not be used.
- If the localization of a Fluent message has attributes not in the source, those extra attributes should be dropped.

For Fluent terms, we should allow the localization full control over the attributes, but not include a wholly new Fluent term if it's not in the source.