### PR TITLE
paths: Discover most common locale directory separator

### DIFF
--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -29,11 +29,11 @@ locale_id = re.compile(
 )
 
 
-def dir_contains(dir: str, path: str) -> bool:
+def _dir_contains(dir: str, path: str) -> bool:
     return commonpath((dir, path)) == dir
 
 
-def locale_dirname(base: str, locale: str, locale_dir_sep: Literal["-", "_"]) -> str:
+def _locale_dirname(base: str, locale: str, locale_dir_sep: Literal["-", "_"]) -> str:
     if "-" not in locale or isdir(join(base, locale)):
         return locale
 
@@ -120,7 +120,7 @@ class L10nDiscoverPaths:
         pot_dirs: list[str] = []
         l10n_dirs: list[str] = []
         # Important! We walk with `topdown=True` to get shortest paths first!
-        if ref_root and not dir_contains(root, ref_root):
+        if ref_root and not _dir_contains(root, ref_root):
             walk_roots: Iterator[tuple[str, list[str], list[str]]] = chain(
                 walk(root, topdown=True), walk(ref_root, topdown=True)
             )
@@ -149,14 +149,16 @@ class L10nDiscoverPaths:
 
         if ref_root:
             for dir in list(ref_dirs):
-                if not dir_contains(ref_root, dir):
+                if not _dir_contains(ref_root, dir):
                     del ref_dirs[dir]
 
         # Filter reference dirs to those with localizable contents,
         # with a preference for .pot template files.
         ref_dirs_with_files = [
-            dir for dir in ref_dirs if any(dir_contains(dir, pd) for pd in pot_dirs)
-        ] or [dir for dir in ref_dirs if any(dir_contains(dir, ld) for ld in l10n_dirs)]
+            dir for dir in ref_dirs if any(_dir_contains(dir, pd) for pd in pot_dirs)
+        ] or [
+            dir for dir in ref_dirs if any(_dir_contains(dir, ld) for ld in l10n_dirs)
+        ]
         if ref_dirs_with_files:
             self._ref_root = min(
                 (rd for rd in ref_dirs.items() if rd[0] in ref_dirs_with_files),
@@ -169,7 +171,7 @@ class L10nDiscoverPaths:
         base_dirs = {
             bd: lds
             for bd, lds in base_dirs.items()
-            if not dir_contains(self._ref_root, bd)
+            if not _dir_contains(self._ref_root, bd)
         }
         # Walk up parents of each l10n_dir to gather base dirs containing
         # localizable files & avoid false positives on locale-id-like sub-dir names.
@@ -214,7 +216,7 @@ class L10nDiscoverPaths:
         )
         if force_paths:
             self.ref_paths.extend(
-                path for path in force_paths if dir_contains(self._ref_root, path)
+                path for path in force_paths if _dir_contains(self._ref_root, path)
             )
 
     @property
@@ -276,7 +278,7 @@ class L10nDiscoverPaths:
         return None, ()
 
     def format_target_path(self, target: str, locale: str) -> str:
-        locale = locale_dirname(self._base(), locale, self.locale_dir_sep)
+        locale = _locale_dirname(self._base(), locale, self.locale_dir_sep)
         return normpath(target.format(locale=locale))
 
     def find_reference(self, target: str) -> tuple[str, dict[str, str]] | None:

--- a/python/moz/l10n/paths/discover.py
+++ b/python/moz/l10n/paths/discover.py
@@ -19,6 +19,7 @@ from collections.abc import Iterable, Iterator
 from itertools import chain
 from os import sep, walk
 from os.path import commonpath, dirname, isdir, join, normpath, relpath, splitext
+from typing import Literal
 
 from moz.l10n.formats import l10n_extensions
 from moz.l10n.util import walk_files
@@ -32,11 +33,14 @@ def dir_contains(dir: str, path: str) -> bool:
     return commonpath((dir, path)) == dir
 
 
-def locale_dirname(base: str, locale: str) -> str:
-    if "-" in locale and not isdir(join(base, locale)):
-        alt_dir = locale.replace("-", "_")
-        if isdir(join(base, alt_dir)):
-            return alt_dir
+def locale_dirname(base: str, locale: str, locale_dir_sep: Literal["-", "_"]) -> str:
+    if "-" not in locale or isdir(join(base, locale)):
+        return locale
+
+    alt_dir = locale.replace("-", "_")
+    if locale_dir_sep == "_" or isdir(join(base, alt_dir)):
+        return alt_dir
+
     return locale
 
 
@@ -53,6 +57,8 @@ class L10nDiscoverPaths:
     """Locales detected from subdirectory names under `base`."""
     ref_paths: list[str]
     """Reference paths"""
+    locale_dir_sep: Literal["-", "_"]
+    """Most common locale directory separator, defaulting to `-`."""
 
     def __init__(
         self,
@@ -191,9 +197,15 @@ class L10nDiscoverPaths:
         if locale_dirs_:
             self.locales = [dir.replace("_", "-") for dir in locale_dirs_]
             self.locales.sort()
-
+            self.locale_dir_sep = (
+                "_"
+                if sum("_" in dir for dir in locale_dirs_)
+                > sum("-" in dir for dir in locale_dirs_)
+                else "-"
+            )
         else:
             self.locales = None
+            self.locale_dir_sep = "-"
 
         self.ref_paths = (
             list(walk_files(self._ref_root, ignorepath=ignorepath))
@@ -264,8 +276,8 @@ class L10nDiscoverPaths:
         return None, ()
 
     def format_target_path(self, target: str, locale: str) -> str:
-        base = self._base()
-        return normpath(target.format(locale=locale_dirname(base, locale)))
+        locale = locale_dirname(self._base(), locale, self.locale_dir_sep)
+        return normpath(target.format(locale=locale))
 
     def find_reference(self, target: str) -> tuple[str, dict[str, str]] | None:
         """

--- a/python/tests/test_discover.py
+++ b/python/tests/test_discover.py
@@ -123,6 +123,7 @@ class TestL10nDiscover(TestCase):
             assert paths.base == join(root, "target")
             assert paths.locales == ["yy-Latn", "zz"]
             assert paths.all_locales == {"yy-Latn", "zz"}
+            assert paths.locale_dir_sep == "_"
             assert paths.all() == {
                 (
                     join(paths.ref_root, "a.ftl"),
@@ -221,12 +222,20 @@ class TestL10nDiscover(TestCase):
             assert paths.base == root
             assert paths.locales is not None
             assert set(paths.locales) == {"yy-Latn", "zz"}
+            assert paths.locale_dir_sep == "_"
 
             paths = L10nDiscoverPaths(root, ref_root=join(root, "en-US"))
             assert paths.ref_root == join(root, "en-US")
             assert paths.base == root
             assert paths.locales is not None
             assert set(paths.locales) == {"yy-Latn", "zz"}
+            assert paths.locale_dir_sep == "_"
+
+            paths.locales = ["xx-Brai", "yy-Latn", "zz"]
+            assert paths.target("a.ftl", locale="xx-Brai") == (
+                join(root, "xx_Brai", "a.ftl"),
+                {"xx-Brai"},
+            )
 
     def test_split_repos(self):
         """Source and translation in separate sibling directories,


### PR DESCRIPTION
Change required for mozilla/pontoon#4261.

When not using a config file, the locale directory for a new locale with more than one subtag (like `en-GB` or `ca-valencia`) should match the most common pre-existing pattern. The pattern used for the source locale directory is ignored.

When using a config file, this is directly controllable via the `locale_map` argument, for which we provide (and use) `get_android_locale` as a specific implementation.