### PR TITLE
Add GitHub Action for publishing new releases on npm & pypi

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,41 @@
+name: Publish release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+      - run: npm publish -w js
+
+  pypi:
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/moz.l10n
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          python-version: '3.12'
+      - run: uv sync --dev --all-packages
+      - run: uv run pytest -vv
+      - run: uv build
+        working-directory: python
+      - uses: pypa/gh-action-pypi-publish@ba38be9e461d3875417946c167d0b5f3d385a247 # v1.14.1


### PR DESCRIPTION
Fixes #169 

I've enabled OpenID Connect trusted publishing from this repo to both https://www.npmjs.com/package/@mozilla/l10n and https://pypi.org/project/moz.l10n/. This PR adds an action that'll trigger on new tags that start with `v` to publish new versions.

This is pretty closely following the instructions available here:
- https://docs.npmjs.com/trusted-publishers
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

Putting together a release still leaves the following manual steps:
- Manually update the `python/pyproject.toml` version id.
- Run `uv sync --dev --all-packages --all-extras` in the repo root.
- Update the JS version with `npm version -w js VERSION`
- Create a PR for the release 
- Once merged, tag the release commit