### PR TITLE
Improve Android placeholder handling

### DIFF
--- a/js/src/android-parse.ts
+++ b/js/src/android-parse.ts
@@ -166,9 +166,9 @@ function* parseQuotes(
 }
 
 const _inline =
-  // 1:esc-unicode     2:esc-char       4:printf
-  //                         3:esc-elem                                  5:printf-conversion              6:xml-entity
-  /\\u([0-9A-Fa-f]{4})|\\(.)|(<[^%>]+>)|(%(?:[1-9]\$|<)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%@]|[tT][a-zA-Z]))|(_entity_\d+_)/g
+  // 1:esc-unicode     2:esc-char       4:printf                         5:printf-conversion
+  //                         3:esc-elem                                            6:xml-entity
+  /\\u([0-9A-Fa-f]{4})|\\(.)|(<[^%>]+>)|(%(?:[1-9]\$|<)?[-#+ 0,(]?[0-9.]*([tT]?.))|(_entity_\d+_)/g
 const _blocktag = /^<(div|h[123456r]|p|d[dt]|li|\/?[dou]l)\b/
 const _breaktag = /^<[bh]r\/?>$/
 

--- a/js/src/android-parse.ts
+++ b/js/src/android-parse.ts
@@ -167,8 +167,8 @@ function* parseQuotes(
 
 const _inline =
   // 1:esc-unicode     2:esc-char       4:printf
-  //                         3:esc-elem                                5:printf-conversion              6:xml-entity
-  /\\u([0-9A-Fa-f]{4})|\\(.)|(<[^%>]+>)|(%(?:[1-9]\$)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%@]|[tT][a-zA-Z]))|(_entity_\d+_)/g
+  //                         3:esc-elem                                  5:printf-conversion              6:xml-entity
+  /\\u([0-9A-Fa-f]{4})|\\(.)|(<[^%>]+>)|(%(?:[1-9]\$|<)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%@]|[tT][a-zA-Z]))|(_entity_\d+_)/g
 const _blocktag = /^<(div|h[123456r]|p|d[dt]|li|\/?[dou]l)\b/
 const _breaktag = /^<[bh]r\/?>$/
 
