### PR TITLE
Add `messagesEqual()` JS function

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -25,13 +25,29 @@ and the parser for `mf2` depends on the `messageformat` package.
 
 ## API
 
+### messagesEqual()
+
+```js
+import { messagesEqual } from '@mozilla/l10n'
+```
+
+```ts
+function messagesEqual(a: Message, b: Message): boolean
+```
+
+Are the messages `a` and `b` deeply equal?
+
+Messages are not normalised for this comparison.
+All catchall keys are considered equal with each other,
+and declaration order is ignored.
+
 ### normalizeMessage()
 
 ```js
 import { normalizeMessage } from '@mozilla/l10n'
 ```
 
-```js
+```ts
 function normalizeMessage(msg: Message): Message
 ```
 
@@ -46,7 +62,7 @@ Objects and arrays in returned value are clones of objects in `msg`.
 import { ParseError, parsePattern } from '@mozilla/l10n'
 ```
 
-```js
+```ts
 function parsePattern(
   format: 'android' | 'fluent' | 'mf2' | 'plain' | 'webext' | 'xliff',
   src: string,
@@ -54,7 +70,7 @@ function parsePattern(
 ): Pattern
 
 class ParseError extends Error {
-  range?: [number, number]  // Set for fluent, mf2, and webext errors
+  range?: [number, number] // Set for fluent, mf2, and webext errors
 }
 ```
 
@@ -71,7 +87,7 @@ If `onError` is undefined, errors are thrown.
 import { SerializeError, serializePattern } from '@mozilla/l10n'
 ```
 
-```js
+```ts
 function serializePattern(
   format: 'android' | 'fluent' | 'mf2' | 'plain' | 'webext' | 'xliff',
   pattern: Pattern,
@@ -79,7 +95,7 @@ function serializePattern(
 ): string
 
 class SerializeError extends Error {
-  pos?: number  // Set for fluent, plain, and webext errors
+  pos?: number // Set for fluent, plain, and webext errors
 }
 ```
 

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -45,7 +45,12 @@ export {
   type PatternMessage,
   type SelectMessage
 } from './model.ts'
-export { messageIsEmpty, normalizeMessage } from './model-utils.ts'
+
+export {
+  messageIsEmpty,
+  messagesEqual,
+  normalizeMessage
+} from './model-utils.ts'
 
 export {
   androidParsePattern,

--- a/js/src/model-utils.test.ts
+++ b/js/src/model-utils.test.ts
@@ -17,6 +17,7 @@ import { describe, expect, test } from 'vitest'
 import {
   type Message,
   messageIsEmpty,
+  messagesEqual,
   normalizeMessage,
   type SelectMessage
 } from './index.ts'
@@ -159,4 +160,99 @@ describe('normalizeMessage', () => {
       })
     }
   })
+})
+
+describe('messagesEqual', () => {
+  const repl = (x: unknown) => JSON.stringify(x).replace(/"/g, '')
+
+  const ok: Message[] = [
+    ['abc'],
+    ['a', 'b'],
+    [
+      'a',
+      { $: 'b' },
+      { _: 'c' },
+      { open: 'd' },
+      { close: 'd' },
+      { elem: 'e' },
+      { fn: 'f' }
+    ],
+    { decl: {}, msg: ['a'] },
+    { decl: { a: { $: 'b', fn: 'c' } }, msg: ['a', { $: 'a' }] },
+    {
+      decl: { a: { $: 'a' } },
+      sel: ['a'],
+      alt: [{ keys: [{ '*': '' }], pat: ['b'] }]
+    }
+  ]
+  for (const msg of ok) {
+    test(repl(msg), () => {
+      const copy = structuredClone(msg)
+      expect(messagesEqual(msg, copy)).toBe(true)
+    })
+  }
+
+  const ok2: Array<[Message, Message]> = [
+    [[{ $: 'a', fn: 'f' }], [{ $: 'a', fn: 'f', opt: {} }]],
+    [[{ elem: 'a', attr: {} }], [{ elem: 'a' }]],
+    [['a'], { decl: {}, msg: ['a'] }],
+    [{ decl: {}, msg: ['b'] }, ['b']],
+    [
+      { decl: { a: { $: 'a' }, b: { _: 'b' } }, msg: [] },
+      { decl: { b: { _: 'b' }, a: { $: 'a' } }, msg: [] }
+    ],
+    [
+      {
+        decl: { a: { $: 'a' } },
+        sel: ['a'],
+        alt: [{ keys: [{ '*': '' }], pat: ['b'] }]
+      },
+      {
+        decl: { a: { $: 'a' } },
+        sel: ['a'],
+        alt: [{ keys: [{ '*': 'c' }], pat: ['b'] }]
+      }
+    ]
+  ]
+  for (const [a, b] of ok2) {
+    test(`${repl(a)} = ${repl(b)}`, () => {
+      expect(messagesEqual(a, b)).toBe(true)
+    })
+  }
+
+  const notOk: Array<[Message, Message]> = [
+    [['a'], ['b']],
+    [[], ['']],
+    [['a', ''], ['a']],
+    [['ab'], ['a', 'b']],
+    [[{ $: 'a' }], []],
+    [[{ $: 'a' }], [{ $: 'a', fn: 'f' }]],
+    [
+      [{ $: 'a', fn: 'f', opt: { b: 'c' } }],
+      [{ $: 'a', fn: 'f', opt: { b: { $: 'c' } } }]
+    ],
+    [
+      {
+        decl: { a: { $: 'a' } },
+        sel: ['a'],
+        alt: [
+          { keys: ['b'], pat: [] },
+          { keys: [{ '*': '' }], pat: [] }
+        ]
+      },
+      {
+        decl: { a: { $: 'a' } },
+        sel: ['a'],
+        alt: [
+          { keys: [{ '*': '' }], pat: [] },
+          { keys: ['b'], pat: [] }
+        ]
+      }
+    ]
+  ]
+  for (const [a, b] of notOk) {
+    test(`${repl(a)} != ${repl(b)}`, () => {
+      expect(messagesEqual(a, b)).toBe(false)
+    })
+  }
 })

--- a/js/src/model-utils.ts
+++ b/js/src/model-utils.ts
@@ -15,6 +15,7 @@
 
 import type {
   Expression,
+  Markup,
   Message,
   Pattern,
   PatternMessage,
@@ -136,4 +137,111 @@ function normalizeDeclarations(
     }
   }
   return hasDecl ? decl : null
+}
+
+/**
+ * Are the messages `a` and `b` deeply equal?
+ *
+ * Messages are not normalised for this comparison.
+ * All catchall keys are considered equal with each other,
+ * and declaration order is ignored.
+ */
+export function messagesEqual(a: Message, b: Message): boolean {
+  if (a === b) return true
+  if (Array.isArray(a)) {
+    if (Array.isArray(b)) return patternsEqual(a, b)
+    if (b.msg && !Object.keys(b.decl).length) return patternsEqual(a, b.msg)
+    return false
+  }
+  if (Array.isArray(b)) {
+    if (a.msg && !Object.keys(a.decl).length) return patternsEqual(a.msg, b)
+    return false
+  }
+  if (a.msg) {
+    // PatternMessage
+    if (!b.msg || !patternsEqual(a.msg, b.msg)) return false
+  } else {
+    // SelectMessage
+    if (b.msg || a.sel.length !== b.sel.length || a.alt.length !== b.alt.length)
+      return false
+    for (let i = 0; i < a.sel.length; ++i) {
+      if (a.sel[i] !== b.sel[i]) return false
+    }
+    for (let i = 0; i < a.alt.length; ++i) {
+      const av = a.alt[i]
+      const bv = b.alt[i]
+      for (let j = 0; j < av.keys.length; ++j) {
+        const ak = av.keys[j]
+        const bk = bv.keys[j]
+        if (typeof ak === 'string') {
+          if (ak !== bk) return false
+        } else {
+          if (typeof bk === 'string') return false
+          // All catchall keys are considered equal with each other
+        }
+      }
+      if (!patternsEqual(av.pat, bv.pat)) return false
+    }
+  }
+  const ad = Object.entries(a.decl)
+  if (ad.length !== Object.keys(b.decl).length) return false
+  for (const [name, ax] of ad) {
+    // Declaration order is ignored
+    const bx = b.decl[name]
+    if (!bx || !placeholdersEqual(ax, bx)) return false
+  }
+  return true
+}
+
+function patternsEqual(a: Pattern, b: Pattern) {
+  if (a.length !== b.length) return false
+  for (let i = 0; i < a.length; ++i) {
+    const ai = a[i]
+    const bi = b[i]
+    if (typeof ai === 'string') {
+      if (ai !== bi) return false
+    } else if (typeof bi === 'string' || !placeholdersEqual(ai, bi)) {
+      return false
+    }
+  }
+  return true
+}
+
+/** Are the placeholders `a` and `b` deeply equal?  */
+function placeholdersEqual(
+  a: Expression | Markup,
+  b: Expression | Markup
+): boolean {
+  if (
+    a._ !== b._ ||
+    a.$ !== b.$ ||
+    a.fn !== b.fn ||
+    a.open !== b.open ||
+    a.close !== b.close ||
+    a.elem !== b.elem
+  )
+    return false
+
+  if (a.opt || b.opt) {
+    const ao = a.opt ? Object.entries(a.opt) : []
+    const bol = b.opt ? Object.keys(b.opt).length : 0
+    if (ao.length !== bol) return false
+    for (const [key, av] of ao) {
+      const bv = b.opt![key]
+      if (typeof av === 'string') {
+        if (bv !== av) return false
+      } else {
+        if (typeof bv !== 'object' || bv.$ !== av.$) return false
+      }
+    }
+  }
+
+  if (a.attr || b.attr) {
+    const aa = a.attr ? Object.entries(a.attr) : []
+    const bal = b.attr ? Object.keys(b.attr).length : 0
+    if (aa.length !== bal) return false
+    for (const [key, av] of aa) if (b.attr![key] !== av) return false
+  }
+
+  return true
 }


### PR DESCRIPTION
Matches the `==` comparability of Python messages, which we get mostly for free by inheriting from dataclasses.