### PR TITLE
Fix parsing & serialization of empty patterns

### DIFF
--- a/js/src/index.test.ts
+++ b/js/src/index.test.ts
@@ -31,6 +31,20 @@ describe('parsePattern', () => {
     expect(pattern).toEqual(['{foo %s}'])
   })
 
+  for (const format of [
+    'android',
+    'fluent',
+    'mf2',
+    'plain',
+    'webext',
+    'xliff'
+  ] as const) {
+    test(`${format} empty`, () => {
+      const pattern = parsePattern(format, '')
+      expect(pattern).toEqual([])
+    })
+  }
+
   for (const [format, str] of [
     ['unsupported' as FormatKey, 'bar'],
     ['android', 'invalid <xml>'],
@@ -54,6 +68,20 @@ describe('serializePattern', () => {
     const str = serializePattern('plain', ['{foo %s}'])
     expect(str).toBe('{foo %s}')
   })
+
+  for (const format of [
+    'android',
+    'fluent',
+    'mf2',
+    'plain',
+    'webext',
+    'xliff'
+  ] as const) {
+    test(`${format} empty`, () => {
+      const str = serializePattern(format, [])
+      expect(str).toBe('')
+    })
+  }
 
   for (const [format, pattern, exp] of [
     ['unsupported' as FormatKey, ['bar'], 'bar'],

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -100,7 +100,7 @@ export function parsePattern(
     case 'xliff':
       return xliffParsePattern(src)
     case 'plain':
-      return [src]
+      return src ? [src] : []
     default:
       throw new ParseError(`${format}: Unsupported format`)
   }

--- a/js/src/xml-utils.ts
+++ b/js/src/xml-utils.ts
@@ -25,7 +25,7 @@ export function serialize(root: Element) {
   const str = new XMLSerializer().serializeToString(root)
   if (str.startsWith(`<${name}`) && str.endsWith(`</${name}>`)) {
     return str.replace(/^<.*?>/, '').slice(0, -1 * (name.length + 3))
-  } else if (new RegExp(`^<${name}[^<>]+/>$`).test(str)) {
+  } else if (new RegExp(`^<${name}[^<>]*/>$`).test(str)) {
     return ''
   } else {
     throw 'Unexpected XML serialization'

--- a/python/moz/l10n/message/parse.py
+++ b/python/moz/l10n/message/parse.py
@@ -73,4 +73,4 @@ def parse_message(
     elif printf_placeholders:
         return PatternMessage(list(parse_printf_pattern(source)))
     else:
-        return PatternMessage([source])
+        return PatternMessage([source] if source else [])

--- a/python/tests/test_message.py
+++ b/python/tests/test_message.py
@@ -98,6 +98,58 @@ class TestMessage(TestCase):
         assert res == "x{}\n*y"
 
 
+class TestEmptyMessage(TestCase):
+    def test_plain(self):
+        msg = parse_message(Format.plain_json, "")
+        assert msg == PatternMessage([])
+        res = serialize_message(Format.plain_json, msg)
+        assert res == ""
+
+    def test_printf(self):
+        msg = parse_message(Format.plain_json, "", printf_placeholders=True)
+        assert msg == PatternMessage([])
+        res = serialize_message(Format.plain_json, msg)
+        assert res == ""
+
+    def test_properties_printf(self):
+        msg = parse_message(Format.properties, "", printf_placeholders=True)
+        assert msg == PatternMessage([])
+        res = serialize_message(Format.properties, msg)
+        assert res == ""
+
+    def test_webext(self):
+        msg = parse_message(Format.webext, "")
+        assert msg == PatternMessage([])
+        res = serialize_message(Format.webext, msg)
+        assert res == ""
+
+    def test_fluent(self):
+        msg = parse_message(Format.fluent, "")
+        assert msg == PatternMessage([])
+        res = serialize_message(Format.fluent, msg)
+        assert res == ""
+
+    def test_android(self):
+        try:
+            from moz.l10n.formats.android import android_parse_message  # noqa: F401
+        except ImportError:
+            raise SkipTest("Requires [xml] extra")
+        msg = parse_message(Format.android, "")
+        assert msg == PatternMessage([])
+        res = serialize_message(Format.android, msg)
+        assert res == ""
+
+    def test_xliff(self):
+        try:
+            from moz.l10n.formats.xliff import xliff_parse_message  # noqa: F401
+        except ImportError:
+            raise SkipTest("Requires [xml] extra")
+        msg = parse_message(Format.xliff, "")
+        assert msg == PatternMessage([])
+        res = serialize_message(Format.xliff, msg)
+        assert res == ""
+
+
 class TestUnsupportedFormat(TestCase):
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Ensure that empty patterns are parsed as `[]` rather than `['']`, and that they serialize correctly.