### PR TITLE
Use `@fluent-fn` attribute for original Fluent function names

### DIFF
--- a/js/src/fluent-parse.ts
+++ b/js/src/fluent-parse.ts
@@ -166,12 +166,13 @@ function message(ftlPattern: FTL.Pattern): Message {
     const decl: Record<string, Expression> = {}
     const sel: string[] = []
     for (const expr of selExpressions) {
-      const stem = expr.$ ?? ''
-      let i = 0
-      let name = stem
-      while (!name || varNames.has(name)) {
-        i += 1
-        name = `${stem}_${i}`
+      let name = expr.$
+      if (!name || expr.attr?.['fluent-fn']) {
+        const stem = name || 'sel'
+        let i = 0
+        do {
+          name = `${stem}_${++i}`
+        } while (varNames.has(name))
       }
       decl[name] = expr
       sel.push(name)
@@ -348,7 +349,8 @@ function expression(
     return expr
   }
   if (fe instanceof FTL.FunctionReference) {
-    const name = fe.id.name.toLowerCase()
+    const ftlName = fe.id.name
+    const name = ftlName.toLowerCase()
     const arg = fe.arguments.positional[0]
     let expr: Expression
     if (arg instanceof FTL.BaseLiteral) {
@@ -364,6 +366,7 @@ function expression(
         expr.opt[arg.name.name] = arg.value.value
       }
     }
+    expr.attr = { 'fluent-fn': ftlName }
     return expr
   }
   throw new FluentError('E0028')

--- a/js/src/fluent-serialize.ts
+++ b/js/src/fluent-serialize.ts
@@ -214,12 +214,9 @@ function expression(
     }
   }
 
-  const arg =
-    '_' in expr && expr._ !== undefined
-      ? literal(expr._)
-      : '$' in expr && isIdentifier(expr.$)
-        ? '$' + expr.$
-        : null
+  let arg: string | undefined
+  if ('_' in expr && expr._ !== undefined) arg = literal(expr._)
+  else if ('$' in expr && isIdentifier(expr.$)) arg = '$' + expr.$
 
   if ('fn' in expr && isIdentifier(expr.fn)) {
     const options: string[] = []

--- a/js/src/fluent-serialize.ts
+++ b/js/src/fluent-serialize.ts
@@ -213,6 +213,14 @@ function expression(
       else decl = declarations[v1]
     }
   }
+
+  const arg =
+    '_' in expr && expr._ !== undefined
+      ? literal(expr._)
+      : '$' in expr && isIdentifier(expr.$)
+        ? '$' + expr.$
+        : null
+
   if ('fn' in expr && isIdentifier(expr.fn)) {
     const options: string[] = []
     if (expr.opt) {
@@ -224,6 +232,7 @@ function expression(
         options.push(`${name}: ${literal(value)}`)
       }
     }
+    let ftlName
     switch (expr.fn) {
       case 'message': {
         if (expr._ !== undefined) {
@@ -249,28 +258,52 @@ function expression(
         const error = 'fluent: Unsupported message or term reference'
         throw new SerializeError(error)
       }
-      case 'number':
-        if (options.length === 0 && isNumber(expr._)) return expr._!
-      // fallthrough
-      default: {
-        if ('_' in expr && expr._ !== undefined) {
-          options.unshift(literal(expr._))
-        } else if ('$' in expr && isIdentifier(expr.$)) {
-          options.unshift('$' + expr.$)
+
+      case 'string':
+        if (!arg) {
+          throw new SerializeError('fluent: Argument required for :string')
         }
-        return expr.fn.toUpperCase() + '(' + options.join(', ') + ')'
+        if (options.length) {
+          const error = 'fluent: Options on :string are not supported'
+          throw new SerializeError(error)
+        }
+        return arg
+
+      case 'datetime':
+      case 'number':
+        if (!arg) {
+          throw new SerializeError(`fluent: Argument required for :${expr.fn}`)
+        }
+        ftlName = expr.attr?.['fluent-fn']
+        if (!ftlName) {
+          if (expr.fn === 'number') {
+            if (options.length === 0) return arg
+            ftlName = 'NUMBER'
+          } else {
+            ftlName = 'DATETIME'
+          }
+        }
+      // fallthrough
+
+      default: {
+        ftlName ??= expr.attr?.['fluent-fn']
+        if (!ftlName || typeof ftlName !== 'string') {
+          const error = `fluent: A @fluent-fn attribute is required for :${expr.fn}`
+          throw new SerializeError(error)
+        }
+        if (arg) options.unshift(arg)
+        return ftlName + '(' + options.join(', ') + ')'
       }
     }
   }
-  if ('_' in expr && expr._ !== undefined) return literal(expr._)
-  if ('$' in expr && isIdentifier(expr.$)) return '$' + expr.$
+  if (arg) return arg
   const error = `fluent: Unsupported pattern part ${JSON.stringify(expr)}`
   throw new SerializeError(error)
 }
 
 function literal(value: string | undefined): string {
   if (!value) return '""'
-  if (isNumber(value)) return value
+  if (/^-?\d+(\.\d*)?$/.test(value)) return value
   const escStr = value
     // eslint-disable-next-line no-control-regex
     .replace(/[\x00-\x1F\\"\x7F-\x9F]/g, (ch) => {
@@ -286,6 +319,3 @@ const isIdentifier = (value: string | undefined): value is string =>
 
 const isIdWithAttr = (value: string): boolean =>
   /^[A-Za-z][-0-9A-Z_a-z]*\.[A-Za-z][-0-9A-Z_a-z]*$/.test(value)
-
-const isNumber = (value: string | undefined): boolean =>
-  /^-?\d+(\.\d*)?$/.test(value ?? '')

--- a/js/src/fluent-serialize.ts
+++ b/js/src/fluent-serialize.ts
@@ -202,7 +202,7 @@ function expression(
   if (declarations && expr.$) {
     let decl = declarations[expr.$]
     while (decl) {
-      if (decl.fn && expr.fn) {
+      if (decl.fn && expr.fn && decl.fn !== expr.fn) {
         const error = `fluent: Unsupported placeholder ${JSON.stringify(expr)} with declaration ${JSON.stringify(decl)}`
         throw new SerializeError(error)
       }

--- a/js/src/fluent.test.ts
+++ b/js/src/fluent.test.ts
@@ -43,14 +43,19 @@ describe('pattern success', () => {
     [{ _: 'one' }, ' ', { _: '42', fn: 'number' }],
     '{ "one" } { 42 }'
   )
-  ok('function', [{ $: 'x', fn: 'foo' }], '{ FOO($x) }')
+  ok(
+    'function',
+    [{ $: 'x', fn: 'foo', attr: { 'fluent-fn': 'FOO' } }],
+    '{ FOO($x) }'
+  )
   ok(
     'options',
     [
       {
         $: 'x',
         fn: 'number',
-        opt: { minimumFractionDigits: '2', notation: 'compact' }
+        opt: { minimumFractionDigits: '2', notation: 'compact' },
+        attr: { 'fluent-fn': 'NUMBER' }
       }
     ],
     '{ NUMBER($x, minimumFractionDigits: 2, notation: "compact") }'
@@ -62,6 +67,18 @@ describe('pattern success', () => {
     [{ _: '-foo', fn: 'message', opt: { bar: '42' } }],
     '{ -foo(bar: 42) }'
   )
+
+  test(':number with no options and no @fluent-fn', () => {
+    const src = fluentSerializePattern([{ $: 'x', fn: 'number', opt: {} }])
+    expect(src).toBe('{ $x }')
+  })
+
+  test(':number with options and no @fluent-fn', () => {
+    const src = fluentSerializePattern([
+      { $: 'x', fn: 'number', opt: { minimumFractionDigits: '2' } }
+    ])
+    expect(src).toBe('{ NUMBER($x, minimumFractionDigits: 2) }')
+  })
 })
 
 describe('pattern parse errors', () => {
@@ -104,6 +121,7 @@ describe('pattern serialize errors', () => {
     { _: 'foo', fn: 'message', opt: { x: 'y' } }
   ])
   fail('invalid term reference', [{ _: '-foo.bar', fn: 'message' }])
+  fail('function reference with no @fluent-fn', [{ $: 'x', fn: 'foo' }])
 })
 
 describe('entry', () => {
@@ -137,7 +155,12 @@ describe('entry', () => {
   ok('plain', 'plain = Progress: { NUMBER($num, style: "percent") }.\n', {
     '=': [
       'Progress: ',
-      { $: 'num', fn: 'number', opt: { style: 'percent' } },
+      {
+        $: 'num',
+        fn: 'number',
+        opt: { style: 'percent' },
+        attr: { 'fluent-fn': 'NUMBER' }
+      },
       '.'
     ]
   })
@@ -176,11 +199,42 @@ describe('entry', () => {
     `,
     {
       '=': {
-        decl: { num_1: { $: 'num', fn: 'number' } },
-        sel: ['num_1'],
+        decl: { num: { $: 'num', fn: 'number' } },
+        sel: ['num'],
         alt: [
           { keys: ['one'], pat: ['One ', { $: 'num' }] },
           { keys: [{ '*': 'other' }], pat: ['Other'] }
+        ]
+      }
+    }
+  )
+
+  ok(
+    'ordinal-selector',
+    ftl`
+    ordinal-selector =
+        { NUMBER($var, type: "ordinal") ->
+            [1] first
+            [one] { $var }st
+           *[other] { $var }nd
+        }
+
+    `,
+    {
+      '=': {
+        decl: {
+          var_1: {
+            $: 'var',
+            fn: 'number',
+            opt: { type: 'ordinal' },
+            attr: { 'fluent-fn': 'NUMBER' }
+          }
+        },
+        sel: ['var_1'],
+        alt: [
+          { keys: ['1'], pat: ['first'] },
+          { keys: ['one'], pat: [{ $: 'var' }, 'st'] },
+          { keys: [{ '*': 'other' }], pat: [{ $: 'var' }, 'nd'] }
         ]
       }
     }
@@ -312,8 +366,8 @@ describe('entry', () => {
     `,
     {
       '=': {
-        decl: { _1: { _: '-term.attr', fn: 'message' } },
-        sel: ['_1'],
+        decl: { sel_1: { _: '-term.attr', fn: 'message' } },
+        sel: ['sel_1'],
         alt: [
           { keys: ['foo'], pat: ['Foo'] },
           { keys: [{ '*': 'other' }], pat: ['Other'] }

--- a/js/src/fluent.test.ts
+++ b/js/src/fluent.test.ts
@@ -210,6 +210,34 @@ describe('entry', () => {
   )
 
   ok(
+    'num-wrapped-placeholder',
+    ftl`
+    num-wrapped-placeholder =
+        { $num ->
+            [one] One { NUMBER($num) }
+           *[other] Other
+        }
+
+    `,
+    {
+      '=': {
+        decl: { num: { $: 'num', fn: 'number' } },
+        sel: ['num'],
+        alt: [
+          {
+            keys: ['one'],
+            pat: [
+              'One ',
+              { $: 'num', fn: 'number', attr: { 'fluent-fn': 'NUMBER' } }
+            ]
+          },
+          { keys: [{ '*': 'other' }], pat: ['Other'] }
+        ]
+      }
+    }
+  )
+
+  ok(
     'ordinal-selector',
     ftl`
     ordinal-selector =

--- a/python/moz/l10n/formats/fluent/parse.py
+++ b/python/moz/l10n/formats/fluent/parse.py
@@ -53,6 +53,7 @@ def fluent_parse(
     Messages with no value will have an empty pattern assigned as their Entry.value.
 
     Function names are lower-cased, so e.g. the Fluent `NUMBER` is `number` in the Resource.
+    Original Fluent function names are stored as `@fluent-fn` expression attributes.
 
     The parsed resource will not include any metadata.
     """
@@ -145,6 +146,7 @@ def fluent_parse_entry(
     Messages with no value will have an empty pattern assigned as their Entry.value.
 
     Function names are lower-cased, so e.g. the Fluent `NUMBER` is `number` in the result.
+    Original Fluent function names are stored as `@fluent-fn` expression attributes.
     """
     if isinstance(source, str):
         ftl_entry = FluentParser(with_spans=with_linepos).parse_entry(source)
@@ -162,6 +164,7 @@ def fluent_parse_message(source: str) -> Message:
     Parse a Fluent pattern into a Message.
 
     Function names are lower-cased, so e.g. the Fluent `NUMBER` is `number` in the result.
+    Original Fluent function names are stored as `@fluent-fn` expression attributes.
 
     Leading and trailing whitespace is stripped.
     """
@@ -265,12 +268,14 @@ def message(ftl_pattern: ftl.Pattern) -> Message:
         declarations = {}
         selectors = []
         for expr in sel_expressions:
-            stem = expr.arg.name if isinstance(expr.arg, VariableRef) else ""
-            i = 0
-            name = stem
-            while name in var_names or name == "":
-                i += 1
-                name = f"{stem}_{i}"
+            name = expr.arg.name if isinstance(expr.arg, VariableRef) else None
+            if name is None or expr.attributes.get("fluent-fn") is not None:
+                stem = name or "sel"
+                name = None
+                i = 0
+                while name is None or name in var_names:
+                    i += 1
+                    name = f"{stem}_{i}"
             declarations[name] = expr
             selectors.append(VariableRef(name))
             var_names.add(name)
@@ -371,7 +376,7 @@ def inline_expression(exp: ftl.InlineExpression) -> Expression:
         name = exp.id.name
         return Expression(VariableRef(name))
     else:  # ftl.FunctionReference
-        name = exp.id.name.lower()
+        name = exp.id.name
         if len(exp.arguments.positional) > 1:
             raise ValueError(
                 f"Functions with more than one positional argument are not supported: {name}"
@@ -395,8 +400,9 @@ def inline_expression(exp: ftl.InlineExpression) -> Expression:
         ftl_named = exp.arguments.named
         return Expression(
             arg,
-            name,
+            name.lower(),
             {opt.name.name: literal_value(opt.value) for opt in ftl_named},
+            {"fluent-fn": name},
         )
 
 

--- a/python/moz/l10n/formats/fluent/serialize.py
+++ b/python/moz/l10n/formats/fluent/serialize.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from collections.abc import Callable, Iterator
 from re import compile, fullmatch
-from typing import Any
+from typing import Any, cast
 
 from fluent.syntax import FluentSerializer
 from fluent.syntax import ast as ftl
@@ -53,8 +53,9 @@ def fluent_serialize(
 
     Section identifiers and multi-part message identifiers are not supported.
 
-    Function names are upper-cased, and expressions using the `message` function
-    are mapped to message and term references.
+    Expressions using the `:message` function are mapped to message and term references.
+    Except for `:datetime` and `:number`, expressions using other functions
+    must have a `@fluent-fn` attribute indicating their corresponding Fluent function name.
 
     If `escape_syntax` is set to `False`,
     syntax characters such as { and } in text elements are not escaped.
@@ -89,8 +90,9 @@ def fluent_astify(
 
     Section identifiers and multi-part message identifiers are not supported.
 
-    Function names are upper-cased, and annotations with the `message` function
-    are mapped to message and term references.
+    Expressions using the `:message` function are mapped to message and term references.
+    Except for `:datetime` and `:number`, expressions using other functions
+    must have a `@fluent-fn` attribute indicating their corresponding Fluent function name.
 
     If `escape_syntax` is set to `False`,
     syntax characters such as { and } in text elements are not escaped.
@@ -163,8 +165,9 @@ def fluent_serialize_entry(
     """
     Serialize an Entry as a Fluent FTL message or term.
 
-    Function names are upper-cased, and expressions using the `message` function
-    are mapped to message and term references.
+    Expressions using the `:message` function are mapped to message and term references.
+    Except for `:datetime` and `:number`, expressions using other functions
+    must have a `@fluent-fn` attribute indicating their corresponding Fluent function name.
 
     If `escape_syntax` is set to `False`,
     syntax characters such as { and } in text elements are not escaped.
@@ -184,8 +187,9 @@ def fluent_astify_entry(
     """
     Transform an Entry into a corresponding Fluent AST message or term.
 
-    Function names are upper-cased, and expressions using the `message` function
-    are mapped to message and term references.
+    Expressions using the `:message` function are mapped to message and term references.
+    Except for `:datetime` and `:number`, expressions using other functions
+    must have a `@fluent-fn` attribute indicating their corresponding Fluent function name.
 
     If `escape_syntax` is set to `False`,
     syntax characters such as { and } in text elements are not escaped.
@@ -231,8 +235,9 @@ def fluent_serialize_message(
     """
     Serialize a message as a Fluent pattern.
 
-    Function names are upper-cased, and expressions using the `message` function
-    are mapped to message and term references.
+    Expressions using the `:message` function are mapped to message and term references.
+    Except for `:datetime` and `:number`, expressions using other functions
+    must have a `@fluent-fn` attribute indicating their corresponding Fluent function name.
 
     If `escape_empty` is set to `True`, a message that would serialize as an empty string
     will instead be serialized as `{ "" }`.
@@ -262,8 +267,9 @@ def fluent_astify_message(
     """
     Transform a message into a corresponding Fluent AST pattern.
 
-    Function names are upper-cased, and expressions using the `message` function
-    are mapped to message and term references.
+    Expressions using the `:message` function are mapped to message and term references.
+    Except for `:datetime` and `:number`, expressions using other functions
+    must have a `@fluent-fn` attribute indicating their corresponding Fluent function name.
 
     If `escape_empty` is set to `True`, a Pattern that would serialize as an empty string
     will instead be escaped as a StringLiteral.
@@ -431,9 +437,7 @@ def expression(
 ) -> ftl.InlineExpression:
     arg = value(decl, expr.arg, decl_name) if expr.arg is not None else None
     if expr.function:
-        return function_ref(decl, arg, expr.function, expr.options)
-    elif expr.function:
-        raise ValueError("Unsupported annotations are not supported")
+        return function_ref(decl, arg, expr)
     if arg:
         return arg
     raise ValueError("Invalid empty expression")
@@ -442,25 +446,39 @@ def expression(
 def function_ref(
     decl: dict[str, Expression],
     arg: ftl.InlineExpression | None,
-    function: str,
-    options: dict[str, str | VariableRef],
+    expr: Expression,
 ) -> ftl.InlineExpression:
     named: list[ftl.NamedArgument] = []
-    for name, val in options.items():
+    for name, val in expr.options.items():
         ftl_val = value(decl, val)
         if isinstance(ftl_val, ftl.Literal):
             named.append(ftl.NamedArgument(ftl.Identifier(name), ftl_val))
         else:
-            raise ValueError(f"Fluent option value not literal for {name}: {ftl_val}")
+            raise ValueError(
+                f"Fluent option value must be literal for {name}: {ftl_val}"
+            )
 
+    function = cast(str, expr.function)
+    ftl_name = expr.attributes.get("fluent-fn", None)
     if function == "string":
         if not arg:
             raise ValueError("Argument required for :string")
         if named:
             raise ValueError("Options on :string are not supported")
         return arg
-    if function == "number" and isinstance(arg, ftl.NumberLiteral) and not named:
-        return arg
+    if function == "datetime":
+        if not arg:
+            raise ValueError("Argument required for :datetime")
+        if not ftl_name:
+            ftl_name = "DATETIME"
+    if function == "number":
+        if not arg:
+            raise ValueError("Argument required for :number")
+        if not ftl_name:
+            if named:
+                ftl_name = "NUMBER"
+            else:
+                return arg
     if function == "message":
         if not isinstance(arg, ftl.Literal):
             raise ValueError(
@@ -480,8 +498,11 @@ def function_ref(
         else:
             return ftl.MessageReference(ftl.Identifier(msg_id), attr)
 
+    if not ftl_name or not isinstance(ftl_name, str):
+        raise ValueError(f"A @fluent-fn attribute is required for :{function}")
+
     args = ftl.CallArguments([arg] if arg else None, named)
-    return ftl.FunctionReference(ftl.Identifier(function.upper()), args)
+    return ftl.FunctionReference(ftl.Identifier(ftl_name), args)
 
 
 # Non-printable ASCII C0 & C1 / Unicode Cc characters

--- a/python/tests/bin/test_migrate.py
+++ b/python/tests/bin/test_migrate.py
@@ -286,44 +286,44 @@ def test_firefox_plural_properties() -> None:
                 # Shows a summary of the number of matches for autocomplete
                 source-search-results-summary =
                     { $n ->
-                        [one] { NUMBER($n) } résultat
-                       *[other] { NUMBER($n) } résultats
+                        [one] { $n } résultat
+                       *[other] { $n } résultats
                     }
                 # Editor Search bar message to summarize the selected search result. e.g. 5 of 10 results.
                 editor-search-results =
                     { $n ->
-                        [one] Résultat { $x } sur { NUMBER($n) }
-                       *[other] Résultat { $x } sur { NUMBER($n) }
+                        [one] Résultat { $x } sur { $n }
+                       *[other] Résultat { $x } sur { $n }
                     }
             """)
         with open(join(root, "lt", "debugger.ftl"), encoding="utf-8") as file:
             assert file.read() == dedent("""\
                 source-search-results-summary =
                     { $n ->
-                        [one] { NUMBER($n) } rezultatas
-                        [few] { NUMBER($n) } rezultatai
-                       *[other] { NUMBER($n) } rezultatų
+                        [one] { $n } rezultatas
+                        [few] { $n } rezultatai
+                       *[other] { $n } rezultatų
                     }
                 editor-search-results =
                     { $n ->
-                        [one] { $x } iš { NUMBER($n) } rezultato
-                        [few] { $x } iš { NUMBER($n) } rezultatų
-                       *[other] { $x } iš { NUMBER($n) } rezultatų
+                        [one] { $x } iš { $n } rezultato
+                        [few] { $x } iš { $n } rezultatų
+                       *[other] { $x } iš { $n } rezultatų
                     }
             """)
         with open(join(root, "uk", "debugger.ftl"), encoding="utf-8") as file:
             assert file.read() == dedent("""\
                 source-search-results-summary =
                     { $n ->
-                        [one] { NUMBER($n) } результат
-                        [few] { NUMBER($n) } результати
-                       *[many] { NUMBER($n) } результатів
+                        [one] { $n } результат
+                        [few] { $n } результати
+                       *[many] { $n } результатів
                     }
                 editor-search-results =
                     { $n ->
-                        [one] { $x } результат з { NUMBER($n) }
-                        [few] { $x } результати з { NUMBER($n) }
-                       *[many] { $x } результатів з { NUMBER($n) }
+                        [one] { $x } результат з { $n }
+                        [few] { $x } результати з { $n }
+                       *[many] { $x } результатів з { $n }
                     }
             """)
         with open(join(root, "ar", "debugger.ftl"), encoding="utf-8") as file:
@@ -333,18 +333,18 @@ def test_firefox_plural_properties() -> None:
                         [zero] لا نتائج
                         [one] نتيجة واحدة
                         [two] نتيجتان
-                        [few] { NUMBER($n) } نتائج
-                        [many] { NUMBER($n) } نتيجة
-                       *[other] { NUMBER($n) } نتيجة
+                        [few] { $n } نتائج
+                        [many] { $n } نتيجة
+                       *[other] { $n } نتيجة
                     }
                 editor-search-results =
                     { $n ->
                         [zero] لا نتائج
                         [one] نتيجة واحدة
                         [two] { $x } من أصل نتيجتين
-                        [few] { $x } من أصل { NUMBER($n) } نتائج
-                        [many] { $x } من أصل { NUMBER($n) } نتيجة
-                       *[other] { $x } من أصل { NUMBER($n) } نتيجة
+                        [few] { $x } من أصل { $n } نتائج
+                        [many] { $x } من أصل { $n } نتيجة
+                       *[other] { $x } من أصل { $n } نتيجة
                     }
             """)
 

--- a/python/tests/formats/test_fluent.py
+++ b/python/tests/formats/test_fluent.py
@@ -194,6 +194,45 @@ class TestFluent(TestCase):
             """
         )
 
+    def test_function_refs(self):
+        msg = PatternMessage([Expression(VariableRef("x"), "foo")])
+        with self.assertRaises(ValueError):
+            fluent_serialize_message(msg)
+
+        msg = fluent_parse_message(
+            """
+            { $num ->
+                [one] { NUMBER($num) } item
+               *[other] { NUMBER($num) } items
+            }
+            """
+        )
+        assert msg == SelectMessage(
+            declarations={"num": Expression(VariableRef("num"), function="number")},
+            selectors=(VariableRef("num"),),
+            variants={
+                ("one",): [
+                    Expression(
+                        VariableRef("num"), "number", attributes={"fluent-fn": "NUMBER"}
+                    ),
+                    " item",
+                ],
+                (CatchallKey("other"),): [
+                    Expression(
+                        VariableRef("num"), "number", attributes={"fluent-fn": "NUMBER"}
+                    ),
+                    " items",
+                ],
+            },
+        )
+        assert fluent_serialize_message(msg) == dedent(
+            """\
+            { $num ->
+                [one] { NUMBER($num) } item
+               *[other] { NUMBER($num) } items
+            }"""
+        )
+
     def test_resource(self):
         res = fluent_parse(
             dedent(

--- a/python/tests/formats/test_fluent.py
+++ b/python/tests/formats/test_fluent.py
@@ -90,8 +90,8 @@ class TestFluent(TestCase):
             Entry(
                 ("has-placeholder",),
                 SelectMessage(
-                    declarations={"num_1": Expression(VariableRef("num"), "number")},
-                    selectors=(VariableRef("num_1"),),
+                    declarations={"num": Expression(VariableRef("num"), "number")},
+                    selectors=(VariableRef("num"),),
                     variants={
                         ("one",): ["One ", Expression(VariableRef("num"))],
                         (other,): ["Other"],
@@ -149,8 +149,8 @@ class TestFluent(TestCase):
             """
         )
         assert msg == SelectMessage(
-            declarations={"num_1": Expression(VariableRef("num"), function="number")},
-            selectors=(VariableRef("num_1"),),
+            declarations={"num": Expression(VariableRef("num"), function="number")},
+            selectors=(VariableRef("num"),),
             variants={
                 ("one",): ["One ", Expression(VariableRef("num"))],
                 (CatchallKey("other"),): ["Other"],
@@ -281,8 +281,17 @@ class TestFluent(TestCase):
                 ("functions",),
                 PatternMessage(
                     [
-                        Expression(VariableRef("arg"), "number"),
-                        Expression("bar", "foo", {"opt": "val"}),
+                        Expression(
+                            VariableRef("arg"),
+                            "number",
+                            attributes={"fluent-fn": "NUMBER"},
+                        ),
+                        Expression(
+                            "bar",
+                            "foo",
+                            {"opt": "val"},
+                            attributes={"fluent-fn": "FOO"},
+                        ),
                     ]
                 ),
                 linepos=get_linepos(14),
@@ -358,8 +367,8 @@ class TestFluent(TestCase):
             Entry(
                 ("term-sel",),
                 SelectMessage(
-                    declarations={"_1": Expression("-term.attr", "message")},
-                    selectors=(VariableRef("_1"),),
+                    declarations={"sel_1": Expression("-term.attr", "message")},
+                    selectors=(VariableRef("sel_1"),),
                     variants={
                         ("foo",): ["Foo"],
                         (other,): ["Other"],
@@ -672,8 +681,8 @@ class TestFluent(TestCase):
             Entry(
                 id=("delete-all-message",),
                 value=SelectMessage(
-                    declarations={"num_1": Expression(VariableRef("num"), "number")},
-                    selectors=(VariableRef("num_1"),),
+                    declarations={"num": Expression(VariableRef("num"), "number")},
+                    selectors=(VariableRef("num"),),
                     variants={
                         ("one",): ["Delete this download?"],
                         (CatchallKey("other"),): [
@@ -688,8 +697,8 @@ class TestFluent(TestCase):
             Entry(
                 id=("delete-all-message-special-cases",),
                 value=SelectMessage(
-                    declarations={"num_1": Expression(VariableRef("num"), "number")},
-                    selectors=(VariableRef("num_1"),),
+                    declarations={"num": Expression(VariableRef("num"), "number")},
+                    selectors=(VariableRef("num"),),
                     variants={
                         ("12",): ["Delete this dozen of downloads?"],
                         ("2",): ["Delete this pair of downloads?"],
@@ -712,6 +721,7 @@ class TestFluent(TestCase):
                             VariableRef("date"),
                             "datetime",
                             {"month": "long", "year": "numeric", "day": "numeric"},
+                            {"fluent-fn": "DATETIME"},
                         ),
                     ],
                 ),
@@ -730,8 +740,12 @@ class TestFluent(TestCase):
             Entry(
                 id=("platform",),
                 value=SelectMessage(
-                    declarations={"_1": Expression(None, "platform")},
-                    selectors=(VariableRef("_1"),),
+                    declarations={
+                        "sel_1": Expression(
+                            None, "platform", attributes={"fluent-fn": "PLATFORM"}
+                        )
+                    },
+                    selectors=(VariableRef("sel_1"),),
                     variants={
                         ("win",): ["Options"],
                         (CatchallKey("other"),): ["Preferences"],
@@ -744,7 +758,10 @@ class TestFluent(TestCase):
                 value=SelectMessage(
                     declarations={
                         "var_1": Expression(
-                            VariableRef("var"), "number", {"type": "ordinal"}
+                            VariableRef("var"),
+                            "number",
+                            {"type": "ordinal"},
+                            {"fluent-fn": "NUMBER"},
                         )
                     },
                     selectors=(VariableRef("var_1"),),
@@ -761,8 +778,12 @@ class TestFluent(TestCase):
                 value=PatternMessage([]),
                 properties={
                     "title": SelectMessage(
-                        declarations={"_1": Expression(None, "platform")},
-                        selectors=(VariableRef("_1"),),
+                        declarations={
+                            "sel_1": Expression(
+                                None, "platform", attributes={"fluent-fn": "PLATFORM"}
+                            )
+                        },
+                        selectors=(VariableRef("sel_1"),),
                         variants={
                             ("win",): ["Options"],
                             (CatchallKey("other"),): ["Preferences"],
@@ -776,16 +797,24 @@ class TestFluent(TestCase):
                 value=PatternMessage([]),
                 properties={
                     "label": SelectMessage(
-                        declarations={"_1": Expression(None, "platform")},
-                        selectors=(VariableRef("_1"),),
+                        declarations={
+                            "sel_1": Expression(
+                                None, "platform", attributes={"fluent-fn": "PLATFORM"}
+                            )
+                        },
+                        selectors=(VariableRef("sel_1"),),
                         variants={
                             ("macos",): ["Choose…"],
                             (CatchallKey("other"),): ["Browse…"],
                         },
                     ),
                     "accesskey": SelectMessage(
-                        declarations={"_1": Expression(None, "platform")},
-                        selectors=(VariableRef("_1"),),
+                        declarations={
+                            "sel_1": Expression(
+                                None, "platform", attributes={"fluent-fn": "PLATFORM"}
+                            )
+                        },
+                        selectors=(VariableRef("sel_1"),),
                         variants={("macos",): ["e"], (CatchallKey("other"),): ["o"]},
                     ),
                 },


### PR DESCRIPTION
Required for mozilla/pontoon#4230

This changes the Fluent parsing & serialization to be explicit about which Fluent placeables (i.e. expressions in moz-l10n terms) contain an actual function call (like `{ NUMBER($x) }`), and which do not (`{ $x }`).

During parsing, the Fluent function name is included in the moz-l10n expression as a `@fluent-fn` attribute.

During serialization, unrecognised functions need to have the attribute in order to be serializable. For `:number` and `:datetime` this is optional, though `:number` expressions with no `@fluent-fn` attribute and no options are serialized in Fluent without a `NUMBER()` wrapper.

This also improves the `moz-l10n migrate` behaviour, as it was previously adding `NUMBER()` wrappers in places where we usually do not.