### PR TITLE
webext(js): When parsing, match variable names correctly

### DIFF
--- a/js/src/webext-parse.ts
+++ b/js/src/webext-parse.ts
@@ -14,7 +14,7 @@
  */
 
 import { ParseError } from './errors.ts'
-import type { Message, Pattern } from './model.ts'
+import type { Expression, Message, Pattern } from './model.ts'
 
 export function webextParsePattern(
   msg: Message,
@@ -37,10 +37,10 @@ export function webextParsePattern(
     pos = m.index + matchSrc.length
     if (m[1]) {
       // Named placeholder
-      const name = m[1].toLowerCase()
+      const name = findDeclarationName(decl, m[1])
       const attr = Object.assign(Object.create(null), { source: matchSrc })
-      pattern.push({ $: name, attr })
-      if (!decl[name]) {
+      pattern.push({ $: name ?? m[1], attr })
+      if (!name) {
         const error = `webext: Unresolved Variable ${matchSrc}`
         onError(new ParseError(error, m.index, pos))
       }
@@ -55,4 +55,12 @@ export function webextParsePattern(
   }
   if (pos < src.length) addText(src.substring(pos))
   return pattern
+}
+
+function findDeclarationName(decl: Record<string, Expression>, name: string) {
+  let name_ = name.replaceAll('@', '_').replace(/^(?=[0-9])/, '_')
+  if (Object.hasOwn(decl, name_)) return name_
+  name_ = name_.toLowerCase()
+  for (const dn of Object.keys(decl)) if (dn.toLowerCase() === name_) return dn
+  return null
 }

--- a/js/src/webext-parse.ts
+++ b/js/src/webext-parse.ts
@@ -58,6 +58,8 @@ export function webextParsePattern(
 }
 
 function findDeclarationName(decl: Record<string, Expression>, name: string) {
+  // Matches the declaration name mapping in the Python implementation at
+  // moz.l10n.formats.webext.parse.webext_parse_message
   let name_ = name.replaceAll('@', '_').replace(/^(?=[0-9])/, '_')
   if (Object.hasOwn(decl, name_)) return name_
   name_ = name_.toLowerCase()

--- a/js/src/webext.test.ts
+++ b/js/src/webext.test.ts
@@ -47,6 +47,15 @@ ok(
 )
 
 ok(
+  'named placeholder with upper-case declaration name',
+  {
+    decl: { WORLD: { $: 'arg1', attr: { source: '$1' } } },
+    msg: ['Hello ', { $: 'WORLD', attr: { source: '$World$' } }]
+  },
+  'Hello $World$'
+)
+
+ok(
   'repeated named placeholder',
   {
     decl: { foo: { $: 'arg1', attr: { source: '$1' } } },
@@ -72,7 +81,7 @@ test('unresolved variable', () => {
   const error = onError.mock.calls[0][0]
   expect(error).toBeInstanceOf(ParseError)
   expect(error.message).toBe('webext: Unresolved Variable $Bar$')
-  expect(res).toEqual(['Has ', { $: 'bar', attr: { source: '$Bar$' } }, '?'])
+  expect(res).toEqual(['Has ', { $: 'Bar', attr: { source: '$Bar$' } }, '?'])
 })
 
 test('unsupported pattern part', () => {


### PR DESCRIPTION
Fix needed for mozilla/pontoon#4262.

Previously, we were making an incorrect presumption in the JS webext parsing code about how webext variable names are mapped to declaration identifiers. Instead of enforcing them to lower-case, let's actually apply the same mapping we use in Python, and look for a declaration case-insensitively.