### PR TITLE
Improves `L10nDiscoverPaths` performance

### DIFF
--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -18,7 +18,7 @@ import re
 from collections.abc import Iterable, Iterator
 from itertools import chain
 from os import sep, walk
-from os.path import commonpath, isdir, join, normpath, relpath, splitext
+from os.path import commonpath, dirname, isdir, join, normpath, relpath, splitext
 
 from moz.l10n.formats import l10n_extensions
 from moz.l10n.util import walk_files
@@ -130,13 +130,17 @@ class L10nDiscoverPaths:
                 base_dirs.append((dirpath, locale_dirs))
             dirnames[:] = (dn for dn in dirnames if not dn.startswith("."))
 
-            if any(not fn.startswith(".") and fn.endswith(".pot") for fn in filenames):
-                pot_dirs.append(dirpath)
-            if any(
+            # .pot is in `l10n_extensions`!
+            # We don't need to check for these if there isn't any at all.
+            if not any(
                 not fn.startswith(".") and splitext(fn)[1] in l10n_extensions
                 for fn in filenames
             ):
-                l10n_dirs.append(dirpath)
+                continue
+
+            l10n_dirs.append(dirpath)
+            if any(not fn.startswith(".") and fn.endswith(".pot") for fn in filenames):
+                pot_dirs.append(dirpath)
 
         if ref_root:
             for dir in list(ref_dirs):
@@ -160,8 +164,19 @@ class L10nDiscoverPaths:
         # with the most locale subdirectories,
         # with a preference for directories with localizable contents.
         base_dirs = [bd for bd in base_dirs if not dir_contains(self._ref_root, bd[0])]
+        base_dir_roots = {bd[0] for bd in base_dirs}
+        confirmed_base_dirs: set[str] = set()
+        for ld in l10n_dirs:
+            parent = ld
+            while True:
+                parent = dirname(parent)
+                if parent in base_dir_roots:
+                    confirmed_base_dirs.add(parent)
+                    break
+                if parent == root or parent == dirname(parent):
+                    break
         base_dirs = [
-            bd for bd in base_dirs if any(dir_contains(bd[0], ld) for ld in l10n_dirs)
+            bd for bd in base_dirs if bd[0] in confirmed_base_dirs
         ] or base_dirs
 
         locale_dirs_: list[str] | None

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -172,7 +172,6 @@ class L10nDiscoverPaths:
                 parent = dirname(parent)
                 if parent in base_dir_roots:
                     confirmed_base_dirs.add(parent)
-                    break
                 if parent == root or parent == dirname(parent):
                     break
         base_dirs = [

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -110,7 +110,6 @@ class L10nDiscoverPaths:
 
         # dir -> score
         ref_dirs: dict[str, int] = {ref_root: len(source_locale)} if ref_root else {}
-        # base_dirs: list[tuple[str, list[str]]] = []  # [(root, [locale_dir])]
         base_dirs: dict[str, list[str]] = {}
         pot_dirs: list[str] = []
         l10n_dirs: list[str] = []
@@ -169,23 +168,18 @@ class L10nDiscoverPaths:
             for bd, lds in base_dirs.items()
             if not dir_contains(self._ref_root, bd)
         }
-        found_parent_dirs: set[str] = set()
+        dirs_with_contents: set[str] = set()
         for ld in l10n_dirs:
             parent = ld
             while True:
                 parent = dirname(parent)
                 if parent in base_dirs:
-                    found_parent_dirs.add(parent)
+                    dirs_with_contents.add(parent)
                 if parent == root or parent == dirname(parent):
                     break
         base_dirs = {
-            bd: lds for bd, lds in base_dirs.items() if bd in found_parent_dirs
+            bd: lds for bd, lds in base_dirs.items() if bd in dirs_with_contents
         } or base_dirs
-        base_dirs = {
-            base_dir: locale_dirs
-            for base_dir, locale_dirs in base_dirs.items()
-            if not dir_contains(self._ref_root, base_dir)
-        }
 
         locale_dirs_: list[str] | None
         self.base, locale_dirs_ = max(

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -113,12 +113,13 @@ class L10nDiscoverPaths:
         base_dirs: dict[str, list[str]] = {}
         pot_dirs: list[str] = []
         l10n_dirs: list[str] = []
+        # Important! We walk with `topdown=True` to get shortest paths first!
         if ref_root and not dir_contains(root, ref_root):
             walk_roots: Iterator[tuple[str, list[str], list[str]]] = chain(
-                walk(root), walk(ref_root)
+                walk(root, topdown=True), walk(ref_root, topdown=True)
             )
         else:
-            walk_roots = walk(root)
+            walk_roots = walk(root, topdown=True)
         for dirpath, dirnames, filenames in walk_roots:
             locale_dirs = []
             for dir in dirnames:
@@ -158,16 +159,14 @@ class L10nDiscoverPaths:
         else:
             raise MissingSourceDirectoryError
 
-        # Pick the localization base dir not in the reference directory with most locale
-        # subdirectories, with preference for directories with localizable contents.
-        # Walk up from each l10n_dir to confirm which base dirs actually contain
-        # localizable files and avoid false positives on locale-id-like dir names.
-        # base_dirs = [bd for bd in base_dirs if not dir_contains(self._ref_root, bd[0])]
+        # Pick localization base dirs not in reference directory.
         base_dirs = {
             bd: lds
             for bd, lds in base_dirs.items()
             if not dir_contains(self._ref_root, bd)
         }
+        # Walk up parents of each l10n_dir to gather base dirs containing
+        # localizable files & avoid false positives on locale-id-like sub-dir names.
         dirs_with_contents: set[str] = set()
         for ld in l10n_dirs:
             parent = ld
@@ -184,10 +183,13 @@ class L10nDiscoverPaths:
         locale_dirs_: list[str] | None
         self.base, locale_dirs_ = max(
             base_dirs.items(), key=lambda s: len(s[1]), default=(None, None)
+        # Select final base dir and containing list of locale subdirectories
+        # by maximum number of locale subdirectories.
         )
         if locale_dirs_:
             self.locales = [dir.replace("_", "-") for dir in locale_dirs_]
             self.locales.sort()
+
         else:
             self.locales = None
 

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -110,7 +110,8 @@ class L10nDiscoverPaths:
 
         # dir -> score
         ref_dirs: dict[str, int] = {ref_root: len(source_locale)} if ref_root else {}
-        base_dirs: list[tuple[str, list[str]]] = []  # [(root, [locale_dir])]
+        # base_dirs: list[tuple[str, list[str]]] = []  # [(root, [locale_dir])]
+        base_dirs: dict[str, list[str]] = {}
         pot_dirs: list[str] = []
         l10n_dirs: list[str] = []
         if ref_root and not dir_contains(root, ref_root):
@@ -127,20 +128,18 @@ class L10nDiscoverPaths:
                 elif locale_id.fullmatch(dir):
                     locale_dirs.append(dir)
             if locale_dirs:
-                base_dirs.append((dirpath, locale_dirs))
+                base_dirs[dirpath] = locale_dirs
             dirnames[:] = (dn for dn in dirnames if not dn.startswith("."))
 
-            # .pot is in `l10n_extensions`!
-            # We don't need to check for these if there isn't any at all.
-            if not any(
+            if any(
                 not fn.startswith(".") and splitext(fn)[1] in l10n_extensions
                 for fn in filenames
             ):
-                continue
-
-            l10n_dirs.append(dirpath)
-            if any(not fn.startswith(".") and fn.endswith(".pot") for fn in filenames):
-                pot_dirs.append(dirpath)
+                l10n_dirs.append(dirpath)
+                if any(
+                    not fn.startswith(".") and fn.endswith(".pot") for fn in filenames
+                ):
+                    pot_dirs.append(dirpath)
 
         if ref_root:
             for dir in list(ref_dirs):
@@ -160,28 +159,37 @@ class L10nDiscoverPaths:
         else:
             raise MissingSourceDirectoryError
 
-        # Pick the localization base dir not in the reference directory
-        # with the most locale subdirectories.
+        # Pick the localization base dir not in the reference directory with most locale
+        # subdirectories, with preference for directories with localizable contents.
         # Walk up from each l10n_dir to confirm which base dirs actually contain
         # localizable files and avoid false positives on locale-id-like dir names.
-        base_dirs = [bd for bd in base_dirs if not dir_contains(self._ref_root, bd[0])]
-        base_dir_roots = {bd[0] for bd in base_dirs}
-        confirmed_base_dirs: set[str] = set()
+        # base_dirs = [bd for bd in base_dirs if not dir_contains(self._ref_root, bd[0])]
+        base_dirs = {
+            bd: lds
+            for bd, lds in base_dirs.items()
+            if not dir_contains(self._ref_root, bd)
+        }
+        found_parent_dirs: set[str] = set()
         for ld in l10n_dirs:
             parent = ld
             while True:
                 parent = dirname(parent)
-                if parent in base_dir_roots:
-                    confirmed_base_dirs.add(parent)
+                if parent in base_dirs:
+                    found_parent_dirs.add(parent)
                 if parent == root or parent == dirname(parent):
                     break
-        base_dirs = [
-            bd for bd in base_dirs if bd[0] in confirmed_base_dirs
-        ] or base_dirs
+        base_dirs = {
+            bd: lds for bd, lds in base_dirs.items() if bd in found_parent_dirs
+        } or base_dirs
+        base_dirs = {
+            base_dir: locale_dirs
+            for base_dir, locale_dirs in base_dirs.items()
+            if not dir_contains(self._ref_root, base_dir)
+        }
 
         locale_dirs_: list[str] | None
         self.base, locale_dirs_ = max(
-            base_dirs, key=lambda s: len(s[1]), default=(None, None)
+            base_dirs.items(), key=lambda s: len(s[1]), default=(None, None)
         )
         if locale_dirs_:
             self.locales = [dir.replace("_", "-") for dir in locale_dirs_]

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -180,11 +180,13 @@ class L10nDiscoverPaths:
             bd: lds for bd, lds in base_dirs.items() if bd in dirs_with_contents
         } or base_dirs
 
-        locale_dirs_: list[str] | None
-        self.base, locale_dirs_ = max(
-            base_dirs.items(), key=lambda s: len(s[1]), default=(None, None)
         # Select final base dir and containing list of locale subdirectories
         # by maximum number of locale subdirectories.
+        locale_dirs_: list[str] | None
+        self.base, locale_dirs_ = max(
+            base_dirs.items(),
+            key=lambda s: len(s[1]),
+            default=(None, None),
         )
         if locale_dirs_:
             self.locales = [dir.replace("_", "-") for dir in locale_dirs_]

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -161,8 +161,9 @@ class L10nDiscoverPaths:
             raise MissingSourceDirectoryError
 
         # Pick the localization base dir not in the reference directory
-        # with the most locale subdirectories,
-        # with a preference for directories with localizable contents.
+        # with the most locale subdirectories.
+        # Walk up from each l10n_dir to confirm which base dirs actually contain
+        # localizable files and avoid false positives on locale-id-like dir names.
         base_dirs = [bd for bd in base_dirs if not dir_contains(self._ref_root, bd[0])]
         base_dir_roots = {bd[0] for bd in base_dirs}
         confirmed_base_dirs: set[str] = set()

--- a/python/tests/test_discover.py
+++ b/python/tests/test_discover.py
@@ -119,6 +119,7 @@ class TestL10nDiscover(TestCase):
             paths = L10nDiscoverPaths(root)
 
             assert paths.ref_root == join(root, "source", "en")
+            assert paths.base is not None
             assert paths.base == join(root, "target")
             assert paths.locales == ["yy-Latn", "zz"]
             assert paths.all_locales == {"yy-Latn", "zz"}
@@ -218,9 +219,43 @@ class TestL10nDiscover(TestCase):
             paths = L10nDiscoverPaths(root)
             assert paths.ref_root == join(root, "en")
             assert paths.base == root
+            assert paths.locales is not None
             assert set(paths.locales) == {"yy-Latn", "zz"}
 
             paths = L10nDiscoverPaths(root, ref_root=join(root, "en-US"))
             assert paths.ref_root == join(root, "en-US")
             assert paths.base == root
+            assert paths.locales is not None
             assert set(paths.locales) == {"yy-Latn", "zz"}
+
+    def test_split_repos(self):
+        """Source and translation in separate sibling directories,
+        as in firefox-l10n-source / firefox-l10n."""
+        source_tree: Tree = {
+            "browser": {"browser.ftl": ""},
+            "toolkit": {"global": {"main.ftl": ""}},
+        }
+        l10n_tree: Tree = {
+            "de": {
+                "browser": {"browser.ftl": ""},
+                "toolkit": {"global": {"main.ftl": ""}},
+            },
+            "fr": {
+                "browser": {"browser.ftl": ""},
+            },
+        }
+        with TemporaryDirectory() as tmp:
+            source_root = join(tmp, "firefox-l10n-source")
+            l10n_root = join(tmp, "firefox-l10n")
+            build_file_tree(source_root, source_tree)
+            build_file_tree(l10n_root, l10n_tree)
+
+            with self.assertRaises(MissingSourceDirectoryError):
+                L10nDiscoverPaths(l10n_root)
+
+            paths = L10nDiscoverPaths(l10n_root, ref_root=source_root)
+            assert paths.ref_root == source_root
+            assert paths.base == l10n_root
+            assert paths.locales is not None
+            assert set(paths.locales) == {"de", "fr"}
+            assert any("browser.ftl" in p for p in paths.ref_paths)

--- a/python/tests/test_discover.py
+++ b/python/tests/test_discover.py
@@ -259,3 +259,25 @@ class TestL10nDiscover(TestCase):
             assert paths.locales is not None
             assert set(paths.locales) == {"de", "fr"}
             assert any("browser.ftl" in p for p in paths.ref_paths)
+
+
+    def test_split_repos_locale_id_intermediate_names(self):
+        """Locale-id-like directory names (e.g. "aa") may appear as component
+        subdirs in source tree, not just locale roots. Let's ensure these
+        don't shadow real localization base dir."""
+        source_tree: Tree = {"dom": {"aa": {"strings.ftl": ""}}}
+        l10n_tree: Tree = {
+            "de": {"dom": {"aa": {"strings.ftl": ""}}},
+            "fr": {"dom": {"aa": {"strings.ftl": ""}}},
+        }
+        with TemporaryDirectory() as tmp:
+            source_root = join(tmp, "src")
+            l10n_root = join(tmp, "l10n")
+            build_file_tree(source_root, source_tree)
+            build_file_tree(l10n_root, l10n_tree)
+
+            paths = L10nDiscoverPaths(l10n_root, ref_root=source_root)
+            assert paths.ref_root == source_root
+            assert paths.base == l10n_root
+            assert paths.locales is not None
+            assert set(paths.locales) == {"de", "fr"}

--- a/python/tests/test_discover.py
+++ b/python/tests/test_discover.py
@@ -260,7 +260,6 @@ class TestL10nDiscover(TestCase):
             assert set(paths.locales) == {"de", "fr"}
             assert any("browser.ftl" in p for p in paths.ref_paths)
 
-
     def test_split_repos_locale_id_intermediate_names(self):
         """Locale-id-like directory names (e.g. "aa") may appear as component
         subdirs in source tree, not just locale roots. Let's ensure these

--- a/python/tests/utils.py
+++ b/python/tests/utils.py
@@ -14,7 +14,7 @@
 
 from __future__ import annotations
 
-from os import mkdir
+from os import makedirs
 from os.path import join
 from typing import Union
 
@@ -29,5 +29,5 @@ def build_file_tree(root: str, tree: Tree) -> None:
                 if value:
                     file.write(value)
         else:
-            mkdir(path)
+            makedirs(path, exist_ok=True)
             build_file_tree(path, value)


### PR DESCRIPTION
Addressing #37

- changed heavy `base_dirs` loop for checks against hashed sets.
- flipped `.pot`-dirs lookup to after `l10n_extensions` check
- added `test_split_repos` mocking `firefox-l10n-source/firefox-l10n` situation.
- changed `build_file_tree` in `utils` to use `makedirs` to be able to create dirs in yet inexistent paths.