### PR TITLE
0.13.0

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla/l10n",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "license": "Apache-2.0",
   "author": "Eemeli Aro <eemeli@mozilla.com>",
   "description": "Mozilla tools for localization",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
     },
     "js": {
       "name": "@mozilla/l10n",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@fluent/syntax": "^0.19.0",

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "moz.l10n"
-version = "0.12.0"
+version = "0.13.0"
 description = "Mozilla tools for localization"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/uv.lock
+++ b/uv.lock
@@ -764,7 +764,7 @@ dev = [
 
 [[package]]
 name = "moz-l10n"
-version = "0.12.0"
+version = "0.13.0"
 source = { editable = "python" }
 dependencies = [
     { name = "click", version = "8.1.8", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },


### PR DESCRIPTION
- BREAKING CHANGE: Use `@fluent-fn` attribute for original Fluent function name (#171)
- Include default support for `{android_locale}` in paths (#166)
- Update dependencies (#184)
