### PR TITLE
webext: Enforce lexicographic order for placeholder definitions

### DIFF
--- a/python/moz/l10n/formats/webext/serialize.py
+++ b/python/moz/l10n/formats/webext/serialize.py
@@ -153,4 +153,4 @@ def webext_serialize_message(
                 msgstr += arg_name if arg_name.startswith("$") else f"${arg_name}"
         else:
             raise ValueError(f"Unsupported message part: {part}")
-    return msgstr, placeholders
+    return msgstr, dict(sorted(placeholders.items()))

--- a/python/tests/formats/test_webext.py
+++ b/python/tests/formats/test_webext.py
@@ -212,6 +212,28 @@ class TestWebext(TestCase):
             """
         )
 
+    def test_serialized_placeholder_order(self):
+        res = webext_parse(
+            '{ "key": { "message": "Hello $foo$ and $bar$", '
+            '"placeholders": { "foo": { "content": "x" }, "bar": { "content": "y" } } } }'
+        )
+        ser = "".join(webext_serialize(res))
+        assert ser == dedent("""\
+            {
+              "key": {
+                "message": "Hello $foo$ and $bar$",
+                "placeholders": {
+                  "bar": {
+                    "content": "y"
+                  },
+                  "foo": {
+                    "content": "x"
+                  }
+                }
+              }
+            }
+            """)
+
     def test_trim_comments(self):
         res = webext_parse(source)
         ser = "".join(webext_serialize(res, trim_comments=True))


### PR DESCRIPTION
Ensure that a stable order is used for serialising placeholder definitions in web extension resources.

Upcoming Pontoon changes will allow us to switch its resource serialisation to depend on the data model values. While JS & Python are pretty good about keeping these keys in order, [Postgres is not](https://www.postgresql.org/docs/current/datatype-json.html#:~:text=does%20not%20preserve%20the%20order%20of%20object%20keys). So to ensure that the order does not change effectively randomly, let's enforce lexicographic order.