### PR TITLE
android: Always include an `other` fallback plural category

### DIFF
--- a/python/moz/l10n/formats/android/serialize.py
+++ b/python/moz/l10n/formats/android/serialize.py
@@ -261,10 +261,14 @@ def set_plural_message(plurals: etree._Element, msg: SelectMessage) -> None:
     if len(msg.declarations) != 1 or not sel or sel.function != "number":
         raise ValueError(f"Unsupported message: {msg}")
     item: etree._Element | None = None
+    # Some Slavic languages use `many` as the fallback plural case,
+    # and translations may exclude a literal `other` case.
+    # However, the Android <plurals> handling hard-codes `other` as the fallback.
+    has_other = any(keys == ("other",) for keys in msg.variants)
     for keys, value in msg.variants.items():
         key = keys[0] if len(keys) == 1 else None
         if isinstance(key, CatchallKey):
-            key = key.value or "other"
+            key = key.value if has_other else "other"
         if key not in plural_categories:
             raise ValueError(f"Unsupported plural variant key: {keys}")
         item = etree.SubElement(plurals, "item", attrib={"quantity": key})

--- a/python/tests/formats/test_android.py
+++ b/python/tests/formats/test_android.py
@@ -878,3 +878,36 @@ class TestAndroid(TestCase):
         )
         ser = "".join(android_serialize(res))
         assert ser == src
+
+    def test_serialize_plural_many_fallback(self):
+        arg1 = Expression(VariableRef("arg1"), "integer", attributes={"source": "%1$d"})
+        entry = Entry(
+            ("trackers_blocked_this_week_uk",),
+            SelectMessage(
+                declarations={
+                    "quantity": Expression(VariableRef("quantity"), "number")
+                },
+                selectors=(VariableRef("quantity"),),
+                variants={
+                    ("one",): ["Цього тижня заблоковано ", arg1, " вистежувач"],
+                    ("few",): ["Цього тижня заблоковано ", arg1, " вистежувачі"],
+                    (CatchallKey("many"),): [
+                        "Цього тижня заблоковано ",
+                        arg1,
+                        " вистежувачів",
+                    ],
+                },
+            ),
+        )
+        res = Resource(Format.android, [Section((), [entry])])
+        ser = "".join(android_serialize(res))
+        assert ser == dedent("""\
+            <?xml version="1.0" encoding="utf-8"?>
+            <resources>
+              <plurals name="trackers_blocked_this_week_uk">
+                <item quantity="one">Цього тижня заблоковано %1$d вистежувач</item>
+                <item quantity="few">Цього тижня заблоковано %1$d вистежувачі</item>
+                <item quantity="other">Цього тижня заблоковано %1$d вистежувачів</item>
+              </plurals>
+            </resources>
+            """)


### PR DESCRIPTION
Avoids linter warnings and runtime errors for Android plurals that use something other than `other` (like `many`) as the plural fallback case, as `other` is [hard-coded to be that](https://cs.android.com/android/platform/superproject/+/329d792f6d5e33e8a6fc5a02809c795ce17774ab:frameworks/base/core/java/android/content/res/ResourcesImpl.java;l=394;bpv=0) in Android `<plurals>` processing.