### PR TITLE
android: Normalize whitespace before & after some tags as a newline

### DIFF
--- a/js/src/android.test.ts
+++ b/js/src/android.test.ts
@@ -91,6 +91,52 @@ describe('success', () => {
   )
 })
 
+describe('newlines', () => {
+  test('breaks', () => {
+    const res = androidParsePattern(
+      '&lt;p>One&lt;/p> &lt;p>two &lt;br/>&lt;hr/> three&lt;/p>'
+    )
+    expect(res).toEqual([
+      { _: '<p>', fn: 'html' },
+      'One',
+      { _: '</p>', fn: 'html' },
+      '\n',
+      { _: '<p>', fn: 'html' },
+      'two ',
+      { _: '<br/>', fn: 'html' },
+      { _: '<hr/>', fn: 'html' },
+      '\nthree',
+      { _: '</p>', fn: 'html' }
+    ])
+  })
+
+  test('list', () => {
+    const res = androidParsePattern(
+      '&lt;ul> &lt;li> One &lt;/li> &lt;li> two &lt;/li> &lt;/ul>'
+    )
+    expect(res).toEqual([
+      { _: '<ul>', fn: 'html' },
+      '\n',
+      { _: '<li>', fn: 'html' },
+      ' One ',
+      { _: '</li>', fn: 'html' },
+      '\n',
+      { _: '<li>', fn: 'html' },
+      ' two ',
+      { _: '</li>', fn: 'html' },
+      '\n',
+      { _: '</ul>', fn: 'html' }
+    ])
+  })
+})
+
+// This works in browsers, but not in tests.
+// https://github.com/capricorn86/happy-dom/issues/1900
+test.fails('CDATA', () => {
+  const res = androidParsePattern('<![CDATA[foo]]>')
+  expect(res).toEqual(['foo'])
+})
+
 describe('parse errors', () => {
   test('invalid xml', () => {
     let error: any

--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -481,7 +481,7 @@ def parse_inline(
                         yield acc
                         acc = ""
                     yield Expression(tag, "html")
-                    at_br = break_tag_re.fullmatch(tag)
+                    at_br = bool(break_tag_re.fullmatch(tag))
                 else:
                     if acc:
                         yield acc

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -697,3 +697,71 @@ class TestAndroid(TestCase):
             </resources>
             """
         )
+
+    def test_newlines(self):
+        src = dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">&lt;p>One&lt;/p> &lt;p>two &lt;br/>&lt;hr/> three&lt;/p></string>
+              <string name="y"><![CDATA[<ul> <li> One </li> <li> two </li> </ul>]]></string>
+            </resources>
+            """
+        )
+
+        res = android_parse(src)
+        assert res == Resource(
+            Format.android,
+            [
+                Section(
+                    (),
+                    [
+                        Entry(
+                            ("x",),
+                            PatternMessage(
+                                [
+                                    Expression("<p>", "html"),
+                                    "One",
+                                    Expression("</p>", "html"),
+                                    "\n",
+                                    Expression("<p>", "html"),
+                                    "two ",
+                                    Expression("<br/>", "html"),
+                                    Expression("<hr/>", "html"),
+                                    "\nthree",
+                                    Expression("</p>", "html"),
+                                ]
+                            ),
+                        ),
+                        Entry(
+                            ("y",),
+                            PatternMessage(
+                                [
+                                    Expression("<ul>", "html"),
+                                    "\n",
+                                    Expression("<li>", "html"),
+                                    " One ",
+                                    Expression("</li>", "html"),
+                                    "\n",
+                                    Expression("<li>", "html"),
+                                    " two ",
+                                    Expression("</li>", "html"),
+                                    "\n",
+                                    Expression("</ul>", "html"),
+                                ]
+                            ),
+                        ),
+                    ],
+                )
+            ],
+        )
+        ser = "".join(android_serialize(res))
+        assert ser == dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x"><![CDATA[<p>One</p>\\n<p>two <br/><hr/>\\nthree</p>]]></string>
+              <string name="y"><![CDATA[<ul>\\n<li> One </li>\\n<li> two </li>\\n</ul>]]></string>
+            </resources>
+            """
+        )


### PR DESCRIPTION
As whitespace around HTML block tags in Android will eventually get swallowed up, the space character that we use has no impact on the formatted results. Hence, let's ensure that block tags always start on a new line, so that the messages are easier to read and translate.