### PR TITLE
Add message normalization

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -25,6 +25,22 @@ and the parser for `mf2` depends on the `messageformat` package.
 
 ## API
 
+### normalizeMessage()
+
+```js
+import { normalizeMessage } from '@mozilla/l10n'
+```
+
+```js
+function normalizeMessage(msg: Message): Message
+```
+
+Drop unused declarations, join adjacent literal elements, and drop empty literal elements.
+
+Does not modify `msg`.
+Objects and arrays in returned value are clones of objects in `msg`.
+
+
 ### parsePattern()
 
 ```js

--- a/js/README.md
+++ b/js/README.md
@@ -40,7 +40,6 @@ Drop unused declarations, join adjacent literal elements, and drop empty literal
 Does not modify `msg`.
 Objects and arrays in returned value are clones of objects in `msg`.
 
-
 ### parsePattern()
 
 ```js

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -45,7 +45,7 @@ export {
   type PatternMessage,
   type SelectMessage
 } from './model.ts'
-export { messageIsEmpty } from './model-utils.ts'
+export { messageIsEmpty, normalizeMessage } from './model-utils.ts'
 
 export {
   androidParsePattern,

--- a/js/src/model-utils.test.ts
+++ b/js/src/model-utils.test.ts
@@ -14,7 +14,12 @@
  */
 
 import { describe, expect, test } from 'vitest'
-import { messageIsEmpty, SelectMessage } from './index.ts'
+import {
+  type Message,
+  messageIsEmpty,
+  normalizeMessage,
+  type SelectMessage
+} from './index.ts'
 
 describe('messageIsEmpty', () => {
   test('Pattern', () => {
@@ -45,5 +50,103 @@ describe('messageIsEmpty', () => {
     }
     expect(messageIsEmpty(sm)).toBe(false)
     expect(messageIsEmpty(sm, true)).toBe(true)
+  })
+})
+
+describe('normalizeMessage', () => {
+  test('literals in pattern', () => {
+    expect(normalizeMessage([''])).toEqual([])
+    expect(normalizeMessage(['', '\n'])).toEqual(['\n'])
+    expect(normalizeMessage(['foo', '', ''])).toEqual(['foo'])
+  })
+
+  test('unused declarations', () => {
+    expect(normalizeMessage({ decl: { x: { _: 'x' } }, msg: ['x'] })).toEqual([
+      'x'
+    ])
+    expect(
+      normalizeMessage({
+        decl: { x: { $: 'x' }, y: { _: 'y' } },
+        msg: ['', { $: 'x' }]
+      })
+    ).toEqual({ decl: { x: { $: 'x' } }, msg: [{ $: 'x' }] })
+  })
+
+  test('variable reference in option value', () => {
+    expect(
+      normalizeMessage({
+        decl: { x: { $: 'x' }, y: { _: 'y' } },
+        msg: ['', { _: 'y', fn: 'fn', opt: { o: { $: 'x' } } }]
+      })
+    ).toEqual({
+      decl: { x: { $: 'x' } },
+      msg: [{ _: 'y', fn: 'fn', opt: { o: { $: 'x' } } }]
+    })
+  })
+
+  test('variable dependency chain', () => {
+    expect(
+      normalizeMessage({
+        decl: {
+          a: { $: 'a' },
+          b: { _: 'b', fn: 'fn', opt: { o: { $: 'a' } } },
+          c: { $: 'b' },
+          d: { $: 'c' },
+          e: { $: 'a' },
+          f: { $: 'e' }
+        },
+        msg: [{ $: 'd' }]
+      })
+    ).toEqual({
+      decl: {
+        a: { $: 'a' },
+        b: { _: 'b', fn: 'fn', opt: { o: { $: 'a' } } },
+        c: { $: 'b' },
+        d: { $: 'c' }
+      },
+      msg: [{ $: 'd' }]
+    })
+  })
+
+  test('SelectMessage', () => {
+    expect(
+      normalizeMessage({
+        decl: { x: { _: 'x' }, y: { $: 'y' }, z: { $: 'z' } },
+        sel: ['x'],
+        alt: [
+          { keys: ['a'], pat: [''] },
+          { keys: [{ '*': '' }], pat: [{ $: 'y' }] }
+        ]
+      })
+    ).toEqual({
+      decl: { x: { _: 'x' }, y: { $: 'y' } },
+      sel: ['x'],
+      alt: [
+        { keys: ['a'], pat: [] },
+        { keys: [{ '*': '' }], pat: [{ $: 'y' }] }
+      ]
+    })
+  })
+
+  describe('input is not modified', () => {
+    for (const msg of [
+      ['x'],
+      [''],
+      { decl: { a: { $: 'a' } }, msg: ['', { $: 'a' }] },
+      {
+        decl: { x: { _: 'x' }, y: { $: 'y' }, z: { $: 'z' } },
+        sel: ['x'],
+        alt: [
+          { keys: ['a'], pat: [''] },
+          { keys: [{ '*': '' }], pat: [{ $: 'y' }] }
+        ]
+      }
+    ] as Message[]) {
+      test(JSON.stringify(msg), () => {
+        const orig = structuredClone(msg)
+        expect(normalizeMessage(msg)).not.toBe(msg)
+        expect(msg).toEqual(orig)
+      })
+    }
   })
 })

--- a/js/src/model-utils.test.ts
+++ b/js/src/model-utils.test.ts
@@ -58,6 +58,16 @@ describe('normalizeMessage', () => {
     expect(normalizeMessage([''])).toEqual([])
     expect(normalizeMessage(['', '\n'])).toEqual(['\n'])
     expect(normalizeMessage(['foo', '', ''])).toEqual(['foo'])
+    expect(normalizeMessage(['foo', '', 'bar'])).toEqual(['foobar'])
+    expect(normalizeMessage(['foo', { _: '' }, 'bar'])).toEqual(['foobar'])
+    expect(
+      normalizeMessage(['foo', { _: '', attr: undefined }, 'bar'])
+    ).toEqual(['foobar'])
+    expect(normalizeMessage(['foo', { _: '', attr: {} }, 'bar'])).toEqual([
+      'foo',
+      { _: '', attr: {} },
+      'bar'
+    ])
   })
 
   test('unused declarations', () => {

--- a/js/src/model-utils.ts
+++ b/js/src/model-utils.ts
@@ -72,7 +72,11 @@ function normalizePattern(pat: Pattern, varRefs: Set<string> | null): Pattern {
   for (const el of pat) {
     if (typeof el === 'string') {
       next = next ? next + el : el
-    } else {
+    } else if (
+      // Skip empty literal expressions, i.e. {||}
+      el._ !== '' ||
+      Object.values(el).reduce((s, v) => (v === undefined ? s : s + 1), 0) !== 1
+    ) {
       if (next) {
         res.push(next)
         next = ''

--- a/js/src/model-utils.ts
+++ b/js/src/model-utils.ts
@@ -13,7 +13,13 @@
  * limitations under the License.
  */
 
-import type { Message, Pattern } from './model.ts'
+import type {
+  Expression,
+  Message,
+  Pattern,
+  PatternMessage,
+  SelectMessage
+} from './model.ts'
 
 /**
  * Determine if a message would format as an empty string.
@@ -33,4 +39,97 @@ export function messageIsEmpty(msg: Message, anyVariant = false): boolean {
       ? patterns.some(emptyPattern)
       : patterns.every(emptyPattern)
   }
+}
+
+/**
+ * Drop unused declarations, join adjacent literal elements, and drop empty literal elements.
+ *
+ * Does not modify `msg`.
+ * Objects and arrays in returned value are clones of objects in `msg`.
+ */
+export function normalizeMessage(msg: Message): Message {
+  if (Array.isArray(msg)) return normalizePattern(msg, null)
+
+  if (msg.msg) {
+    const varRefs = new Set<string>()
+    const pat = normalizePattern(msg.msg, varRefs)
+    const decl = normalizeDeclarations(msg, varRefs)
+    return decl ? { decl, msg: pat } : pat
+  }
+
+  const varRefs = new Set<string>(msg.sel)
+  const alt = msg.alt.map(({ keys, pat }) => ({
+    keys: structuredClone(keys),
+    pat: normalizePattern(pat, varRefs)
+  }))
+  const decl = normalizeDeclarations(msg, varRefs)!
+  return { decl, sel: [...msg.sel], alt }
+}
+
+function normalizePattern(pat: Pattern, varRefs: Set<string> | null): Pattern {
+  const res: Pattern = []
+  let next: string = ''
+  for (const el of pat) {
+    if (typeof el === 'string') {
+      next = next ? next + el : el
+    } else {
+      if (next) {
+        res.push(next)
+        next = ''
+      }
+      res.push(structuredClone(el))
+      if (varRefs) {
+        if (typeof el.$ === 'string') varRefs.add(el.$)
+        if (el.opt) {
+          for (const optVal of Object.values(el.opt)) {
+            if (typeof optVal !== 'string') varRefs.add(optVal.$)
+          }
+        }
+      }
+    }
+  }
+  if (next) res.push(next)
+  return res
+}
+
+function normalizeDeclarations(
+  msg: PatternMessage | SelectMessage,
+  varRefs: Set<string>
+): Record<string, Expression> | null {
+  const declRefs: Record<string, Set<string>> = {}
+  for (const [name, decl] of Object.entries(msg.decl)) {
+    const refs = new Set<string>()
+    if (typeof decl.$ === 'string' && decl.$ !== name) refs.add(decl.$)
+    if (decl.opt) {
+      for (const optVal of Object.values(decl.opt)) {
+        if (typeof optVal !== 'string') refs.add(optVal.$)
+      }
+    }
+    if (refs.size) declRefs[name] = refs
+  }
+
+  function* varDependencies(name: string): Iterable<string> {
+    const drs = declRefs[name]
+    if (drs) {
+      delete declRefs[name]
+      for (const dr of drs) {
+        yield dr
+        yield* varDependencies(dr)
+      }
+    }
+  }
+
+  for (const ref of varRefs) {
+    for (const dr of varDependencies(ref)) varRefs.add(dr)
+  }
+
+  let hasDecl = false
+  const decl: Record<string, Expression> = {}
+  for (const [name, exp] of Object.entries(msg.decl)) {
+    if (varRefs.has(name)) {
+      decl[name] = structuredClone(exp)
+      hasDecl = true
+    }
+  }
+  return hasDecl ? decl : null
 }

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -134,6 +134,8 @@ class PatternMessage:
         Drop unused declarations,
         join adjacent literal elements,
         and drop empty literal elements.
+
+        Mutates this PatternMessage.
         """
         var_refs: set[str] = set()
         _normalize_pattern(self.pattern, var_refs)
@@ -192,6 +194,8 @@ class SelectMessage:
         Drop unused declarations,
         join adjacent literal elements,
         and drop empty literal elements in all patterns.
+
+        Mutates this SelectMessage.
         """
         var_refs = set(sel.name for sel in self.selectors)
         for pattern in self.variants.values():

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -16,9 +16,10 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Generic, Iterable, Literal, TypeVar, Union
+from typing import Generic, Literal, TypeVar, Union
 
 from .formats import Format
+from .util.normalize import _normalize_declarations, _normalize_pattern
 
 __all__ = [
     "CatchallKey",
@@ -203,48 +204,6 @@ class SelectMessage:
 
 
 Message = Union[PatternMessage, SelectMessage]
-
-
-def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
-    i = 0
-    at_str = False
-    while i < len(pattern):
-        el = pattern[i]
-        if isinstance(el, str):
-            if el == "":
-                pattern.pop(i)
-            elif at_str:
-                pattern[i - 1] += el  # type: ignore
-                pattern.pop(i)
-            else:
-                at_str = True
-                i += 1
-        else:
-            at_str = False
-            i += 1
-            for var in el.variable_refs():
-                var_refs.add(var.name)
-
-
-def _normalize_declarations(msg: Message, var_refs: set[str]) -> None:
-    decl_refs = {
-        name: set(var.name for var in decl.variable_refs() if var.name != name)
-        for name, decl in msg.declarations.items()
-    }
-    for name in list(var_refs):
-        var_refs.update(_var_dependencies(decl_refs, name))
-    for name in list(msg.declarations):
-        if name not in var_refs:
-            del msg.declarations[name]
-
-
-def _var_dependencies(decl_refs: dict[str, set[str]], name: str) -> Iterable[str]:
-    drs = decl_refs.get(name, None)
-    if drs:
-        del decl_refs[name]
-        for dr in drs:
-            yield dr
-            yield from _var_dependencies(decl_refs, dr)
 
 
 @dataclass

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass, field
-from typing import Generic, Literal, TypeVar, Union
+from typing import Generic, Iterable, Literal, TypeVar, Union
 
 from .formats import Format
 
@@ -59,6 +59,16 @@ class Expression:
     options: dict[str, str | VariableRef] = field(default_factory=dict)
     attributes: dict[str, str | Literal[True]] = field(default_factory=dict)
 
+    def variable_refs(self) -> Iterator[VariableRef]:
+        """
+        VariableRef values in this Expression
+        """
+        if isinstance(self.arg, VariableRef):
+            yield self.arg
+        for opt in self.options.values():
+            if isinstance(opt, VariableRef):
+                yield opt
+
     def __repr__(self) -> str:
         body = [repr(self.arg)]
         if self.function:
@@ -76,6 +86,14 @@ class Markup:
     name: str
     options: dict[str, str | VariableRef] = field(default_factory=dict)
     attributes: dict[str, str | Literal[True]] = field(default_factory=dict)
+
+    def variable_refs(self) -> Iterator[VariableRef]:
+        """
+        VariableRef values in this Markup
+        """
+        for opt in self.options.values():
+            if isinstance(opt, VariableRef):
+                yield opt
 
     def __repr__(self) -> str:
         body = [repr(self.kind), repr(self.name)]
@@ -109,6 +127,17 @@ class PatternMessage:
         Is the message's pattern empty, or consists only of empty strings?
         """
         return all(el == "" for el in self.pattern)
+
+    def normalize(self) -> PatternMessage:
+        """
+        Drop unused declarations,
+        join adjacent literal elements,
+        and drop empty literal elements.
+        """
+        var_refs: set[str] = set()
+        _normalize_pattern(self.pattern, var_refs)
+        _normalize_declarations(self, var_refs)
+        return self
 
     def __repr__(self) -> str:
         body = (
@@ -157,11 +186,65 @@ class SelectMessage:
             all(el == "" for el in pattern) for pattern in self.variants.values()
         )
 
+    def normalize(self) -> SelectMessage:
+        """
+        Drop unused declarations,
+        join adjacent literal elements,
+        and drop empty literal elements in all patterns.
+        """
+        var_refs = set(sel.name for sel in self.selectors)
+        for pattern in self.variants.values():
+            _normalize_pattern(pattern, var_refs)
+        _normalize_declarations(self, var_refs)
+        return self
+
     def selector_expressions(self) -> tuple[Expression, ...]:
         return tuple(self.declarations[var.name] for var in self.selectors)
 
 
 Message = Union[PatternMessage, SelectMessage]
+
+
+def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
+    i = 0
+    at_str = False
+    while i < len(pattern):
+        el = pattern[i]
+        if isinstance(el, str):
+            if el == "":
+                pattern.pop(i)
+            elif at_str:
+                pattern[i - 1] += el  # type: ignore
+                pattern.pop(i)
+            else:
+                at_str = True
+                i += 1
+        else:
+            at_str = False
+            i += 1
+            for var in el.variable_refs():
+                var_refs.add(var.name)
+
+
+def _normalize_declarations(msg: Message, var_refs: set[str]) -> None:
+    decl_refs = {
+        name: set(var.name for var in decl.variable_refs() if var.name != name)
+        for name, decl in msg.declarations.items()
+    }
+    for name in list(var_refs):
+        var_refs.update(_var_dependencies(decl_refs, name))
+    for name in list(msg.declarations):
+        if name not in var_refs:
+            del msg.declarations[name]
+
+
+def _var_dependencies(decl_refs: dict[str, set[str]], name: str) -> Iterable[str]:
+    drs = decl_refs.get(name, None)
+    if drs:
+        del decl_refs[name]
+        for dr in drs:
+            yield dr
+            yield from _var_dependencies(decl_refs, dr)
 
 
 @dataclass

--- a/python/moz/l10n/util/normalize.py
+++ b/python/moz/l10n/util/normalize.py
@@ -1,0 +1,67 @@
+# Copyright Mozilla Foundation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Iterable
+
+if TYPE_CHECKING:
+    from moz.l10n.model import Message, Pattern
+
+__all__ = [
+    "_normalize_declarations",
+    "_normalize_pattern",
+]
+
+
+def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
+    i = 0
+    at_str = False
+    while i < len(pattern):
+        el = pattern[i]
+        if isinstance(el, str):
+            if el == "":
+                pattern.pop(i)
+            elif at_str:
+                pattern[i - 1] += el  # type: ignore
+                pattern.pop(i)
+            else:
+                at_str = True
+                i += 1
+        else:
+            at_str = False
+            i += 1
+            for var in el.variable_refs():
+                var_refs.add(var.name)
+
+
+def _normalize_declarations(msg: Message, var_refs: set[str]) -> None:
+    decl_refs = {
+        name: set(var.name for var in decl.variable_refs() if var.name != name)
+        for name, decl in msg.declarations.items()
+    }
+    for name in list(var_refs):
+        var_refs.update(_var_dependencies(decl_refs, name))
+    for name in list(msg.declarations):
+        if name not in var_refs:
+            del msg.declarations[name]
+
+
+def _var_dependencies(decl_refs: dict[str, set[str]], name: str) -> Iterable[str]:
+    drs = decl_refs.get(name, None)
+    if drs:
+        del decl_refs[name]
+        for dr in drs:
+            yield dr
+            yield from _var_dependencies(decl_refs, dr)

--- a/python/moz/l10n/util/normalize.py
+++ b/python/moz/l10n/util/normalize.py
@@ -26,6 +26,9 @@ __all__ = [
 
 
 def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
+    from moz.l10n.model import Expression
+
+    empty_literal = Expression("")
     i = 0
     at_str = False
     while i < len(pattern):
@@ -39,6 +42,8 @@ def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
             else:
                 at_str = True
                 i += 1
+        elif el == empty_literal:
+            pattern.pop(i)
         else:
             at_str = False
             i += 1

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -65,6 +65,17 @@ class TestMessage(TestCase):
         assert PatternMessage([""]).normalize() == PatternMessage([])
         assert PatternMessage(["", "\n"]).normalize() == PatternMessage(["\n"])
         assert PatternMessage(["foo", ""]).normalize() == PatternMessage(["foo"])
+        assert PatternMessage(["foo", "", "bar"]).normalize() == PatternMessage(
+            ["foobar"]
+        )
+        assert PatternMessage(
+            ["foo", Expression(""), "bar"]
+        ).normalize() == PatternMessage(["foobar"])
+        assert PatternMessage(
+            ["foo", Expression("", attributes={"source": ""}), "bar"]
+        ).normalize() == PatternMessage(
+            ["foo", Expression("", attributes={"source": ""}), "bar"]
+        )
         assert PatternMessage(
             declarations={"x": Expression("x")}, pattern=["x"]
         ).normalize() == PatternMessage(["x"])

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# mypy: allow-untyped-defs
+
 from __future__ import annotations
 
 from unittest import TestCase
@@ -27,6 +29,7 @@ from moz.l10n.model import (
     Resource,
     Section,
     SelectMessage,
+    VariableRef,
 )
 
 
@@ -58,6 +61,64 @@ class TestMessage(TestCase):
             },
         ).is_empty()
 
+    def test_normalize_pattern_message(self):
+        assert PatternMessage([""]).normalize() == PatternMessage([])
+        assert PatternMessage(["", "\n"]).normalize() == PatternMessage(["\n"])
+        assert PatternMessage(["foo", ""]).normalize() == PatternMessage(["foo"])
+        assert PatternMessage(
+            declarations={"x": Expression("x")}, pattern=["x"]
+        ).normalize() == PatternMessage(["x"])
+        assert PatternMessage(
+            declarations={"x": Expression("x")},
+            pattern=["", Expression(VariableRef("x")), ""],
+        ).normalize() == PatternMessage(
+            declarations={"x": Expression("x")}, pattern=[Expression(VariableRef("x"))]
+        )
+        assert PatternMessage(
+            declarations={"x": Expression("x")},
+            pattern=[Expression("x", "fn", {"o": VariableRef("x")})],
+        ).normalize() == PatternMessage(
+            declarations={"x": Expression("x")},
+            pattern=[Expression("x", "fn", {"o": VariableRef("x")})],
+        )
+        assert PatternMessage(
+            declarations={
+                "a": Expression(VariableRef("a")),
+                "b": Expression("b", "fn", {"o": VariableRef("a")}),
+                "c": Expression(VariableRef("b")),
+                "d": Expression(VariableRef("c")),
+                "e": Expression(VariableRef("a")),
+                "f": Expression(VariableRef("e")),
+            },
+            pattern=[Expression(VariableRef("d"))],
+        ).normalize() == PatternMessage(
+            declarations={
+                "a": Expression(VariableRef("a")),
+                "b": Expression("b", "fn", {"o": VariableRef("a")}),
+                "c": Expression(VariableRef("b")),
+                "d": Expression(VariableRef("c")),
+            },
+            pattern=[Expression(VariableRef("d"))],
+        )
+
+    def test_normalize_select_message(self):
+        assert SelectMessage(
+            declarations={
+                "x": Expression("x"),
+                "y": Expression(VariableRef("y")),
+                "z": Expression(VariableRef("z")),
+            },
+            selectors=(VariableRef("x"),),
+            variants={("a",): [""], (CatchallKey(),): [Expression(VariableRef("y"))]},
+        ).normalize() == SelectMessage(
+            declarations={
+                "x": Expression("x"),
+                "y": Expression(VariableRef("y")),
+            },
+            selectors=(VariableRef("x"),),
+            variants={("a",): [], (CatchallKey(),): [Expression(VariableRef("y"))]},
+        )
+
 
 class TestResource(TestCase):
     def test_all_entries_some(self):
@@ -67,7 +128,7 @@ class TestResource(TestCase):
             Entry(("e2",), PatternMessage(["m2"])),
             Entry(("e3",), PatternMessage(["m3"])),
         ]
-        res = Resource(
+        res: Resource[PatternMessage] = Resource(
             Format.inc,
             [
                 Section((), [Comment("c1"), entries[0], Comment("c2"), entries[1]]),
@@ -85,7 +146,7 @@ class TestResource(TestCase):
         )
 
     def test_all_entries_none(self):
-        res = Resource(
+        res: Resource[PatternMessage] = Resource(
             Format.inc,
             [
                 Section((), [Comment("c1"), Comment("c2")]),
@@ -133,7 +194,7 @@ class TestMeta(TestCase):
         )
 
     def test_resource(self):
-        res = Resource(
+        res: Resource[PatternMessage] = Resource(
             Format.properties,
             [Section((), [])],
             meta=[Metadata("key", "value1"), Metadata("key", "value2")],


### PR DESCRIPTION
Adds JS & Python functions for message normalization, i.e. dropping unused declarations, joining adjacent literal elements, and dropping empty literal elements.

The intent is to use this in Pontoon to ensure that translations that _appear_ to be the same are also considered equal.