### PR TITLE
Add fluentParseEntry() to JS implementation

### DIFF
--- a/js/src/fluent-parse.ts
+++ b/js/src/fluent-parse.ts
@@ -101,14 +101,14 @@ function message(ftlPattern: FTL.Pattern): Message {
       msgVariants = [[[], []]]
       break
     case 1:
-      msgVariants = uniqueSortedKeys(selData[0]).map((key) => [[key], []])
+      msgVariants = uniqueKeys(selData[0]).map((key) => [[key], []])
       break
     default: {
       // With multiple selectors, for each selector,
       // ensure that a row of keys exists with each of its values in its key column,
       // combined with each value of all other selectors.
       // Effectively this involves a cross product of two vectors.
-      const selKeyValues = selData.map(uniqueSortedKeys)
+      const selKeyValues = selData.map(uniqueKeys)
       // @ts-expect-error TS doesn't support this (valid) reduce variant
       const keyMatrix = selKeyValues.reduce((res: Key[] | Key[][], selKeys) =>
         res.flatMap((prev) => selKeys.map((key) => [prev, key].flat()))
@@ -220,16 +220,11 @@ function findSelectors(
   return result
 }
 
-function uniqueSortedKeys({ keys }: SelectorResultRow): Key[] {
+function uniqueKeys({ keys }: SelectorResultRow): Key[] {
   const res: Key[] = []
   for (const key of keys) {
     if (res.every((prev) => !keysEqual(prev, key))) res.push(key)
   }
-  res.sort((a, b) => {
-    if (a.isDefault !== b.isDefault) return a.isDefault ? 1 : -1
-    if (a.isNumeric !== b.isNumeric) return a.isNumeric ? -1 : 1
-    return 0
-  })
   return res
 }
 

--- a/js/src/fluent-parse.ts
+++ b/js/src/fluent-parse.ts
@@ -13,7 +13,7 @@
  * limitations under the License.
  */
 
-import * as AST from '@fluent/syntax/esm/ast.js'
+import * as FTL from '@fluent/syntax/esm/ast.js'
 import {
   ParseError as FluentError,
   FluentParser
@@ -21,7 +21,255 @@ import {
 import { FluentParserStream } from '@fluent/syntax/esm/stream.js'
 
 import { ParseError } from './errors.ts'
-import type { Expression, Pattern } from './model.ts'
+import type {
+  CatchallKey,
+  Expression,
+  Message,
+  Pattern,
+  Entry
+} from './model.ts'
+
+const pluralCategories = new Set(['zero', 'one', 'two', 'few', 'many', 'other'])
+
+/**
+ * Parses a string as a Fluent entry.
+ *
+ * Comments are discarded.
+ */
+export function fluentParseEntry(
+  src: string,
+  onError: (error: ParseError) => void
+): [string, Entry] {
+  let id = ''
+  let attrId = ''
+  try {
+    const entry = new FluentParser().parseEntry(src)
+    if (entry instanceof FTL.Message || entry instanceof FTL.Term) {
+      id = entry.id.name
+      if (entry instanceof FTL.Term) id = '-' + id
+      const value = entry.value ? message(entry.value) : null
+      const attributes: Record<string, Message> = {}
+      for (const attr of entry.attributes) {
+        attrId = attr.id.name
+        attributes[attrId] = message(attr.value)
+      }
+      return value
+        ? [
+            id,
+            Object.keys(attributes).length
+              ? { '=': value, '+': attributes }
+              : { '=': value }
+          ]
+        : [id, { '+': attributes }]
+    } else if (entry instanceof FTL.Junk && entry.annotations[0]) {
+      const annot = entry.annotations[0]
+      const msg = `fluent: ${annot.message} (${annot.code})`
+      const span = annot?.span ?? entry.span
+      onError(new ParseError(msg, span?.start ?? 0, span?.end ?? src.length))
+      return ['', { '=': [] }]
+    } else {
+      throw new Error('Parse error')
+    }
+  } catch (error) {
+    if (attrId) id += '.' + attrId
+    const pre = id ? `fluent(${id})` : 'fluent'
+    const msg =
+      error instanceof FluentError
+        ? `${error.message} (${error.code})`
+        : String(error)
+    onError(new ParseError(`${pre}: ${msg}`, 0, src.length))
+    return ['', { '=': [] }]
+  }
+}
+
+type Key = {
+  name: string
+  isDefault: boolean
+  isNumeric: boolean
+}
+
+type SelectorResultRow = {
+  msgSel: Expression
+  ftlSelectors: FTL.InlineExpression[]
+  keys: Key[]
+}
+
+function message(ftlPattern: FTL.Pattern): Message {
+  const selData = findSelectors(ftlPattern, [])
+  const selExpressions = selData.map((row) => row.msgSel)
+  let msgVariants: [Key[], Pattern][]
+  const varNames = new Set<string>()
+  switch (selExpressions.length) {
+    case 0:
+      msgVariants = [[[], []]]
+      break
+    case 1:
+      msgVariants = uniqueSortedKeys(selData[0]).map((key) => [[key], []])
+      break
+    default: {
+      // With multiple selectors, for each selector,
+      // ensure that a row of keys exists with each of its values in its key column,
+      // combined with each value of all other selectors.
+      // Effectively this involves a cross product of two vectors.
+      const selKeyValues = selData.map(uniqueSortedKeys)
+      // @ts-expect-error TS doesn't support this (valid) reduce variant
+      const keyMatrix = selKeyValues.reduce((res: Key[] | Key[][], selKeys) =>
+        res.flatMap((prev) => selKeys.map((key) => [prev, key].flat()))
+      ) as Key[][]
+      msgVariants = keyMatrix.map((keys) => [keys, []])
+    }
+  }
+
+  const filter: (Key | undefined)[] = new Array(selExpressions.length)
+
+  function addPattern(ftlPattern: FTL.Pattern) {
+    let el:
+      | FTL.TextElement
+      | FTL.Placeable
+      | FTL.InlineExpression
+      | FTL.SelectExpression
+    for (el of ftlPattern.elements) {
+      while (el instanceof FTL.Placeable) el = el.expression
+      if (el instanceof FTL.SelectExpression) {
+        const ftlSel = el.selector
+        const msgSel = selData.find((row) =>
+          row.ftlSelectors.includes(ftlSel)
+        )!.msgSel
+        const idx = selExpressions.indexOf(msgSel)
+        const prevFilt = filter[idx]
+        for (const v of el.variants) {
+          filter[idx] = variantKey(v)
+          addPattern(v.value)
+        }
+        filter[idx] = prevFilt
+      } else {
+        for (const [keys, pat] of msgVariants) {
+          if (
+            filter.every(
+              (filt, idx) => filt === undefined || keysEqual(filt, keys[idx])
+            )
+          ) {
+            if (el instanceof FTL.TextElement) {
+              if (typeof pat.at(-1) === 'string')
+                pat[pat.length - 1] += el.value
+              else pat.push(el.value)
+            } else {
+              const expr = expression(el, false)
+              if (expr.$) varNames.add(expr.$)
+              pat.push(expr)
+            }
+          }
+        }
+      }
+    }
+  }
+  addPattern(ftlPattern)
+
+  if (selExpressions.length) {
+    const decl: Record<string, Expression> = {}
+    const sel: string[] = []
+    for (const expr of selExpressions) {
+      const stem = expr.$ ?? ''
+      let i = 0
+      let name = stem
+      while (!name || varNames.has(name)) {
+        i += 1
+        name = `${stem}_${i}`
+      }
+      decl[name] = expr
+      sel.push(name)
+      varNames.add(name)
+    }
+
+    function message_key(key: Key): string | CatchallKey {
+      return key.isDefault ? { '*': key.name } : key.name
+    }
+
+    const alt = msgVariants
+      .filter((mv) => mv[1].length)
+      .map(([keys, pat]) => ({ keys: keys.map(message_key), pat }))
+    return { decl, sel, alt }
+  } else {
+    return msgVariants[0][1]
+  }
+}
+
+function findSelectors(
+  pattern: FTL.Pattern,
+  result: SelectorResultRow[]
+): SelectorResultRow[] {
+  for (const el of pattern.elements) {
+    if (
+      el instanceof FTL.Placeable &&
+      el.expression instanceof FTL.SelectExpression
+    ) {
+      const ftlSel = el.expression.selector
+      const keys = el.expression.variants.map(variantKey)
+      const msgSel = selectExpression(ftlSel, keys)
+      let foundPrev = false
+      for (const row of result) {
+        if (exprEqual(row.msgSel, msgSel)) {
+          row.ftlSelectors.push(ftlSel)
+          row.keys.push(...keys)
+          foundPrev = true
+        }
+      }
+      if (!foundPrev) {
+        result.push({ msgSel, ftlSelectors: [ftlSel], keys })
+      }
+      for (const v of el.expression.variants) findSelectors(v.value, result)
+    }
+  }
+  return result
+}
+
+function uniqueSortedKeys({ keys }: SelectorResultRow): Key[] {
+  const res: Key[] = []
+  for (const key of keys) {
+    if (res.every((prev) => !keysEqual(prev, key))) res.push(key)
+  }
+  res.sort((a, b) => {
+    if (a.isDefault !== b.isDefault) return a.isDefault ? 1 : -1
+    if (a.isNumeric !== b.isNumeric) return a.isNumeric ? -1 : 1
+    return 0
+  })
+  return res
+}
+
+const keysEqual = (a: Key, b: Key) =>
+  a.name === b.name &&
+  a.isDefault === b.isDefault &&
+  a.isNumeric === b.isNumeric
+
+const exprEqual = (a: Expression, b: Expression) =>
+  a.$ === b.$ &&
+  a._ === b._ &&
+  a.fn === b.fn &&
+  (a.opt === b.opt || JSON.stringify(a.opt) === JSON.stringify(b.opt))
+
+function variantKey(v: FTL.Variant): Key {
+  if (v.key instanceof FTL.Identifier) {
+    return { name: v.key.name, isDefault: v.default, isNumeric: false }
+  } else {
+    return { name: v.key.value, isDefault: v.default, isNumeric: true }
+  }
+}
+
+function selectExpression(
+  ftlSel: FTL.InlineExpression,
+  keys: Key[]
+): Expression {
+  if (ftlSel instanceof FTL.VariableReference) {
+    const fn = keys.every((k) => k.isNumeric || pluralCategories.has(k.name))
+      ? 'number'
+      : 'string'
+    return { $: ftlSel.id.name, fn }
+  } else if (ftlSel instanceof FTL.StringLiteral) {
+    return { _: ftlSel.value, fn: 'string' }
+  } else {
+    return expression(ftlSel, true)
+  }
+}
 
 /**
  * Parses a string as a Fluent pattern, without any internal selectors.
@@ -41,7 +289,8 @@ export function fluentParsePattern(
         case '{': {
           ps.next()
           ps.skipBlank()
-          const expr = expression(ps)
+          const fe = new FluentParser().getInlineExpression(ps)
+          const expr = expression(fe, false)
           ps.skipBlank()
           if (ps.currentChar() === '-' && ps.peek() === '>') {
             // Not supporting selectors within patterns
@@ -76,19 +325,24 @@ export function fluentParsePattern(
   return pattern
 }
 
-function expression(ps: FluentParserStream): Expression {
-  const fe = new FluentParser().getInlineExpression(ps)
-  if (fe instanceof AST.NumberLiteral) return { _: fe.value, fn: 'number' }
-  if (fe instanceof AST.StringLiteral) return { _: fe.parse().value }
-  if (fe instanceof AST.VariableReference) return { $: fe.id.name }
-  if (fe instanceof AST.MessageReference) {
+function expression(
+  fe: FTL.InlineExpression | FTL.Placeable,
+  isSelector: boolean
+): Expression {
+  if (fe instanceof FTL.NumberLiteral) return { _: fe.value, fn: 'number' }
+  if (fe instanceof FTL.StringLiteral) return { _: fe.parse().value }
+  if (fe instanceof FTL.VariableReference) return { $: fe.id.name }
+  if (fe instanceof FTL.MessageReference) {
     let name = fe.id.name
     if (fe.attribute) name += '.' + fe.attribute.name
     return { _: name, fn: 'message' }
   }
-  if (fe instanceof AST.TermReference) {
-    if (fe.attribute) throw new FluentError('E0019')
-    const name = '-' + fe.id.name
+  if (fe instanceof FTL.TermReference) {
+    let name = '-' + fe.id.name
+    if (fe.attribute) {
+      if (isSelector) name += '.' + fe.attribute.name
+      else throw new FluentError('E0019')
+    }
     const expr: Expression = { _: name, fn: 'message' }
     if (fe.arguments?.named.length) {
       expr.opt = Object.create(null) as Record<string, string>
@@ -98,13 +352,13 @@ function expression(ps: FluentParserStream): Expression {
     }
     return expr
   }
-  if (fe instanceof AST.FunctionReference) {
+  if (fe instanceof FTL.FunctionReference) {
     const name = fe.id.name.toLowerCase()
     const arg = fe.arguments.positional[0]
     let expr: Expression
-    if (arg instanceof AST.BaseLiteral) {
+    if (arg instanceof FTL.BaseLiteral) {
       expr = { _: arg.value, fn: name }
-    } else if (arg instanceof AST.VariableReference) {
+    } else if (arg instanceof FTL.VariableReference) {
       expr = { $: arg.id.name, fn: name }
     } else {
       expr = { fn: name }

--- a/js/src/fluent.test.ts
+++ b/js/src/fluent.test.ts
@@ -110,25 +110,25 @@ describe('pattern serialize errors', () => {
 describe('entry parse', () => {
   const ok = (name: string, src: string, exp: Entry) =>
     test(name, () => {
-      const onError = vi.fn()
-      const res = fluentParseEntry(src, onError)
-      expect(onError).not.toHaveBeenCalled()
+      const res = fluentParseEntry(src)
       expect(res).toEqual([name, exp])
     })
 
   const fail = (name: string, src: string, code: string | null) =>
     test(name, () => {
-      const onError = vi.fn()
-      fluentParseEntry(src, onError)
-      expect(onError).toHaveBeenCalledOnce()
-      const error = onError.mock.calls[0][0]
-      expect(error).toBeInstanceOf(ParseError)
-      if (code) {
-        expect(error.message).toMatch(
-          new RegExp(`^fluent(\\(\\w+\\))?: .*\\(${code}\\)$`)
-        )
-      } else {
-        expect(error.message).toMatch(/^fluent/)
+      try {
+        fluentParseEntry(src)
+        throw Error('Expectred an error')
+        // @ts-expect-error yes, we check this.
+      } catch (error: ParseError) {
+        expect(error).toBeInstanceOf(ParseError)
+        if (code) {
+          expect(error.message).toMatch(
+            new RegExp(`^fluent(\\(\\w+\\))?: .*\\(${code}\\)$`)
+          )
+        } else {
+          expect(error.message).toMatch(/^fluent/)
+        }
       }
     })
 

--- a/js/src/fluent.test.ts
+++ b/js/src/fluent.test.ts
@@ -207,10 +207,10 @@ describe('entry parse', () => {
         },
         sel: ['a', 'b'],
         alt: [
-          { keys: ['1', 'cc'], pat: ['pre One mid CC post'] },
           { keys: ['1', { '*': 'bb' }], pat: ['pre One mid BB post'] },
-          { keys: [{ '*': '2' }, 'cc'], pat: ['pre Two mid CC post'] },
-          { keys: [{ '*': '2' }, { '*': 'bb' }], pat: ['pre Two mid BB post'] }
+          { keys: ['1', 'cc'], pat: ['pre One mid CC post'] },
+          { keys: [{ '*': '2' }, { '*': 'bb' }], pat: ['pre Two mid BB post'] },
+          { keys: [{ '*': '2' }, 'cc'], pat: ['pre Two mid CC post'] }
         ]
       }
     }
@@ -251,9 +251,9 @@ describe('entry parse', () => {
           { keys: ['0', { '*': 'other' }], pat: ['0,x'] },
           { keys: ['one', 'one'], pat: [{ _: '1,1' }] },
           { keys: ['one', { '*': 'other' }], pat: ['1,x'] },
-          { keys: [{ '*': 'other' }, '0'], pat: ['x,0'] },
           { keys: [{ '*': 'other' }, 'one'], pat: ['x,1'] },
-          { keys: [{ '*': 'other' }, { '*': 'other' }], pat: ['x,x'] }
+          { keys: [{ '*': 'other' }, { '*': 'other' }], pat: ['x,x'] },
+          { keys: [{ '*': 'other' }, '0'], pat: ['x,0'] }
         ]
       }
     }

--- a/js/src/fluent.test.ts
+++ b/js/src/fluent.test.ts
@@ -14,13 +14,14 @@
  */
 
 import { describe, expect, test, vi } from 'vitest'
+import ftl from '@fluent/dedent'
 
 import { ERROR_RESULT, ParseError, SerializeError } from './errors.ts'
-import { fluentParsePattern } from './fluent-parse.ts'
+import { fluentParseEntry, fluentParsePattern } from './fluent-parse.ts'
 import { fluentSerializePattern } from './fluent-serialize.ts'
-import type { Pattern } from './model.ts'
+import type { Entry, Pattern } from './model.ts'
 
-describe('success', () => {
+describe('pattern success', () => {
   const ok = (name: string, pattern: Pattern, exp: string) =>
     test(name, () => {
       const onError = vi.fn()
@@ -64,7 +65,7 @@ describe('success', () => {
   )
 })
 
-describe('parse errors', () => {
+describe('pattern parse errors', () => {
   const fail = (name: string, src: string, code: string) =>
     test(name, () => {
       const onError = vi.fn()
@@ -83,7 +84,7 @@ describe('parse errors', () => {
   fail('newline in literal', '{ "foo\nbar" }', 'E0020')
 })
 
-describe('serialize errors', () => {
+describe('pattern serialize errors', () => {
   const fail = (name: string, pattern: Pattern) =>
     test(name, () => {
       const onError = vi.fn()
@@ -104,4 +105,200 @@ describe('serialize errors', () => {
     { _: 'foo', fn: 'message', opt: { x: 'y' } }
   ])
   fail('invalid term reference', [{ _: '-foo.bar', fn: 'message' }])
+})
+
+describe('entry parse', () => {
+  const ok = (name: string, src: string, exp: Entry) =>
+    test(name, () => {
+      const onError = vi.fn()
+      const res = fluentParseEntry(src, onError)
+      expect(onError).not.toHaveBeenCalled()
+      expect(res).toEqual([name, exp])
+    })
+
+  const fail = (name: string, src: string, code: string | null) =>
+    test(name, () => {
+      const onError = vi.fn()
+      fluentParseEntry(src, onError)
+      expect(onError).toHaveBeenCalledOnce()
+      const error = onError.mock.calls[0][0]
+      expect(error).toBeInstanceOf(ParseError)
+      if (code) {
+        expect(error.message).toMatch(
+          new RegExp(`^fluent(\\(\\w+\\))?: .*\\(${code}\\)$`)
+        )
+      } else {
+        expect(error.message).toMatch(/^fluent/)
+      }
+    })
+
+  ok('plain', 'plain = Progress: { NUMBER($num, style: "percent") }.', {
+    '=': [
+      'Progress: ',
+      { $: 'num', fn: 'number', opt: { style: 'percent' } },
+      '.'
+    ]
+  })
+
+  ok(
+    'num-no-placeholder',
+    ftl`
+    num-no-placeholder =
+        { $num ->
+            [one] One
+           *[other] Other
+        }
+    `,
+    {
+      '=': {
+        decl: { num: { $: 'num', fn: 'number' } },
+        sel: ['num'],
+        alt: [
+          { keys: ['one'], pat: ['One'] },
+          { keys: [{ '*': 'other' }], pat: ['Other'] }
+        ]
+      }
+    }
+  )
+
+  ok(
+    'num-has-placeholder',
+    ftl`
+    num-has-placeholder =
+        { $num ->
+            [one] One { $num }
+           *[other] Other
+        }
+    `,
+    {
+      '=': {
+        decl: { num_1: { $: 'num', fn: 'number' } },
+        sel: ['num_1'],
+        alt: [
+          { keys: ['one'], pat: ['One ', { $: 'num' }] },
+          { keys: [{ '*': 'other' }], pat: ['Other'] }
+        ]
+      }
+    }
+  )
+
+  ok('-term-with-attr', '-term-with-attr = body\n  .attr = value\n', {
+    '=': ['body'],
+    '+': { attr: ['value'] }
+  })
+
+  ok(
+    'two-sels',
+    ftl`
+    two-sels =
+        pre { $a ->
+            [1] One
+           *[2] Two
+        } mid { $b ->
+           *[bb] BB
+            [cc] CC
+        } post
+    `,
+    {
+      '=': {
+        decl: {
+          a: { $: 'a', fn: 'number' },
+          b: { $: 'b', fn: 'string' }
+        },
+        sel: ['a', 'b'],
+        alt: [
+          { keys: ['1', 'cc'], pat: ['pre One mid CC post'] },
+          { keys: ['1', { '*': 'bb' }], pat: ['pre One mid BB post'] },
+          { keys: [{ '*': '2' }, 'cc'], pat: ['pre Two mid CC post'] },
+          { keys: [{ '*': '2' }, { '*': 'bb' }], pat: ['pre Two mid BB post'] }
+        ]
+      }
+    }
+  )
+
+  ok(
+    'deep-sels',
+    ftl`
+    deep-sels =
+      { $a ->
+          [0]
+            { $b ->
+                [one] {""}
+               *[other] 0,x
+            }
+          [one]
+            { $b ->
+                [one] {"1,1"}
+               *[other] 1,x
+            }
+         *[other]
+            { $b ->
+                [0] x,0
+                [one] x,1
+               *[other] x,x
+            }
+      }
+    `,
+    {
+      '=': {
+        decl: {
+          a: { $: 'a', fn: 'number' },
+          b: { $: 'b', fn: 'number' }
+        },
+        sel: ['a', 'b'],
+        alt: [
+          { keys: ['0', 'one'], pat: [{ _: '' }] },
+          { keys: ['0', { '*': 'other' }], pat: ['0,x'] },
+          { keys: ['one', 'one'], pat: [{ _: '1,1' }] },
+          { keys: ['one', { '*': 'other' }], pat: ['1,x'] },
+          { keys: [{ '*': 'other' }, '0'], pat: ['x,0'] },
+          { keys: [{ '*': 'other' }, 'one'], pat: ['x,1'] },
+          { keys: [{ '*': 'other' }, { '*': 'other' }], pat: ['x,x'] }
+        ]
+      }
+    }
+  )
+
+  ok(
+    'term-attr-sel',
+    ftl`
+    term-attr-sel =
+      { -term.attr ->
+         [foo] Foo
+        *[other] Other
+      }
+    `,
+    {
+      '=': {
+        decl: { _1: { _: '-term.attr', fn: 'message' } },
+        sel: ['_1'],
+        alt: [
+          { keys: ['foo'], pat: ['Foo'] },
+          { keys: [{ '*': 'other' }], pat: ['Other'] }
+        ]
+      }
+    }
+  )
+
+  fail(
+    'term-sel',
+    ftl`
+    term-sel =
+      { -term ->
+         [foo] Foo
+        *[other] Other
+      }
+    `,
+    'E0017'
+  )
+
+  ok('comment', '# comment\ncomment = value', { '=': ['value'] })
+  ok('skip-comment', '# comment\n\n\n\nskip-comment = value', {
+    '=': ['value']
+  })
+  fail('standalone comment', '# comment\n', 'E0002')
+
+  fail('missing key', 'value\n', 'E0003')
+  fail('missing expression end', 'key = missing {', 'E0028')
+  fail('missing expression body', 'key = missing {}\n', 'E0028')
 })

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -16,7 +16,7 @@
 import { androidParsePattern } from './android-parse.ts'
 import { androidSerializePattern } from './android-serialize.ts'
 import { ParseError, SerializeError } from './errors.js'
-import { fluentParsePattern } from './fluent-parse.ts'
+import { fluentParseEntry, fluentParsePattern } from './fluent-parse.ts'
 import { fluentSerializePattern } from './fluent-serialize.ts'
 import { mf2ParsePattern } from './mf2-parse.ts'
 import { mf2SerializePattern } from './mf2-serialize.ts'
@@ -40,8 +40,11 @@ export {
 export {
   androidParsePattern,
   androidSerializePattern,
+  fluentParseEntry,
   fluentParsePattern,
   fluentSerializePattern,
+  mf2ParsePattern,
+  mf2SerializePattern,
   ParseError,
   SerializeError,
   webextParsePattern,

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -29,9 +29,12 @@ import { xliffSerializePattern } from './xliff-serialize.ts'
 export {
   isExpression,
   isMarkup,
+  type CatchallKey,
+  type Entry,
   type Expression,
   type Markup,
   type Message,
+  type Metadata,
   type Pattern,
   type PatternMessage,
   type SelectMessage

--- a/js/src/model.ts
+++ b/js/src/model.ts
@@ -78,10 +78,12 @@ export interface SelectMessage {
   msg?: never
   sel: string[]
   alt: {
-    keys: (string | { '*': string })[]
+    keys: (string | CatchallKey)[]
     pat: Pattern
   }[]
 }
+
+export type CatchallKey = { '*': string }
 
 export const isExpression = (
   x: string | Expression | Markup

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       ],
       "devDependencies": {
         "@eslint/js": "^9.19.0",
+        "@fluent/dedent": "^0.5.0",
         "@vitest/coverage-v8": "^3.0.5",
         "eslint": "^9.19.0",
         "eslint-config-prettier": "^10.0.1",
@@ -665,6 +666,17 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@fluent/dedent": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@fluent/dedent/-/dedent-0.5.0.tgz",
+      "integrity": "sha512-SANNuitARjbXA4kVj7V9OJ/45nw5ImkW/cb2qOlPSI/gJTBLb5gTMXgmHvZrwilqqHfdHKGMJ0JkwWulATWJqw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@fluent/syntax": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.19.0",
+    "@fluent/dedent": "^0.5.0",
     "@vitest/coverage-v8": "^3.0.5",
     "eslint": "^9.19.0",
     "eslint-config-prettier": "^10.0.1",


### PR DESCRIPTION
Adds a matching JS implementation for the pre-existing Python [`fluent_parse_entry()`](https://github.com/mozilla/moz-l10n/blob/eaee0ca670a12844d91c8d1492f639c45d28a516/python/moz/l10n/formats/fluent/parse.py#L135).