@@ -178,6 +178,7 @@ function* parseInline(
 ): Iterable<string | Expression | Markup> {
   let buffer = ''
   let atBreak = false
+  let prevVarName = ''
   for (const part of pattern) {
     if (typeof part === 'string') {
       let pos = 0
@@ -250,7 +251,21 @@ function* parseInline(
               default:
                 if (m[5][0].toLowerCase() === 't') fn = 'datetime'
             }
-            yield { $: varName(m[4]), fn, attr }
+            let name
+            if (m[0].startsWith('%<')) {
+              // # https://developer.android.com/reference/java/util/Formatter#argument-index
+              if (prevVarName) {
+                name = prevVarName
+                const prevIdx = /[1-9]$/.test(name) ? name.at(-1) + '$' : ''
+                attr.source = `%${prevIdx}${m[0].substring(2)}`
+              } else {
+                throw new ParseError(`Invalid ${m[0]} placeholder`)
+              }
+            } else {
+              name = varName(m[4])
+              prevVarName = name
+            }
+            yield { $: name, fn, attr }
           } else {
             yield { $: entities[m[6]] ?? 'UNKNOWN', fn: 'entity' }
           }

--- a/js/src/android-parse.ts
+++ b/js/src/android-parse.ts
@@ -214,9 +214,6 @@ function* parseInline(
             attr.source = m[0]
             let fn: string | undefined = undefined
             switch (m[5]) {
-              case '%':
-                yield { _: '%', attr }
-                continue // for
               case 'b':
               case 'B':
                 fn = 'boolean'
@@ -244,6 +241,12 @@ function* parseInline(
               case 'G':
                 fn = 'number'
                 break
+              case 'n':
+                yield { _: '\n', attr }
+                continue // for
+              case '%':
+                yield { _: '%', attr }
+                continue // for
               default:
                 if (m[5][0].toLowerCase() === 't') fn = 'datetime'
             }

--- a/js/src/android.test.ts
+++ b/js/src/android.test.ts
@@ -103,6 +103,20 @@ describe('success', () => {
     ],
     'Welcome to <b>&foo;</b>!'
   )
+
+  test('inline previous variable references', () => {
+    const pattern = androidParsePattern('Birthday: %1$tm %&lt;te,%&lt;tY')
+    expect(pattern).toEqual([
+      'Birthday: ',
+      { $: 'arg1', fn: 'datetime', attr: { source: '%1$tm' } },
+      ' ',
+      { $: 'arg1', fn: 'datetime', attr: { source: '%1$te' } },
+      ',',
+      { $: 'arg1', fn: 'datetime', attr: { source: '%1$tY' } }
+    ])
+    const res = androidSerializePattern(pattern)
+    expect(res).toBe('Birthday: %1$tm %1$te,%1$tY')
+  })
 })
 
 describe('newlines', () => {

--- a/js/src/android.test.ts
+++ b/js/src/android.test.ts
@@ -48,6 +48,15 @@ describe('success', () => {
     'Hello, %1$s!'
   )
   ok(
+    'inline percent escapes',
+    [
+      'Hello',
+      { _: '%', attr: { source: '%%' } },
+      { _: '\n', attr: { source: '%n' } }
+    ],
+    'Hello%%%n'
+  )
+  ok(
     'inline %@ variable',
     ['Hello, ', { $: 'arg', attr: { source: '%@' } }, '!'],
     'Hello, %@!'

--- a/js/src/android.test.ts
+++ b/js/src/android.test.ts
@@ -32,6 +32,7 @@ describe('success', () => {
       expect(res).toEqual(pattern)
     })
 
+  ok('empty pattern', [], '')
   ok(
     'resource reference',
     [{ _: '@foo:bar/baz', fn: 'reference' }],

--- a/js/src/xml-utils.ts
+++ b/js/src/xml-utils.ts
@@ -25,6 +25,8 @@ export function serialize(root: Element) {
   const str = new XMLSerializer().serializeToString(root)
   if (str.startsWith(`<${name}`) && str.endsWith(`</${name}>`)) {
     return str.replace(/^<.*?>/, '').slice(0, -1 * (name.length + 3))
+  } else if (new RegExp(`^<${name}[^<>]+/>$`).test(str)) {
+    return ''
   } else {
     throw 'Unexpected XML serialization'
   }

--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -490,6 +490,9 @@ def parse_inline(
                     if conversion == "%":
                         # Literal %
                         yield Expression("%", attributes={"source": m[4]})
+                    elif conversion == "n":
+                        # Literal newline
+                        yield Expression("\n", attributes={"source": m[4]})
                     else:
                         # Placeholder
                         func: str | None

--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -435,10 +435,11 @@ inline_re = compile(
     r"\\u([0-9a-fA-F]{4})|"
     r"\\(.)|"
     r"(<[^%>]+>)|"
-    r"(%(?:[1-9]\$)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%@]|[tT][a-zA-Z]))"
+    r"(%(?:[1-9]\$|<)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%@]|[tT][a-zA-Z]))"
 )
 block_tag_re = compile(r"<(div|h[123456r]|p|d[dt]|li|/?[dou]l)\b")
 break_tag_re = compile(r"<[bh]r/?>")
+var_idx_re = compile(r"[1-9]$")
 
 
 def parse_inline(
@@ -446,6 +447,7 @@ def parse_inline(
 ) -> Iterator[str | Expression | Markup]:
     acc = ""
     at_br = False
+    prev_var_name = None
     for part in iter:
         if not isinstance(part, str):
             if acc:
@@ -508,9 +510,21 @@ def parse_inline(
                         else:
                             c0 = conversion[0]
                             func = "datetime" if c0 == "t" or c0 == "T" else None
-                        name = get_var_name(m[4])
+                        source = m[0]
+                        if source.startswith("%<"):
+                            # https://developer.android.com/reference/java/util/Formatter#argument-index
+                            if prev_var_name:
+                                name = prev_var_name
+                                prev_idx_m = var_idx_re.search(name)
+                                prev_idx = prev_idx_m[0] + "$" if prev_idx_m else ""
+                                source = f"%{prev_idx}{source[2:]}"
+                            else:
+                                raise ValueError(f"Invalid {source} placeholder")
+                        else:
+                            name = get_var_name(source)
+                            prev_var_name = name
                         yield Expression(
-                            VariableRef(name), func, attributes={"source": m[4]}
+                            VariableRef(name), func, attributes={"source": source}
                         )
                 pos = m.end()
             acc += part[pos:]
@@ -518,14 +532,14 @@ def parse_inline(
         yield acc
 
 
-printf = compile(r"%([1-9]\$)?")
+arg_idx = compile(r"%([1-9]\$)?")
 not_name_char = compile(f"[^{xml_name_start}{xml_name_rest}]")
 not_name_start = compile(f"[^{xml_name_start}]")
 
 
 def get_var_name(src: str) -> str:
     """Returns a valid MF2 name."""
-    pm = printf.match(src)
+    pm = arg_idx.match(src)
     if pm:
         return f"arg{pm[1][0]}" if pm[1] else "arg"
     name = not_name_char.sub("", src)

--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -435,7 +435,7 @@ inline_re = compile(
     r"\\u([0-9a-fA-F]{4})|"
     r"\\(.)|"
     r"(<[^%>]+>)|"
-    r"(%(?:[1-9]\$|<)?[-#+ 0,(]?[0-9.]*([a-su-zA-SU-Z%@]|[tT][a-zA-Z]))"
+    r"(%(?:[1-9]\$|<)?[-#+ 0,(]?[0-9.]*([tT]?.))"
 )
 block_tag_re = compile(r"<(div|h[123456r]|p|d[dt]|li|/?[dou]l)\b")
 break_tag_re = compile(r"<[bh]r/?>")
@@ -491,10 +491,10 @@ def parse_inline(
                     conversion = m[5]
                     if conversion == "%":
                         # Literal %
-                        yield Expression("%", attributes={"source": m[4]})
+                        yield Expression("%", attributes={"source": m[0]})
                     elif conversion == "n":
                         # Literal newline
-                        yield Expression("\n", attributes={"source": m[4]})
+                        yield Expression("\n", attributes={"source": m[0]})
                     else:
                         # Placeholder
                         func: str | None
@@ -507,9 +507,10 @@ def parse_inline(
                             func = "integer"
                         elif conversion in {"a", "A", "e", "E", "f", "g", "G"}:
                             func = "number"
+                        elif len(conversion) == 2 and conversion[0] in {"t", "T"}:
+                            func = "datetime"
                         else:
-                            c0 = conversion[0]
-                            func = "datetime" if c0 == "t" or c0 == "T" else None
+                            func = None
                         source = m[0]
                         if source.startswith("%<"):
                             # https://developer.android.com/reference/java/util/Formatter#argument-index

--- a/python/tests/formats/data/strings.xml
+++ b/python/tests/formats/data/strings.xml
@@ -16,7 +16,7 @@
   <!-- standalone -->
 
   <string name="welcome">Welcome to <b>&foo;</b>!</string>
-  <string name="placeholders">Hello, %1$s! You have %2$d new messages.</string>
+  <string name="placeholders">Hello, %1$s! You have %2$d new messages.%%%n</string>
   <string name="real_html">Hello, %1$s! You have <b>%2$d new messages</b>.</string>
   <string name="escaped_html">Hello, %1$s! You have &lt;b>%2$d new messages&lt;/b>.</string>
   <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>

--- a/python/tests/formats/data/strings.xml
+++ b/python/tests/formats/data/strings.xml
@@ -21,6 +21,7 @@
   <string name="escaped_html">Hello, %1$s! You have &lt;b>%2$d new messages&lt;/b>.</string>
   <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
   <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
+  <string name="datetime">Birthday: %1$tm %1$te,%1$tY</string>
 
   <string name="ws_trimmed"> &#32;  &#8200;
     &#8195;</string>

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -219,6 +219,31 @@ class TestAndroid(TestCase):
                                 ]
                             ),
                         ),
+                        Entry(
+                            ("datetime",),
+                            PatternMessage(
+                                [
+                                    "Birthday: ",
+                                    Expression(
+                                        VariableRef("arg1"),
+                                        function="datetime",
+                                        attributes={"source": "%1$tm"},
+                                    ),
+                                    " ",
+                                    Expression(
+                                        VariableRef("arg1"),
+                                        function="datetime",
+                                        attributes={"source": "%1$te"},
+                                    ),
+                                    ",",
+                                    Expression(
+                                        VariableRef("arg1"),
+                                        function="datetime",
+                                        attributes={"source": "%1$tY"},
+                                    ),
+                                ]
+                            ),
+                        ),
                         Entry(("ws_trimmed",), PatternMessage([])),
                         Entry(
                             ("ws_quoted",),
@@ -463,6 +488,7 @@ class TestAndroid(TestCase):
               <string name="escaped_html"><![CDATA[Hello, %1$s! You have <b>%2$d new messages</b>.]]></string>
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>
               <string name="nested_protections">Welcome to <xliff:g><b><xliff:g>Foo</xliff:g></b>!</xliff:g></string>
+              <string name="datetime">Birthday: %1$tm %1$te,%1$tY</string>
               <string name="ws_trimmed"></string>
               <string name="ws_quoted">\\u0020\\u0020\\u0020\\u2008\\n \\u0020\\u0020\\u0020\\u2003</string>
               <string name="ws_escaped">\\u0020\\u0020\\u2008 \\u2003</string>

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -118,6 +118,8 @@ class TestAndroid(TestCase):
                                         attributes={"source": "%2$d"},
                                     ),
                                     " new messages.",
+                                    Expression("%", attributes={"source": "%%"}),
+                                    Expression("\n", attributes={"source": "%n"}),
                                 ]
                             ),
                         ),
@@ -456,7 +458,7 @@ class TestAndroid(TestCase):
               <!-- standalone -->
 
               <string name="welcome">Welcome to <b>&foo;</b>!</string>
-              <string name="placeholders">Hello, %1$s! You have %2$d new messages.</string>
+              <string name="placeholders">Hello, %1$s! You have %2$d new messages.%%%n</string>
               <string name="real_html">Hello, %1$s! You have <b>%2$d new messages</b>.</string>
               <string name="escaped_html"><![CDATA[Hello, %1$s! You have <b>%2$d new messages</b>.]]></string>
               <string name="protected">Hello, <xliff:g id="user" example="Bob">%1$s</xliff:g>! You have <xliff:g id="count">%2$d</xliff:g> new messages.</string>

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -769,6 +769,55 @@ class TestAndroid(TestCase):
             """
         )
 
+    def test_previous_placeholder(self):
+        src = dedent(
+            """\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <string name="x">Birthday: %1$tm %&lt;te,%&lt;tY</string>
+            </resources>
+            """
+        )
+
+        res = android_parse(src)
+        assert res == Resource(
+            Format.android,
+            [
+                Section(
+                    (),
+                    [
+                        Entry(
+                            ("x",),
+                            PatternMessage(
+                                [
+                                    "Birthday: ",
+                                    Expression(
+                                        VariableRef("arg1"),
+                                        function="datetime",
+                                        attributes={"source": "%1$tm"},
+                                    ),
+                                    " ",
+                                    Expression(
+                                        VariableRef("arg1"),
+                                        function="datetime",
+                                        attributes={"source": "%1$te"},
+                                    ),
+                                    ",",
+                                    Expression(
+                                        VariableRef("arg1"),
+                                        function="datetime",
+                                        attributes={"source": "%1$tY"},
+                                    ),
+                                ]
+                            ),
+                        )
+                    ],
+                )
+            ],
+        )
+        ser = "".join(android_serialize(res))
+        assert ser == src.replace("&lt;", "1$")
+
     def test_xcode_placeholder(self):
         src = dedent(
             """\


### PR DESCRIPTION
Applies a number of Android's [java.util.Formatter](https://developer.android.com/reference/java/util/Formatter) practices to provide a better match with runtime behaviour.

For [`%<` references](https://developer.android.com/reference/java/util/Formatter#argument-index) to the preceding argument's index, the referenced argument index is used internally and in any subsequent serialization. This is to enable moving the placeholders around so their order changes during translation.

Now all `%` characters are presumed to start a placeholder, which matches what's done with Android strings that are formatted with placeholders. But this does reveal a slight problem: An Android `strings.xml` file does not contain sufficient information to determine whether a string is to be formatted with placeholders or not, and if it's not, then if it contains a literal non-terminal `%`, that can get mis-handled. This should not be a problem with any of our current messages, but we ought to handle this a bit better, possibly with heuristics to detect the string format (which could theoretically also be ICU MessageFormat, or anything else) and/or a requirement to specify the message format as a `<string>` attribute.