### PR TITLE
Add translation coverage reporting to l10n-build and l10n-build-file

### DIFF
--- a/python/moz/l10n/bin/build.py
+++ b/python/moz/l10n/bin/build.py
@@ -14,6 +14,7 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from collections import defaultdict
@@ -61,6 +62,11 @@ def cli() -> None:
     parser.add_argument(
         "--locales", metavar="LOCALE", nargs="+", required=True, help="target locales"
     )
+    parser.add_argument(
+        "--coverage",
+        action="store_true",
+        help="write a coverage.json file per locale with the translation ratio",
+    )
     args = parser.parse_args()
 
     log_level = (
@@ -76,9 +82,17 @@ def cli() -> None:
     l10n_base: str = args.base
     l10n_target: str = args.target
     locales: set[str] = set(args.locales)
+    write_coverage: bool = args.coverage
 
     # locale -> [ftl_missing, src_fallback]
     msg_data: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+
+    # locale -> {file_path -> {"total": int, "missing": [id, ...]}}.
+    # Pre-initialized so every requested locale gets a coverage.json,
+    # even if no source files were parseable.
+    coverage_data: dict[str, dict[str, dict[str, int | list[str | list[str]]]]] = {
+        locale: {} for locale in locales
+    }
 
     paths = L10nConfigPaths(cfg_path)
     paths.base = l10n_base
@@ -95,13 +109,21 @@ def cli() -> None:
             tgt_path = join(l10n_target, rel_path)
             makedirs(dirname(tgt_path), exist_ok=True)
             if source:
-                msg_delta = write_target_file(rel_path, source, l10n_path, tgt_path)
+                msg_delta, total_count, missing_ids = write_target_file(
+                    rel_path, source, l10n_path, tgt_path
+                )
                 if msg_delta < 0:
                     msg_data[locale][0] -= msg_delta
                 elif msg_delta > 0:
                     msg_data[locale][1] += msg_delta
                 else:
                     msg_data[locale]
+                if write_coverage:
+                    file_key = relpath(l10n_path, join(l10n_base, locale))
+                    coverage_data[locale][file_key] = {
+                        "total": total_count,
+                        "missing": missing_ids,
+                    }
             else:
                 from_path = l10n_path if exists(l10n_path) else source_path
                 if from_path != tgt_path:
@@ -110,6 +132,13 @@ def cli() -> None:
                     copyfile(from_path, tgt_path)
                 else:
                     log.info(f"skip {rel_path}")
+
+    if write_coverage:
+        for locale, file_coverage in coverage_data.items():
+            coverage_path = join(l10n_target, locale, "coverage.json")
+            makedirs(dirname(coverage_path), exist_ok=True)
+            with open(coverage_path, "w", encoding="utf-8") as f:
+                json.dump(file_coverage, f, indent=2, sort_keys=True)
 
     log.info("----")
     for locale, (ftl_missing, src_fallback) in sorted(
@@ -125,7 +154,7 @@ def write_target_file(
     source_res: Resource[Message],
     l10n_path: str,
     tgt_path: str,
-) -> int:
+) -> tuple[int, int, list[str | list[str]]]:
     if exists(l10n_path):
         l10n_res = parse_resource(l10n_path)
         l10n_map = {
@@ -141,13 +170,20 @@ def write_target_file(
     # Fluent uses per-message fallback at runtime, allowing resources to be incomplete.
     is_fluent = source_res.format == Format.fluent
     msg_delta = 0
+    total_count = 0
+    missing_ids: list[str | list[str]] = []
+
+    def missing_id(id: tuple[str, ...]) -> str | list[str]:
+        # Keep the id structural; a single-part id is simplified to a string.
+        return id[0] if len(id) == 1 else list(id)
 
     def get_entry(
         section_id: tuple[str, ...], source_entry: Entry[Message] | Comment
     ) -> Entry[Message] | Comment | None:
-        nonlocal msg_delta
+        nonlocal msg_delta, total_count
         if isinstance(source_entry, Comment):
             return None
+        total_count += 1
         id = section_id + source_entry.id
         if id in l10n_map:
             l10n_entry = l10n_map[id]
@@ -164,13 +200,16 @@ def write_target_file(
                         }
                         return l10n_entry
                     msg_delta -= 1
+                    missing_ids.append(missing_id(id))
                     return None
             return l10n_entry
         elif is_fluent:
             msg_delta -= 1
+            missing_ids.append(missing_id(id))
             return None
         else:
             msg_delta += 1
+            missing_ids.append(missing_id(id))
             return source_entry
 
     for section in source_res.sections:
@@ -186,7 +225,7 @@ def write_target_file(
     with open(tgt_path, "w", encoding="utf-8") as file:
         for line in serialize_resource(l10n_res, trim_comments=True):
             file.write(line)
-    return msg_delta
+    return msg_delta, total_count, missing_ids
 
 
 if __name__ == "__main__":

--- a/python/moz/l10n/bin/build_file.py
+++ b/python/moz/l10n/bin/build_file.py
@@ -14,15 +14,17 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from os import makedirs
-from os.path import dirname, exists
+from os.path import dirname, exists, join, relpath
 from shutil import copyfile
 from textwrap import dedent
 
 from moz.l10n.bin.build import write_target_file
 from moz.l10n.formats import UnsupportedFormat
+from moz.l10n.model import Entry
 from moz.l10n.resource import parse_resource, serialize_resource
 
 log = logging.getLogger(__name__)
@@ -47,6 +49,13 @@ def cli() -> None:
     parser.add_argument("--source", metavar="PATH", required=True, help="source file")
     parser.add_argument("--l10n", metavar="PATH", help="localization file")
     parser.add_argument("--target", metavar="PATH", required=True, help="output target")
+    parser.add_argument(
+        "--coverage-base",
+        metavar="DIR",
+        help="base dir for coverage reporting: update <DIR>/coverage.json with "
+        "this file's translation ratio, keyed by --target's path relative to DIR "
+        "(e.g. browser/browser.ftl), matching l10n-build's keys",
+    )
     args = parser.parse_args()
 
     log_level = (
@@ -64,6 +73,8 @@ def cli() -> None:
         except UnsupportedFormat:
             source_res = None
         makedirs(dirname(args.target), exist_ok=True)
+        total_count = 0
+        missing_ids: list[str | list[str]] = []
         if source_res is None:
             from_path = (
                 args.l10n
@@ -75,8 +86,35 @@ def cli() -> None:
             with open(args.target, "w", encoding="utf-8") as file:
                 for line in serialize_resource(source_res, trim_comments=True):
                     file.write(line)
+            total_count = sum(
+                isinstance(entry, Entry)
+                for section in source_res.sections
+                for entry in section.entries
+            )
         else:
-            write_target_file(args.source, source_res, args.l10n, args.target)
+            _, total_count, missing_ids = write_target_file(
+                args.source, source_res, args.l10n, args.target
+            )
+
+        if args.coverage_base:
+            # Match l10n-build: one coverage.json per locale dir, keyed by the
+            # file path relative to that dir (e.g. browser/browser.ftl). The
+            # --coverage-base dir holds the coverage.json and is the root the
+            # key is computed against. Read any pre-existing file and
+            # add/overwrite this resource's entry.
+            coverage_path = join(args.coverage_base, "coverage.json")
+            coverage_name = relpath(args.target, args.coverage_base)
+            coverage_data: dict[str, dict[str, object]] = {}
+            if exists(coverage_path):
+                with open(coverage_path, encoding="utf-8") as file:
+                    coverage_data = json.load(file)
+            coverage_data[coverage_name] = {
+                "total": total_count,
+                "missing": missing_ids,
+            }
+            makedirs(args.coverage_base, exist_ok=True)
+            with open(coverage_path, "w", encoding="utf-8") as file:
+                json.dump(coverage_data, file, indent=2, sort_keys=True)
     except (OSError, UnsupportedFormat) as error:
         raise SystemExit(error)
 

--- a/python/tests/test_bin_build.py
+++ b/python/tests/test_bin_build.py
@@ -14,14 +14,20 @@
 
 from __future__ import annotations
 
-from os.path import join
+import json
+import sys
+from os.path import exists, join
 from tempfile import TemporaryDirectory
 from textwrap import dedent
 from unittest import TestCase
+from unittest.mock import patch
 
-from moz.l10n.bin.build import write_target_file
+from moz.l10n.bin.build import cli, write_target_file
+from moz.l10n.bin.build_file import cli as build_file_cli
 from moz.l10n.formats import Format
 from moz.l10n.model import Comment, Entry, PatternMessage, Resource, Section
+
+from .utils import Tree, build_file_tree
 
 
 class TestBuild(TestCase):
@@ -55,7 +61,9 @@ class TestBuild(TestCase):
             tgt_path = join(tmpdir, "tgt.ftl")
             with open(l10n_path, mode="w") as file:
                 file.write(l10n_src)
-            msg_delta = write_target_file("", source_res, l10n_path, tgt_path)
+            msg_delta, total_count, missing_ids = write_target_file(
+                "", source_res, l10n_path, tgt_path
+            )
             with open(tgt_path, mode="r") as file:
                 tgt_src = file.read()
             assert tgt_src == dedent("""\
@@ -68,6 +76,8 @@ class TestBuild(TestCase):
                     .extra = tgt
                 """)
             assert msg_delta == -2
+            assert total_count == 6
+            assert missing_ids == ["msg-c", "-term-c"]
 
     def test_write_target_file_nonfluent(self):
         entries: list[Entry[PatternMessage] | Comment] = [
@@ -100,7 +110,9 @@ class TestBuild(TestCase):
             tgt_path = join(tmpdir, "tgt.ftl")
             with open(l10n_path, mode="w") as file:
                 file.write(l10n_src)
-            msg_delta = write_target_file("", source_res, l10n_path, tgt_path)
+            msg_delta, total_count, missing_ids = write_target_file(
+                "", source_res, l10n_path, tgt_path
+            )
             with open(tgt_path, mode="r") as file:
                 tgt_src = file.read()
             assert tgt_src == dedent("""\
@@ -118,3 +130,310 @@ class TestBuild(TestCase):
                 -term-c = s
                 """)
             assert msg_delta == 1
+            assert total_count == 6
+            assert missing_ids == ["-term-c"]
+
+    def test_write_target_file_multipart_id(self):
+        # INI sections produce two-part ids, kept as a list rather than joined.
+        entries: list[Entry[PatternMessage] | Comment] = [
+            Entry(("WelcomeText",), PatternMessage(["s"])),
+            Entry(("LicenseText",), PatternMessage(["s"])),
+        ]
+        source_res = Resource(Format.ini, [Section(("Strings",), entries)])
+        l10n_src = "[Strings]\nWelcomeText = tgt\n"
+        with TemporaryDirectory() as tmpdir:
+            l10n_path = join(tmpdir, "l10n.ini")
+            tgt_path = join(tmpdir, "tgt.ini")
+            with open(l10n_path, mode="w") as file:
+                file.write(l10n_src)
+            msg_delta, total_count, missing_ids = write_target_file(
+                "", source_res, l10n_path, tgt_path
+            )
+            assert msg_delta == 1
+            assert total_count == 2
+            assert missing_ids == [["Strings", "LicenseText"]]
+
+    def test_cli_writes_coverage_json(self):
+        cfg_toml = dedent(
+            """
+            basepath = "."
+            locales = ["fr", "de"]
+            [[paths]]
+                reference = "en/file.ftl"
+                l10n = "{locale}/file.ftl"
+            """
+        )
+        source_ftl = dedent("""\
+            msg-a = src
+            msg-b = src
+            msg-c = src
+            msg-d = src
+            """)
+        fr_ftl = dedent("""\
+            msg-a = fr
+            msg-b = fr
+            msg-c = fr
+            msg-d = fr
+            """)
+        de_ftl = dedent("""\
+            msg-a = de
+            msg-b = de
+            """)
+        tree: Tree = {
+            "l10n.toml": cfg_toml,
+            "en": {"file.ftl": source_ftl},
+            "fr": {"file.ftl": fr_ftl},
+            "de": {"file.ftl": de_ftl},
+        }
+        with TemporaryDirectory() as root:
+            build_file_tree(root, tree)
+            target = join(root, "out")
+            argv = [
+                "l10n-build",
+                "--config",
+                join(root, "l10n.toml"),
+                "--base",
+                root,
+                "--target",
+                target,
+                "--locales",
+                "fr",
+                "de",
+                "--coverage",
+            ]
+            with patch.object(sys, "argv", argv):
+                cli()
+
+            with open(join(target, "fr", "coverage.json"), encoding="utf-8") as f:
+                fr_coverage = json.load(f)
+            with open(join(target, "de", "coverage.json"), encoding="utf-8") as f:
+                de_coverage = json.load(f)
+
+            assert fr_coverage == {"file.ftl": {"total": 4, "missing": []}}
+            assert de_coverage == {
+                "file.ftl": {"total": 4, "missing": ["msg-c", "msg-d"]}
+            }
+
+    def test_cli_skips_coverage_without_flag(self):
+        cfg_toml = dedent(
+            """
+            basepath = "."
+            locales = ["fr"]
+            [[paths]]
+                reference = "en/file.ftl"
+                l10n = "{locale}/file.ftl"
+            """
+        )
+        tree: Tree = {
+            "l10n.toml": cfg_toml,
+            "en": {"file.ftl": "msg-a = src\n"},
+            "fr": {"file.ftl": "msg-a = fr\n"},
+        }
+        with TemporaryDirectory() as root:
+            build_file_tree(root, tree)
+            target = join(root, "out")
+            argv = [
+                "l10n-build",
+                "--config",
+                join(root, "l10n.toml"),
+                "--base",
+                root,
+                "--target",
+                target,
+                "--locales",
+                "fr",
+            ]
+            with patch.object(sys, "argv", argv):
+                cli()
+
+            assert not exists(join(target, "fr", "coverage.json"))
+
+
+class TestBuildFile(TestCase):
+    def test_coverage_merge(self):
+        src = "msg-a = src\nmsg-b = src\nmsg-c = src\n"
+        l10n = "msg-a = fr\nmsg-b = fr\n"
+        with TemporaryDirectory() as root:
+            build_file_tree(root, {"en.ftl": src, "fr.ftl": l10n})
+            target = join(root, "file.ftl")
+            coverage = join(root, "coverage.json")
+            argv = [
+                "l10n-build-file",
+                "--source",
+                join(root, "en.ftl"),
+                "--l10n",
+                join(root, "fr.ftl"),
+                "--target",
+                target,
+                "--coverage-base",
+                root,
+            ]
+            with patch.object(sys, "argv", argv):
+                build_file_cli()
+
+            with open(coverage, encoding="utf-8") as f:
+                assert json.load(f) == {"file.ftl": {"total": 3, "missing": ["msg-c"]}}
+
+    def test_coverage_updates_existing_file(self):
+        # fastermake builds one resource at a time, sharing the per-locale
+        # coverage.json: the existing entries are preserved and the current
+        # resource's entry is added/overwritten.
+        src = "msg-a = src\nmsg-b = src\n"
+        l10n = "msg-a = fr\n"
+        with TemporaryDirectory() as root:
+            build_file_tree(root, {"en.ftl": src, "fr.ftl": l10n})
+            target = join(root, "file.ftl")
+            coverage = join(root, "coverage.json")
+            with open(coverage, "w", encoding="utf-8") as f:
+                json.dump(
+                    {
+                        "other.ftl": {"total": 5, "missing": []},
+                        "file.ftl": {"total": 1, "missing": ["stale"]},
+                    },
+                    f,
+                )
+            argv = [
+                "l10n-build-file",
+                "--source",
+                join(root, "en.ftl"),
+                "--l10n",
+                join(root, "fr.ftl"),
+                "--target",
+                target,
+                "--coverage-base",
+                root,
+            ]
+            with patch.object(sys, "argv", argv):
+                build_file_cli()
+
+            with open(coverage, encoding="utf-8") as f:
+                assert json.load(f) == {
+                    "other.ftl": {"total": 5, "missing": []},
+                    "file.ftl": {"total": 2, "missing": ["msg-b"]},
+                }
+
+    def test_coverage_source_only(self):
+        src = "msg-a = src\nmsg-b = src\n"
+        with TemporaryDirectory() as root:
+            build_file_tree(root, {"en.ftl": src})
+            target = join(root, "file.ftl")
+            coverage = join(root, "coverage.json")
+            argv = [
+                "l10n-build-file",
+                "--source",
+                join(root, "en.ftl"),
+                "--target",
+                target,
+                "--coverage-base",
+                root,
+            ]
+            with patch.object(sys, "argv", argv):
+                build_file_cli()
+
+            with open(coverage, encoding="utf-8") as f:
+                assert json.load(f) == {"file.ftl": {"total": 2, "missing": []}}
+
+    def test_coverage_unparseable_source(self):
+        with TemporaryDirectory() as root:
+            build_file_tree(root, {"en.txt": "not a known format\n"})
+            target = join(root, "file.txt")
+            coverage = join(root, "coverage.json")
+            argv = [
+                "l10n-build-file",
+                "--source",
+                join(root, "en.txt"),
+                "--target",
+                target,
+                "--coverage-base",
+                root,
+            ]
+            with patch.object(sys, "argv", argv):
+                build_file_cli()
+
+            with open(coverage, encoding="utf-8") as f:
+                assert json.load(f) == {"file.txt": {"total": 0, "missing": []}}
+
+    def test_coverage_matches_l10n_build(self):
+        # A coverage.json first created by l10n-build is then updated by
+        # l10n-build-file for one resource. With --coverage-base set to the
+        # locale dir, the key is derived as target's relative path, so the
+        # entry is overwritten in place rather than added under a divergent
+        # (absolute) path.
+        cfg_toml = dedent(
+            """
+            basepath = "."
+            locales = ["fr"]
+            [[paths]]
+                reference = "en/file.ftl"
+                l10n = "{locale}/file.ftl"
+            """
+        )
+        source_ftl = "msg-a = src\nmsg-b = src\nmsg-c = src\n"
+        fr_ftl = "msg-a = fr\n"
+        tree: Tree = {
+            "l10n.toml": cfg_toml,
+            "en": {"file.ftl": source_ftl},
+            "fr": {"file.ftl": fr_ftl},
+        }
+        with TemporaryDirectory() as root:
+            build_file_tree(root, tree)
+            target = join(root, "out")
+            argv = [
+                "l10n-build",
+                "--config",
+                join(root, "l10n.toml"),
+                "--base",
+                root,
+                "--target",
+                target,
+                "--locales",
+                "fr",
+                "--coverage",
+            ]
+            with patch.object(sys, "argv", argv):
+                cli()
+
+            coverage = join(target, "fr", "coverage.json")
+            with open(coverage, encoding="utf-8") as f:
+                assert json.load(f) == {
+                    "file.ftl": {"total": 3, "missing": ["msg-b", "msg-c"]}
+                }
+
+            # Re-localize the same file with a more complete translation.
+            fr_full = join(root, "fr", "file.ftl")
+            with open(fr_full, "w", encoding="utf-8") as f:
+                f.write("msg-a = fr\nmsg-b = fr\n")
+            argv = [
+                "l10n-build-file",
+                "--source",
+                join(root, "en", "file.ftl"),
+                "--l10n",
+                fr_full,
+                "--target",
+                join(target, "fr", "file.ftl"),
+                "--coverage-base",
+                join(target, "fr"),
+            ]
+            with patch.object(sys, "argv", argv):
+                build_file_cli()
+
+            with open(coverage, encoding="utf-8") as f:
+                # Same key updated in place, no stale duplicate entry.
+                assert json.load(f) == {"file.ftl": {"total": 3, "missing": ["msg-c"]}}
+
+    def test_skips_coverage_without_flag(self):
+        src = "msg-a = src\n"
+        with TemporaryDirectory() as root:
+            build_file_tree(root, {"en.ftl": src})
+            target = join(root, "out.ftl")
+            argv = [
+                "l10n-build-file",
+                "--source",
+                join(root, "en.ftl"),
+                "--target",
+                target,
+            ]
+            with patch.object(sys, "argv", argv):
+                build_file_cli()
+
+            assert not exists(join(root, "coverage.json"))


### PR DESCRIPTION
## Summary

Adds optional per-locale translation coverage reporting to the build tools.

### l10n-build
- New `--coverage` flag. When set, writes a `coverage.json` per locale under
  `--target`, mapping each file to its message coverage:
  ```json
  {
    "file.ftl": { "total": 4, "missing": ["msg-c", "msg-d"] }
  }
- Message ids are kept structural: a single-part id is emitted as a string,
while multi-part ids (are emitted as a list of strings.

### l10n-build-file

- New `--coverage PATH` option, mirroring l10n-build's capability for the
single-file builds.