### PR TITLE
Fix Xliff markup-close serialization

### DIFF
--- a/js/src/xliff.test.ts
+++ b/js/src/xliff.test.ts
@@ -53,6 +53,17 @@ describe('success', () => {
     ],
     '<x id="INTERPOLATION" equiv-text="{{minutes}}"/> minutes ago'
   )
+  ok(
+    'parts',
+    [
+      'Go to ',
+      { opt: { href: 'open-account' }, open: 'a' },
+      'Create password',
+      { close: 'a' },
+      ' in settings.'
+    ],
+    'Go to <a href="open-account">Create password</a> in settings.'
+  )
 })
 
 describe('parse errors', () => {

--- a/python/moz/l10n/formats/xliff/serialize.py
+++ b/python/moz/l10n/formats/xliff/serialize.py
@@ -465,7 +465,7 @@ def set_pattern(el: etree._Element, pattern: Pattern) -> None:
                     )
                 if parent.tag != name or parent == el:
                     raise ValueError(f"Improper element nesting for {part} in {parent}")
-                node = parent
+                prev = parent
                 parent = cast(etree._Element, parent.getparent())
             else:
                 attrib = {}

--- a/python/moz/l10n/model.py
+++ b/python/moz/l10n/model.py
@@ -102,7 +102,7 @@ class Markup:
             body.append(f"options={self.options!r}")
         if self.attributes:
             body.append(f"attributes={self.attributes!r}")
-        return f"Expression({','.join(body)})"
+        return f"Markup({','.join(body)})"
 
 
 Pattern = list[Union[str, Expression, Markup]]

--- a/python/tests/formats/test_xliff1.py
+++ b/python/tests/formats/test_xliff1.py
@@ -164,6 +164,21 @@ class TestXliff1(TestCase):
         res = xliff_serialize_message(msg)
         assert res == ""
 
+    def test_message_with_tags(self):
+        src = 'Go to <a href="open-account">Create password</a> in settings.'
+        msg = xliff_parse_message(src)
+        assert msg == PatternMessage(
+            [
+                "Go to ",
+                Markup("open", "a", options={"href": "open-account"}),
+                "Create password",
+                Markup("close", "a"),
+                " in settings.",
+            ]
+        )
+        res = xliff_serialize_message(msg)
+        assert res == src
+
     def test_message_xcode(self):
         src = "Hello, <b>%s</b>"
         msg = xliff_parse_message(src, is_xcode=True)


### PR DESCRIPTION
Required for mozilla/pontoon#4266.

On markup-close, the serialiser state was not being correctly set.

The added JS test is just to match Python, and the `repr(Markup)` fix is incidental, as I encountered it while fixing this.