### PR TITLE
Do not strip empty literals during normalization

### DIFF
--- a/js/src/model-utils.test.ts
+++ b/js/src/model-utils.test.ts
@@ -30,7 +30,9 @@ describe('messageIsEmpty', () => {
 
   test('PatternMessage', () => {
     expect(messageIsEmpty({ decl: {}, msg: [] })).toBe(true)
-    expect(messageIsEmpty({ decl: { x: { _: '' } }, msg: ['', ''] })).toBe(true)
+    expect(messageIsEmpty({ decl: { x: { _: 'X' } }, msg: ['', ''] })).toBe(
+      true
+    )
     expect(messageIsEmpty({ decl: {}, msg: [' '] })).toBe(false)
     expect(messageIsEmpty([' '])).toBe(false)
   })
@@ -59,10 +61,14 @@ describe('normalizeMessage', () => {
     expect(normalizeMessage(['', '\n'])).toEqual(['\n'])
     expect(normalizeMessage(['foo', '', ''])).toEqual(['foo'])
     expect(normalizeMessage(['foo', '', 'bar'])).toEqual(['foobar'])
-    expect(normalizeMessage(['foo', { _: '' }, 'bar'])).toEqual(['foobar'])
+    expect(normalizeMessage(['foo', { _: '' }, 'bar'])).toEqual([
+      'foo',
+      { _: '' },
+      'bar'
+    ])
     expect(
       normalizeMessage(['foo', { _: '', attr: undefined }, 'bar'])
-    ).toEqual(['foobar'])
+    ).toEqual(['foo', { _: '', attr: undefined }, 'bar'])
     expect(normalizeMessage(['foo', { _: '', attr: {} }, 'bar'])).toEqual([
       'foo',
       { _: '', attr: {} },

--- a/js/src/model-utils.ts
+++ b/js/src/model-utils.ts
@@ -72,11 +72,7 @@ function normalizePattern(pat: Pattern, varRefs: Set<string> | null): Pattern {
   for (const el of pat) {
     if (typeof el === 'string') {
       next = next ? next + el : el
-    } else if (
-      // Skip empty literal expressions, i.e. {||}
-      el._ !== '' ||
-      Object.values(el).reduce((s, v) => (v === undefined ? s : s + 1), 0) !== 1
-    ) {
+    } else {
       if (next) {
         res.push(next)
         next = ''

--- a/python/moz/l10n/util/normalize.py
+++ b/python/moz/l10n/util/normalize.py
@@ -26,9 +26,6 @@ __all__ = [
 
 
 def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
-    from moz.l10n.model import Expression
-
-    empty_literal = Expression("")
     i = 0
     at_str = False
     while i < len(pattern):
@@ -42,8 +39,6 @@ def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
             else:
                 at_str = True
                 i += 1
-        elif el == empty_literal:
-            pattern.pop(i)
         else:
             at_str = False
             i += 1

--- a/python/tests/test_model.py
+++ b/python/tests/test_model.py
@@ -70,7 +70,7 @@ class TestMessage(TestCase):
         )
         assert PatternMessage(
             ["foo", Expression(""), "bar"]
-        ).normalize() == PatternMessage(["foobar"])
+        ).normalize() == PatternMessage(["foo", Expression(""), "bar"])
         assert PatternMessage(
             ["foo", Expression("", attributes={"source": ""}), "bar"]
         ).normalize() == PatternMessage(


### PR DESCRIPTION
The message normalization added in #135 needs to be amended a bit, to keep empty literals in message patterns.

This is needed to be able to distinguish Fluent messages that have no value
```fluent
key =
  .attr = foo
```
from Fluent messages that have an empty value
```fluent
key = { "" }
  .attr = foo
```
