### PR TITLE
js: Add .properties pattern parser & serialiser

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -15,6 +15,7 @@ The library currently supports the following message pattern formats:
 - `fluent`: Fluent (without internal selectors)
 - `mf2`: MessageFormat 2.0
 - `plain`: Patterns without placeholders (used in multiple resource formats)
+- `properties`: Java .properties files
 - `webext`: WebExtensions (messages.json)
 - `xliff`: XLIFF 1.2, including XCode customizations
 
@@ -64,7 +65,14 @@ import { ParseError, parsePattern } from '@mozilla/l10n'
 
 ```ts
 function parsePattern(
-  format: 'android' | 'fluent' | 'mf2' | 'plain' | 'webext' | 'xliff',
+  format:
+    | 'android'
+    | 'fluent'
+    | 'mf2'
+    | 'plain'
+    | 'properties'
+    | 'webext'
+    | 'xliff',
   src: string,
   baseMsg?: Message
 ): Pattern
@@ -89,13 +97,20 @@ import { SerializeError, serializePattern } from '@mozilla/l10n'
 
 ```ts
 function serializePattern(
-  format: 'android' | 'fluent' | 'mf2' | 'plain' | 'webext' | 'xliff',
+  format:
+    | 'android'
+    | 'fluent'
+    | 'mf2'
+    | 'plain'
+    | 'properties'
+    | 'webext'
+    | 'xliff',
   pattern: Pattern,
   onError?: (error: SerializeError) => void
 ): string
 
 class SerializeError extends Error {
-  pos?: number // Set for fluent, plain, and webext errors
+  pos?: number // Set for fluent, plain, properties, and webext errors
 }
 ```
 

--- a/js/src/index.test.ts
+++ b/js/src/index.test.ts
@@ -36,6 +36,7 @@ describe('parsePattern', () => {
     'fluent',
     'mf2',
     'plain',
+    'properties',
     'webext',
     'xliff'
   ] as const) {
@@ -74,6 +75,7 @@ describe('serializePattern', () => {
     'fluent',
     'mf2',
     'plain',
+    'properties',
     'webext',
     'xliff'
   ] as const) {
@@ -86,6 +88,7 @@ describe('serializePattern', () => {
   for (const [format, pattern, exp] of [
     ['unsupported' as FormatKey, ['bar'], 'bar'],
     ['plain', ['hello ', { _: 'lit' }], 'hello {�}'],
+    ['properties', ['hello ', { _: 'lit' }], 'hello {�}'],
     ['android', [{ open: 'x' }, 'not closed'], '<x>not closed</x>'],
     ['fluent', [{ _: undefined }, { $: undefined }], '{�}{�}']
   ] as [FormatKey, Pattern, string][]) {

--- a/js/src/index.ts
+++ b/js/src/index.ts
@@ -15,7 +15,7 @@
 
 import { androidParsePattern } from './android-parse.ts'
 import { androidSerializePattern } from './android-serialize.ts'
-import { ParseError, SerializeError } from './errors.js'
+import { ERROR_RESULT, ParseError, SerializeError } from './errors.ts'
 import { fluentParseEntry, fluentParsePattern } from './fluent-parse.ts'
 import {
   fluentSerializeEntry,
@@ -26,6 +26,8 @@ import {
 import { mf2ParseMessage, mf2ParsePattern } from './mf2-parse.ts'
 import { mf2SerializeMessage, mf2SerializePattern } from './mf2-serialize.ts'
 import type { Message, Pattern } from './model.ts'
+import { propertiesParsePattern } from './properties-parse.ts'
+import { propertiesSerializePattern } from './properties-serialize.ts'
 import { webextParsePattern } from './webext-parse.ts'
 import { webextSerializePattern } from './webext-serialize.ts'
 import { xliffParsePattern } from './xliff-parse.ts'
@@ -65,6 +67,8 @@ export {
   mf2SerializeMessage,
   mf2SerializePattern,
   ParseError,
+  propertiesParsePattern,
+  propertiesSerializePattern,
   SerializeError,
   webextParsePattern,
   webextSerializePattern,
@@ -78,6 +82,7 @@ export type FormatKey =
   | 'fluent'
   | 'mf2'
   | 'plain'
+  | 'properties'
   | 'webext'
   | 'xliff'
 
@@ -100,6 +105,8 @@ export function parsePattern(
       return fluentParsePattern(src)
     case 'mf2':
       return mf2ParsePattern(src)
+    case 'properties':
+      return propertiesParsePattern(src)
     case 'webext':
       return webextParsePattern(baseMsg ?? [], src)
     case 'xliff':
@@ -133,6 +140,8 @@ export function serializePattern(
       return fluentSerializePattern(pattern, undefined, { onError })
     case 'mf2':
       return mf2SerializePattern(pattern, false)
+    case 'properties':
+      return propertiesSerializePattern(pattern, onError)
     case 'webext':
       return webextSerializePattern(pattern, onError)
     case 'xliff':
@@ -148,7 +157,7 @@ export function serializePattern(
     else {
       const error = `${format}: Unsupported pattern part: ${JSON.stringify(part)}`
       onError(new SerializeError(error, res.length))
-      res += '{�}'
+      res += ERROR_RESULT
     }
   }
   return res

--- a/js/src/properties-parse.ts
+++ b/js/src/properties-parse.ts
@@ -1,0 +1,40 @@
+/* Copyright Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Pattern } from './model.ts'
+
+export function propertiesParsePattern(src: string): Pattern {
+  const value = src.replace(/\\(u[0-9A-Fa-f]{1,4}|.)/g, decodeEscape)
+  return value ? [value] : []
+}
+
+function decodeEscape(_: unknown, esc: string): string {
+  switch (esc) {
+    case 'f':
+      return '\f'
+    case 'n':
+      return '\n'
+    case 'r':
+      return '\r'
+    case 't':
+      return '\t'
+    default:
+      if (esc.startsWith('u')) {
+        const n = parseInt(esc.substring(1), 16)
+        if (!Number.isNaN(n)) return String.fromCharCode(n)
+      }
+      return esc
+  }
+}

--- a/js/src/properties-serialize.ts
+++ b/js/src/properties-serialize.ts
@@ -1,0 +1,67 @@
+/* Copyright Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { ERROR_RESULT, SerializeError } from './errors.ts'
+import type { Pattern } from './model.ts'
+
+export function propertiesSerializePattern(
+  pattern: Pattern,
+  onError?: (error: SerializeError) => void
+): string {
+  onError ??= (error) => {
+    throw error
+  }
+  let str = ''
+  for (const part of pattern) {
+    if (typeof part === 'string') {
+      str += part
+    } else {
+      const source = part.attr?.source
+      if (typeof source === 'string') {
+        str += source
+      } else {
+        const error = `properties: Unsupported pattern part ${JSON.stringify(part)}`
+        onError(new SerializeError(error, str.length))
+        str += ERROR_RESULT
+      }
+    }
+  }
+
+  // eslint-disable-next-line no-control-regex
+  str = str.replace(/[\x00-\x19\x5C\x7F-\x9F]/g, encodeChar)
+  if (str.startsWith(' ')) str = '\\' + str
+  if (str.endsWith(' ') && !str.endsWith('\\ ')) {
+    str = str.slice(0, -1) + '\\u0020'
+  }
+
+  return str
+}
+
+function encodeChar(ch: string): string {
+  switch (ch) {
+    case '\\':
+      return '\\\\'
+    case '\t':
+      return '\\t'
+    case '\n':
+      return '\\n'
+    case '\f':
+      return '\\f'
+    case '\r':
+      return '\\r'
+    default:
+      return `\\u${ch.charCodeAt(0).toString(16).padStart(4, '0')}`
+  }
+}

--- a/js/src/properties.test.ts
+++ b/js/src/properties.test.ts
@@ -1,0 +1,67 @@
+/* Copyright Mozilla Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, test, vi } from 'vitest'
+
+import { SerializeError } from './errors.ts'
+import { propertiesParsePattern } from './properties-parse.ts'
+import { propertiesSerializePattern } from './properties-serialize.ts'
+
+test('multiple parts', () => {
+  const src = propertiesSerializePattern(['foo', ' ', 'bar'])
+  expect(src).toBe('foo bar')
+  const res = propertiesParsePattern(src)
+  expect(res).toEqual(['foo bar'])
+})
+
+test('special characters', () => {
+  const src = propertiesSerializePattern(['foo\n\tbar'])
+  expect(src).toBe('foo\\n\\tbar')
+  const res = propertiesParsePattern(src)
+  expect(res).toEqual(['foo\n\tbar'])
+})
+
+test('outer whitespace', () => {
+  const src = propertiesSerializePattern(['  foo  '])
+  expect(src).toBe('\\  foo \\u0020')
+  const res = propertiesParsePattern(src)
+  expect(res).toEqual(['  foo  '])
+})
+
+test('placeholder', () => {
+  const src = propertiesSerializePattern([
+    'Hello ',
+    { $: 'world', attr: { source: '%s' } }
+  ])
+  expect(src).toBe('Hello %s')
+  const res = propertiesParsePattern(src)
+  expect(res).toEqual(['Hello %s'])
+})
+
+test('unsupported pattern part', () => {
+  const onError = vi.fn()
+  const src = propertiesSerializePattern(
+    ['Hello ', { _: 'world' }, '?'],
+    onError
+  )
+  expect(onError).toHaveBeenCalled()
+  const error = onError.mock.calls[0][0]
+  expect(error).toBeInstanceOf(SerializeError)
+  expect(error.message).toBe(
+    'properties: Unsupported pattern part {"_":"world"}'
+  )
+  expect(error.pos).toBe(6)
+  expect(src).toBe('Hello {�}?')
+})


### PR DESCRIPTION
Required for mozilla/pontoon#4270.

Adds a pattern parser & serialiser for .properties files. Does not parse any placeholders or other syntax from the source, so only handles character escapes.