### PR TITLE
fluent: Enforce lexicographic order for named options & properties

### DIFF
--- a/js/src/fluent-serialize.ts
+++ b/js/src/fluent-serialize.ts
@@ -49,7 +49,12 @@ export function fluentSerializeEntry(
   }
   str += '\n'
   if (entry['+']) {
-    for (const [name, value] of Object.entries(entry['+'])) {
+    const properties = Object.entries(entry['+']).sort((a, b) => {
+      const an = a[0].toLowerCase().replace('accesskey', '\uFFFFaccesskey')
+      const bn = b[0].toLowerCase().replace('accesskey', '\uFFFFaccesskey')
+      return an < bn ? -1 : an > bn ? 1 : 0
+    })
+    for (const [name, value] of properties) {
       str += `    .${name} =`
       const attrStr = fluentSerializeMessage(value, options) || '{ "" }'
       str += attrStr.includes('\n')
@@ -229,6 +234,7 @@ function expression(
         options.push(`${name}: ${literal(value)}`)
       }
     }
+    options.sort()
     let ftlName
     switch (expr.fn) {
       case 'message': {

--- a/js/src/fluent-serialize.ts
+++ b/js/src/fluent-serialize.ts
@@ -49,6 +49,7 @@ export function fluentSerializeEntry(
   }
   str += '\n'
   if (entry['+']) {
+    // Use lexicographic order, with accesskeys last.
     const properties = Object.entries(entry['+']).sort((a, b) => {
       const an = a[0].toLowerCase().replace('accesskey', '\uFFFFaccesskey')
       const bn = b[0].toLowerCase().replace('accesskey', '\uFFFFaccesskey')

--- a/js/src/fluent.test.ts
+++ b/js/src/fluent.test.ts
@@ -384,6 +384,38 @@ describe('entry', () => {
   )
 
   ok(
+    'sort',
+    ftl`
+    sort =
+        .accesskey = Accesskey
+        .foo = Foo { NUMBER(42, c: "C", a: "A", b: "B") }
+        .bar = Bar
+    `,
+    {
+      '+': {
+        accesskey: ['Accesskey'],
+        foo: [
+          'Foo ',
+          {
+            _: '42',
+            fn: 'number',
+            opt: { a: 'A', b: 'B', c: 'C' },
+            attr: { 'fluent-fn': 'NUMBER' }
+          }
+        ],
+        bar: ['Bar']
+      }
+    },
+    ftl`
+    sort =
+        .bar = Bar
+        .foo = Foo { NUMBER(42, a: "A", b: "B", c: "C") }
+        .accesskey = Accesskey
+
+    `
+  )
+
+  ok(
     'term-attr-sel',
     ftl`
     term-attr-sel =

--- a/python/moz/l10n/formats/fluent/serialize.py
+++ b/python/moz/l10n/formats/fluent/serialize.py
@@ -209,6 +209,9 @@ def fluent_astify_entry(
         )
         for key, val in entry.properties.items()
     )
+    attributes.sort(
+        key=lambda a: a.id.name.lower().replace("accesskey", "\uffffaccesskey")
+    )
     if comment_str is None:
         if entry.meta:
             raise ValueError("Metadata requires custom serializer")
@@ -457,6 +460,7 @@ def function_ref(
             raise ValueError(
                 f"Fluent option value must be literal for {name}: {ftl_val}"
             )
+    named.sort(key=lambda a: a.name.name)
 
     function = cast(str, expr.function)
     ftl_name = expr.attributes.get("fluent-fn", None)

--- a/python/moz/l10n/formats/fluent/serialize.py
+++ b/python/moz/l10n/formats/fluent/serialize.py
@@ -209,6 +209,7 @@ def fluent_astify_entry(
         )
         for key, val in entry.properties.items()
     )
+    # Use lexicographic order, with accesskeys last.
     attributes.sort(
         key=lambda a: a.id.name.lower().replace("accesskey", "\uffffaccesskey")
     )

--- a/python/tests/formats/test_fluent.py
+++ b/python/tests/formats/test_fluent.py
@@ -983,7 +983,7 @@ class TestFluent(TestCase):
                    *[other] Delete { $num } downloads?
                 }
             # DATETIME Built-in function
-            today-is = Today is { DATETIME($date, month: "long", year: "numeric", day: "numeric") }
+            today-is = Today is { DATETIME($date, day: "numeric", month: "long", year: "numeric") }
             # Soft Launch
             default-content-process-count =
                 .label = { $num } (default)


### PR DESCRIPTION
Ensure that a stable order is used for serialising named arguments and properties in Fluent.

Upcoming Pontoon changes will allow us to switch its resource serialisation to depend on the data model values. While JS & Python are pretty good about keeping these keys in order, [Postgres is not](https://www.postgresql.org/docs/current/datatype-json.html#:~:text=does%20not%20preserve%20the%20order%20of%20object%20keys). So to ensure that the order does not change effectively randomly, let's enforce lexicographic order.

I'll file separate PRs for similar issues in different formats.