### PR TITLE
Use structural pattern matching where appropriate

### DIFF
--- a/python/moz/l10n/formats/android/parse.py
+++ b/python/moz/l10n/formats/android/parse.py
@@ -498,19 +498,19 @@ def parse_inline(
                     else:
                         # Placeholder
                         func: str | None
-                        # TODO post-py38: should be a match
-                        if conversion in {"b", "B"}:
-                            func = "boolean"
-                        elif conversion in {"c", "C", "s", "S"}:
-                            func = "string"
-                        elif conversion in {"d", "h", "H", "o", "x", "X"}:
-                            func = "integer"
-                        elif conversion in {"a", "A", "e", "E", "f", "g", "G"}:
-                            func = "number"
-                        elif len(conversion) == 2 and conversion[0] in {"t", "T"}:
-                            func = "datetime"
-                        else:
-                            func = None
+                        match conversion:
+                            case "b" | "B":
+                                func = "boolean"
+                            case "c" | "C" | "s" | "S":
+                                func = "string"
+                            case "d" | "h" | "H" | "o" | "x" | "X":
+                                func = "integer"
+                            case "a" | "A" | "e" | "E" | "f" | "g" | "G":
+                                func = "number"
+                            case dt if len(dt) == 2 and dt[0] in {"t", "T"}:
+                                func = "datetime"
+                            case _:
+                                func = None
                         source = m[0]
                         if source.startswith("%<"):
                             # https://developer.android.com/reference/java/util/Formatter#argument-index

--- a/python/moz/l10n/formats/xliff/parse_xcode.py
+++ b/python/moz/l10n/formats/xliff/parse_xcode.py
@@ -514,19 +514,19 @@ def parse_xcode_pattern(src: str | None) -> Iterator[str | Expression]:
             else:
                 name: str
                 func: str | None
-                # TODO post-py38: should be a match
-                if format in {"c", "C", "s", "S"}:
-                    name = "str"
-                    func = "string"
-                elif format in {"d", "D", "o", "O", "p", "u", "U", "x", "X"}:
-                    name = "int"
-                    func = "integer"
-                elif format in {"a", "A", "e", "E", "f", "g", "G"}:
-                    name = "num"
-                    func = "number"
-                else:
-                    name = "arg"
-                    func = None
+                match format:
+                    case "c" | "C" | "s" | "S":
+                        name = "str"
+                        func = "string"
+                    case "d" | "D" | "o" | "O" | "p" | "u" | "U" | "x" | "X":
+                        name = "int"
+                        func = "integer"
+                    case "a" | "A" | "e" | "E" | "f" | "g" | "G":
+                        name = "num"
+                        func = "number"
+                    case _:
+                        name = "arg"
+                        func = None
                 if m[1]:
                     attributes["index"] = index = m[1][0]
                     name += index

--- a/python/moz/l10n/message/parse.py
+++ b/python/moz/l10n/message/parse.py
@@ -53,24 +53,33 @@ def parse_message(
 
     To parse an `xliff` message with XCode customizations, enable `xliff_is_xcode`.
     """
-    # TODO post-py38: should be a match
-    if format == Format.properties:
-        return properties_parse_message(source, printf_placeholders=printf_placeholders)
-    elif format == Format.webext:
-        return webext_parse_message(source, webext_placeholders)
-    elif format == Format.android:
-        if android_parse_message is None:
-            raise UnsupportedFormat("Parsing Android messages requires [xml] extra")
-        return android_parse_message(source, ascii_spaces=android_ascii_spaces)
-    elif format == Format.xliff:
-        if xliff_parse_message is None:
-            raise UnsupportedFormat("Parsing XLIFF messages requires [xml] extra")
-        return xliff_parse_message(source, is_xcode=xliff_is_xcode)
-    elif format == Format.mf2:
-        return mf2_parse_message(source)
-    elif format == Format.fluent:
-        return fluent_parse_message(source)
-    elif printf_placeholders:
-        return PatternMessage(list(parse_printf_pattern(source)))
-    else:
-        return PatternMessage([source] if source else [])
+    match format:
+        case Format.properties:
+            return properties_parse_message(
+                source, printf_placeholders=printf_placeholders
+            )
+
+        case Format.webext:
+            return webext_parse_message(source, webext_placeholders)
+
+        case Format.android:
+            if android_parse_message is None:
+                raise UnsupportedFormat("Parsing Android messages requires [xml] extra")
+            return android_parse_message(source, ascii_spaces=android_ascii_spaces)
+
+        case Format.xliff:
+            if xliff_parse_message is None:
+                raise UnsupportedFormat("Parsing XLIFF messages requires [xml] extra")
+            return xliff_parse_message(source, is_xcode=xliff_is_xcode)
+
+        case Format.mf2:
+            return mf2_parse_message(source)
+
+        case Format.fluent:
+            return fluent_parse_message(source)
+
+        case _ if printf_placeholders:
+            return PatternMessage(list(parse_printf_pattern(source)))
+
+        case _:
+            return PatternMessage([source] if source else [])

--- a/python/moz/l10n/message/serialize.py
+++ b/python/moz/l10n/message/serialize.py
@@ -49,37 +49,50 @@ def serialize_message(
     """
     if isinstance(msg, list):
         msg = PatternMessage(msg)
-    # TODO post-py38: should be a match
-    if format == Format.properties:
-        return properties_serialize_message(msg)
-    elif format == Format.webext:
-        # Placeholders are discarded
-        return webext_serialize_message(msg)[0]
-    elif format == Format.android:
-        if android_serialize_message is None:
-            raise UnsupportedFormat("Serializing Android messages requires [xml] extra")
-        return android_serialize_message(msg)
-    elif format == Format.xliff:
-        if xliff_serialize_message is None:
-            raise UnsupportedFormat("Serializing XLIFF messages requires [xml] extra")
-        return xliff_serialize_message(msg)
-    elif format == Format.mf2:
-        return mf2_serialize_message(msg)
-    elif format == Format.fluent:
-        return fluent_serialize_message(
-            msg, escape_empty=fluent_escape_empty, escape_syntax=fluent_escape_syntax
-        )
-    elif not isinstance(msg, PatternMessage) or msg.declarations:
-        raise ValueError(f"Unsupported message: {msg}")
-    else:
-        res = ""
-        for part in msg.pattern:
-            if isinstance(part, str):
-                res += part
-            else:
-                part_source = part.attributes.get("source", None)
-                if isinstance(part_source, str):
-                    res += part_source
+    match format:
+        case Format.properties:
+            return properties_serialize_message(msg)
+
+        case Format.webext:
+            # Placeholders are discarded
+            return webext_serialize_message(msg)[0]
+
+        case Format.android:
+            if android_serialize_message is None:
+                raise UnsupportedFormat(
+                    "Serializing Android messages requires [xml] extra"
+                )
+            return android_serialize_message(msg)
+
+        case Format.xliff:
+            if xliff_serialize_message is None:
+                raise UnsupportedFormat(
+                    "Serializing XLIFF messages requires [xml] extra"
+                )
+            return xliff_serialize_message(msg)
+
+        case Format.mf2:
+            return mf2_serialize_message(msg)
+
+        case Format.fluent:
+            return fluent_serialize_message(
+                msg,
+                escape_empty=fluent_escape_empty,
+                escape_syntax=fluent_escape_syntax,
+            )
+
+        case _ if not isinstance(msg, PatternMessage) or msg.declarations:
+            raise ValueError(f"Unsupported message: {msg}")
+
+        case _:
+            res = ""
+            for part in msg.pattern:
+                if isinstance(part, str):
+                    res += part
                 else:
-                    raise ValueError(f"Unsupported placeholder: {part}")
-        return res
+                    part_source = part.attributes.get("source", None)
+                    if isinstance(part_source, str):
+                        res += part_source
+                    else:
+                        raise ValueError(f"Unsupported placeholder: {part}")
+            return res

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -197,7 +197,7 @@ class SelectMessage:
 
         Mutates this SelectMessage.
         """
-        var_refs = set(sel.name for sel in self.selectors)
+        var_refs = {sel.name for sel in self.selectors}
         for pattern in self.variants.values():
             _normalize_pattern(pattern, var_refs)
         _normalize_declarations(self, var_refs)
@@ -368,7 +368,7 @@ class Entry(Generic[V_co], _WithMeta):
     i.e. the concatenation of its section header identifier (if any) and its own.
     """
 
-    value: V_co
+    value: V_co  # type: ignore
     """
     The value of an entry, i.e. the message.
 

--- a/python/moz/l10n/resource/parse_resource.py
+++ b/python/moz/l10n/resource/parse_resource.py
@@ -68,48 +68,62 @@ def parse_resource(
         with open(input, mode="rb") as file:
             source = file.read()
             input_is_file = True
-    # TODO post-py38: should be a match
+
     format = input if isinstance(input, Format) else detect_format(input, source)
-    if format == Format.dtd:
-        return dtd_parse(source)
-    elif format == Format.fluent:
-        return fluent_parse(source)
-    elif format == Format.gettext:
-        # Workaround for https://github.com/izimobil/polib/issues/170
-        source_ = cast(str, input) if input_is_file else source
-        return gettext_parse(
-            source_, plurals=gettext_plurals, skip_obsolete=gettext_skip_obsolete
-        )
-    elif format == Format.inc:
-        return inc_parse(source)
-    elif format == Format.ini:
-        return ini_parse(source)
-    elif format == Format.plain_json:
-        return plain_json_parse(source)
-    elif format == Format.properties:
-        return properties_parse(
-            source, printf_placeholders=properties_printf_placeholders
-        )
-    elif format == Format.webext:
-        return webext_parse(source)
-    elif format == Format.android and android_parse is not None:
-        return android_parse(
-            source,
-            ascii_spaces=android_ascii_spaces,
-            literal_quotes=android_literal_quotes,
-        )
-    elif format == Format.xliff and xliff_parse is not None:
-        return xliff_parse(source, source_entries=xliff_source_entries)
-    else:
-        msg = (
-            "Resource format detection failed"
-            if format is None
-            else f"Unsupported resource format: {format.name}"
-        )
-        if xliff_parse is None and (
-            (input_is_file and cast(str, input).endswith((".xlf", ".xliff", ".xml")))
-            or (isinstance(source, str) and source.startswith("<"))
-            or (isinstance(source, bytes) and source.startswith(b"<"))
-        ):
-            msg += ". For XML support `lxml` is required."
-        raise UnsupportedFormat(msg)
+    match format:
+        case Format.dtd:
+            return dtd_parse(source)
+
+        case Format.fluent:
+            return fluent_parse(source)
+
+        case Format.gettext:
+            # Workaround for https://github.com/izimobil/polib/issues/170
+            source_ = cast(str, input) if input_is_file else source
+            return gettext_parse(
+                source_, plurals=gettext_plurals, skip_obsolete=gettext_skip_obsolete
+            )
+
+        case Format.inc:
+            return inc_parse(source)
+
+        case Format.ini:
+            return ini_parse(source)
+
+        case Format.plain_json:
+            return plain_json_parse(source)
+
+        case Format.properties:
+            return properties_parse(
+                source, printf_placeholders=properties_printf_placeholders
+            )
+
+        case Format.webext:
+            return webext_parse(source)
+
+        case Format.android if android_parse is not None:
+            return android_parse(
+                source,
+                ascii_spaces=android_ascii_spaces,
+                literal_quotes=android_literal_quotes,
+            )
+
+        case Format.xliff if xliff_parse is not None:
+            return xliff_parse(source, source_entries=xliff_source_entries)
+
+        case _:
+            msg = (
+                "Resource format detection failed"
+                if format is None
+                else f"Unsupported resource format: {format.name}"
+            )
+            if xliff_parse is None and (
+                (
+                    input_is_file
+                    and cast(str, input).endswith((".xlf", ".xliff", ".xml"))
+                )
+                or (isinstance(source, str) and source.startswith("<"))
+                or (isinstance(source, bytes) and source.startswith(b"<"))
+            ):
+                msg += ". For XML support `lxml` is required."
+            raise UnsupportedFormat(msg)

--- a/python/moz/l10n/resource/serialize_resource.py
+++ b/python/moz/l10n/resource/serialize_resource.py
@@ -57,34 +57,47 @@ def serialize_resource(
     With `trim_comments`,
     all standalone and attached comments are left out of the serialization.
     """
-    # TODO post-py38: should be a match
     if not format:
         format = resource.format
-    if format == Format.dtd:
-        return dtd_serialize(resource, trim_comments=trim_comments)
-    elif format == Format.fluent:
-        return fluent_serialize(
-            resource, escape_syntax=fluent_escape_syntax, trim_comments=trim_comments
-        )
-    elif format == Format.gettext:
-        return gettext_serialize(
-            resource, plurals=gettext_plurals, trim_comments=trim_comments
-        )
-    elif format == Format.inc:
-        return inc_serialize(resource, trim_comments=trim_comments)
-    elif format == Format.ini:
-        return ini_serialize(resource, trim_comments=trim_comments)
-    elif format == Format.plain_json:
-        return plain_json_serialize(resource, trim_comments=trim_comments)
-    elif format == Format.properties:
-        return properties_serialize(resource, trim_comments=trim_comments)
-    elif format == Format.webext:
-        return webext_serialize(resource, trim_comments=trim_comments)
-    elif format == Format.android and android_serialize is not None:
-        return android_serialize(resource, trim_comments)
-    elif format == Format.xliff and xliff_serialize is not None:
-        return xliff_serialize(
-            resource, trim_comments, source_entries=xliff_source_entries
-        )
-    else:
-        raise ValueError(f"Unsupported resource format: {format or resource.format}")
+
+    match format:
+        case Format.dtd:
+            return dtd_serialize(resource, trim_comments=trim_comments)
+
+        case Format.fluent:
+            return fluent_serialize(
+                resource,
+                escape_syntax=fluent_escape_syntax,
+                trim_comments=trim_comments,
+            )
+
+        case Format.gettext:
+            return gettext_serialize(
+                resource, plurals=gettext_plurals, trim_comments=trim_comments
+            )
+
+        case Format.inc:
+            return inc_serialize(resource, trim_comments=trim_comments)
+
+        case Format.ini:
+            return ini_serialize(resource, trim_comments=trim_comments)
+
+        case Format.plain_json:
+            return plain_json_serialize(resource, trim_comments=trim_comments)
+
+        case Format.properties:
+            return properties_serialize(resource, trim_comments=trim_comments)
+
+        case Format.webext:
+            return webext_serialize(resource, trim_comments=trim_comments)
+
+        case Format.android if android_serialize is not None:
+            return android_serialize(resource, trim_comments)
+
+        case Format.xliff if xliff_serialize is not None:
+            return xliff_serialize(
+                resource, trim_comments, source_entries=xliff_source_entries
+            )
+
+        case _:
+            raise ValueError(f"Unsupported resource format: {format}")

--- a/python/moz/l10n/util/normalize.py
+++ b/python/moz/l10n/util/normalize.py
@@ -48,7 +48,7 @@ def _normalize_pattern(pattern: Pattern, var_refs: set[str]) -> None:
 
 def _normalize_declarations(msg: Message, var_refs: set[str]) -> None:
     decl_refs = {
-        name: set(var.name for var in decl.variable_refs() if var.name != name)
+        name: {var.name for var in decl.variable_refs() if var.name != name}
         for name, decl in msg.declarations.items()
     }
     for name in list(var_refs):

--- a/python/moz/l10n/util/printf.py
+++ b/python/moz/l10n/util/printf.py
@@ -42,17 +42,17 @@ def parse_printf_pattern(src: str | None) -> Iterator[str | Expression]:
             continue
 
         func: str | None
-        # TODO post-py38: should be a match
-        if datetime:
-            func = "datetime"
-        elif type in {"c", "C", "s", "S"}:
-            func = "string"
-        elif type in {"d", "D", "o", "O", "p", "u", "U", "x", "X"}:
-            func = "integer"
-        elif type in {"a", "A", "e", "E", "f", "F", "g", "G"}:
-            func = "number"
-        else:
-            func = "printf"
+        match type:
+            case _ if datetime:
+                func = "datetime"
+            case "c" | "C" | "s" | "S":
+                func = "string"
+            case "d" | "D" | "o" | "O" | "p" | "u" | "U" | "x" | "X":
+                func = "integer"
+            case "a" | "A" | "e" | "E" | "f" | "F" | "g" | "G":
+                func = "number"
+            case _:
+                func = "printf"
         yield Expression(
             VariableRef(argname or ("arg" + (argnum or ""))),
             func,


### PR DESCRIPTION
We've required at least Python 3.9 for a while, and so should follow-up on all the
```python
# TODO post-py38: should be a match
```
comments around if...elif...elif...else chains.